### PR TITLE
feat: Add Google IAP support, dynamic connections, and HTTP/SSE mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Multi-stage build for ssh-mcp with gcloud CLI
+FROM node:20-slim AS builder
+
+# Install build dependencies
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build
+COPY . .
+RUN npm run build
+
+# Production image
+FROM node:20-slim
+
+# Install gcloud CLI
+RUN apt-get update && \
+    apt-get install -y \
+        curl \
+        gnupg \
+        apt-transport-https \
+        ca-certificates && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+        tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+        gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update && \
+    apt-get install -y google-cloud-cli && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create app user
+RUN useradd -m -u 1000 sshmcp
+
+# Install production dependencies
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production && \
+    npm cache clean --force
+
+# Copy built application
+COPY --from=builder /app/build ./build
+
+# Change ownership
+RUN chown -R sshmcp:sshmcp /app
+
+# Switch to non-root user
+USER sshmcp
+
+# Expose default HTTP port
+EXPOSE 3000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:3000/health || exit 1
+
+# Default command - HTTP/SSE mode on port 3000
+CMD ["node", "build/index.js", "--port=3000"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
 
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/tufantunc/ssh-mcp)](https://archestra.ai/mcp-catalog/tufantunc__ssh-mcp)
 
-**SSH MCP Server** is a local Model Context Protocol (MCP) server that exposes SSH control for Linux and Windows systems, enabling LLMs and other MCP clients to execute shell commands securely via SSH.
+**SSH MCP Server** is a local Model Context Protocol (MCP) server that exposes SSH control for Linux and Windows systems, enabling LLMs and other MCP clients to execute shell commands securely via SSH or Google IAP tunnel.
+
+## 🔥 Dynamic Connections
+
+**New in v2.0:** ssh-mcp now supports **dynamic connections** - specify the target server with each command instead of at server startup. One MCP server can manage connections to unlimited remote systems!
 
 ## Contents
 
@@ -26,15 +30,18 @@
 ## Quick Start
 
 - [Install](#installation) SSH MCP Server
-- [Configure](#configuration) SSH MCP Server
-- [Set up](#client-setup) your MCP Client (e.g. Claude Desktop, Cursor, etc)
-- Execute remote shell commands on your Linux or Windows server via natural language
+- [Set up](#client-setup) your MCP Client (e.g. Claude Code, Claude Desktop, Cursor, etc)
+- Ask Claude to execute commands on **any** remote server:
+  - "List processes on vm-bastion in project prj-fgo-s-fdj" (Google IAP)
+  - "Check disk space on 192.168.1.100" (Direct SSH)
+  - **No server restart needed** - connections are created dynamically!
 
 ## Features
 
 - MCP-compliant server exposing SSH capabilities
 - Execute shell commands on remote Linux and Windows systems
 - Secure authentication via password or SSH key
+- **Google IAP (Identity-Aware Proxy) support** for secure access to GCP instances without public IPs
 - Built with TypeScript and the official MCP SDK
 - **Configurable timeout protection** with automatic process abortion
 - **Graceful timeout handling** - attempts to kill hanging processes before closing connections
@@ -77,96 +84,148 @@
 
 ## Client Setup
 
-You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use this MCP Server.
+### Dynamic Mode (Recommended - v2.0+)
 
-**Required Parameters:**
-- `host`: Hostname or IP of the Linux or Windows server
-- `user`: SSH username
+In **dynamic mode**, you specify connection details **with each command** instead of at server startup. This allows Claude to connect to unlimited servers with a single MCP server.
 
-**Optional Parameters:**
-- `port`: SSH port (default: 22)
-- `password`: SSH password (or use `key` for key-based auth)
-- `key`: Path to private SSH key
-- `sudoPassword`: Password for sudo elevation (when executing commands with sudo)
-- `suPassword`: Password for su elevation (when you need a persistent root shell)
+**Global Parameters (optional):**
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
-- `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
+- `disableSudo`: Flag to disable the `sudo-exec` tool completely
 
+**Per-Command Parameters:**
 
-```commandline
-{
-    "mcpServers": {
-        "ssh-mcp": {
-            "command": "npx",
-            "args": [
-                "ssh-mcp",
-                "-y",
-                "--",
-                "--host=1.2.3.4",
-                "--port=22",
-                "--user=root",
-                "--password=pass",
-                "--key=path/to/key",
-                "--timeout=30000",
-                "--maxChars=none"
-            ]
-        }
-    }
-}
-```
+Connection details are specified when Claude calls the `exec` or `sudo-exec` tools:
+
+**For Direct SSH:**
+- `host`: Hostname or IP address (required)
+- `port`: SSH port (optional, default: 22)
+- `user`: SSH username (required)
+- `password`: SSH password (optional)
+- `privateKey`: SSH private key content (optional)
+- `privateKeyPath`: Path to SSH private key file (optional)
+- `sudoPassword`: Password for sudo (optional)
+- `suPassword`: Password for su elevation (optional)
+
+**For Google IAP:**
+- `iapInstance`: GCP VM instance name (required)
+- `iapProject`: GCP project ID (required)
+- `iapZone`: GCP zone (optional - gcloud auto-detects zone if not specified)
+- `user`: SSH username (required)
+- Authentication uses gcloud credentials (no password/key needed for IAP)
+- `sudoPassword`: Password for sudo (optional)
+- `suPassword`: Password for su elevation (optional)
+
+**Note:** Google IAP mode uses `gcloud compute ssh --tunnel-through-iap` which handles authentication through your gcloud credentials. Make sure you're logged in with `gcloud auth login` and have the necessary IAP permissions.
 
 ### Claude Code
 
-You can add this MCP server to Claude Code using the `claude mcp add` command. This is the recommended method for Claude Code.
+Add ssh-mcp to Claude Code using the `claude mcp add` command:
 
-**Basic Installation:**
+**Dynamic Mode (Recommended):**
 
 ```bash
-claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=YOUR_HOST --user=YOUR_USER --password=YOUR_PASSWORD
+# Basic setup - no connection details needed at startup!
+claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp
+
+# With custom timeout and no character limit
+claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --timeout=120000 --maxChars=none
 ```
 
-**Installation Examples:**
+**That's it!** Now ask Claude to connect to any server:
 
-**With Password Authentication:**
+**Examples:**
+- **"List processes on vm-fgo-s-fdj-bastion in project prj-fgo-s-fdj as user admin"**
+  - Claude will use IAP to connect: `iapInstance=vm-fgo-s-fdj-bastion`, `iapProject=prj-fgo-s-fdj`, `user=admin`
+
+- **"Check disk space on 192.168.1.100 as root with key /path/to/key"**
+  - Claude will use direct SSH: `host=192.168.1.100`, `user=root`, `privateKeyPath=/path/to/key`
+
+- **"Restart nginx on server.example.com"**
+  - Claude will prompt for missing details (user, password, etc.)
+
+**How Authentication Works:**
+
+Claude needs to know credentials to connect. You can provide them:
+1. **In your prompt:** "Connect to 192.168.1.100 as user admin with password secret123"
+2. **Via environment variables** (for security - coming soon)
+3. **Stored in Claude's context** (Claude remembers credentials during the conversation)
+
+**Security Note:** Avoid hardcoding passwords in prompts. Use SSH keys when possible: `privateKeyPath=/path/to/key`
+
+---
+
+### Static Mode (Legacy - v1.x compatibility)
+
+In **static mode**, you specify connection details **at server startup**. One MCP server connects to one specific remote system. This mode is for backward compatibility and simple single-server setups.
+
+**Command-line usage:**
+
 ```bash
-claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --port=22 --user=admin --password=your_password
+# Direct SSH mode
+node build/index.js --host=192.168.1.100 --user=root --password=secret --timeout=60000
+
+# Google IAP mode
+node build/index.js --iapInstance=vm-name --iapProject=project-id --user=admin --iapZone=us-central1-a
+
+# With SSH key
+node build/index.js --host=server.example.com --user=deploy --key=/path/to/id_rsa
 ```
 
-**With SSH Key Authentication:**
+**Available startup parameters:**
+- `--host`: SSH hostname or IP (for direct SSH)
+- `--port`: SSH port (default: 22)
+- `--iapInstance`: GCP VM instance name (for IAP mode)
+- `--iapProject`: GCP project ID (for IAP mode)
+- `--iapZone`: GCP zone (optional - auto-detected)
+- `--user`: SSH username (required)
+- `--password`: SSH password
+- `--key`: Path to SSH private key file
+- `--sudoPassword`: Password for sudo commands
+- `--suPassword`: Password for su elevation
+- `--timeout`: Command timeout in ms (default: 60000)
+- `--maxChars`: Max command length (default: 1000)
+- `--disableSudo`: Disable sudo-exec tool
+
+**Note:** In static mode, you don't need to provide connection parameters with each command - they're pre-configured at startup.
+
+### HTTP/SSE Mode
+
+In **HTTP/SSE mode**, the server runs as a web service using Express, allowing MCP clients to connect via Server-Sent Events (SSE) and HTTP POST requests. This is useful for remote deployments, Docker containers, or environments where standard input/output (stdio) is not available.
+
+**Command-line usage:**
+
 ```bash
-claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=example.com --user=root --key=/path/to/private/key
+# Start the server on port 3000
+node build/index.js --port=3000
 ```
 
-**With Custom Timeout and No Character Limit:**
+**Endpoints:**
+- `GET /sse`: SSE endpoint for establishing the MCP connection
+- `POST /message`: Endpoint for sending JSON-RPC messages from the client
+- `GET /health`: Health check endpoint returning status and mode
+
+**Client Configuration:**
+
+To connect a client like Claude Desktop or another MCP client to the HTTP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "ssh-mcp": {
+      "command": "node",
+      "args": ["build/index.js", "--port=3000"],
+      "url": "http://localhost:3000/sse"
+    }
+  }
+}
+```
+
+**Docker Example:**
+
 ```bash
-claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --user=admin --password=your_password --timeout=120000 --maxChars=none
+docker run -p 3000:3000 -v ~/.ssh:/root/.ssh -v ~/.config/gcloud:/root/.config/gcloud ssh-mcp --port=3000
 ```
-
-**With Sudo and Su Support:**
-```bash
-claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --user=admin --password=your_password --sudoPassword=sudo_pass --suPassword=root_pass
-```
-
-**Installation Scopes:**
-
-You can specify the scope when adding the server:
-
-- **Local scope** (default): For personal use in the current project
-  ```bash
-  claude mcp add --transport stdio ssh-mcp --scope local -- npx -y ssh-mcp -- --host=YOUR_HOST --user=YOUR_USER --password=YOUR_PASSWORD
-  ```
-
-- **Project scope**: Share with your team via `.mcp.json` file
-  ```bash
-  claude mcp add --transport stdio ssh-mcp --scope project -- npx -y ssh-mcp -- --host=YOUR_HOST --user=YOUR_USER --password=YOUR_PASSWORD
-  ```
-
-- **User scope**: Available across all your projects
-  ```bash
-  claude mcp add --transport stdio ssh-mcp --scope user -- npx -y ssh-mcp -- --host=YOUR_HOST --user=YOUR_USER --password=YOUR_PASSWORD
-  ```
-
 
 **Verify Installation:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "ssh-mcp",
-  "version": "1.2.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
+        "cors": "^2.8.5",
+        "express": "^5.2.1",
         "ssh2": "^1.17.0",
         "zod": "3.23.8"
       },
@@ -17,6 +19,8 @@
         "ssh-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.6",
         "@types/node": "^24.5.2",
         "@types/ssh2": "^1.15.5",
         "cross-env": "^7.0.3",
@@ -630,6 +634,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1099,6 +1104,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1107,6 +1123,26 @@
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1146,14 +1182,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ssh2": {
@@ -1681,22 +1785,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1797,6 +1906,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1809,6 +1919,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2044,6 +2155,7 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -2289,6 +2401,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2338,6 +2451,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2346,6 +2460,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2361,6 +2476,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2579,17 +2695,20 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -2795,6 +2914,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2831,6 +2951,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2901,6 +3022,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2919,6 +3041,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2938,29 +3061,39 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3218,6 +3351,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3226,6 +3360,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3425,6 +3560,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3693,6 +3829,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -3732,17 +3869,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/readable-stream": {
@@ -4067,6 +4205,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -4085,6 +4224,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -4100,6 +4240,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4117,6 +4258,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4208,9 +4350,10 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4498,6 +4641,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4615,6 +4759,7 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4638,6 +4783,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -4653,6 +4799,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4737,6 +4884,7 @@
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -4853,6 +5001,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,14 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
+    "cors": "^2.8.5",
+    "express": "^5.2.1",
     "ssh2": "^1.17.0",
     "zod": "3.23.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.6",
     "@types/node": "^24.5.2",
     "@types/ssh2": "^1.15.5",
     "cross-env": "^7.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,37 +5,74 @@ import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { spawn, ChildProcess } from 'child_process';
+import express from 'express';
+import cors from 'cors';
 
-// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
+// Example usage:
+// Static mode (legacy): node build/index.js --host=1.2.3.4 --user=root --password=pass
+// IAP static mode: node build/index.js --iapInstance=vm-name --iapProject=project-id --user=root
+// Dynamic mode (recommended): node build/index.js --timeout=60000 --maxChars=none
+// HTTP/SSE mode: node build/index.js --port=3000
+// Then specify connection details in each command via the tools
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
-  for (const arg of args) {
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
     if (arg.startsWith('--')) {
       const equalIndex = arg.indexOf('=');
       if (equalIndex === -1) {
-        // Flag without value
-        config[arg.slice(2)] = null;
+        // No "=" sign - check if next arg is the value
+        const key = arg.slice(2);
+        const nextArg = args[i + 1];
+        if (nextArg && !nextArg.startsWith('--')) {
+          // Next arg is the value
+          config[key] = nextArg;
+          i += 2; // Skip both this arg and the value
+        } else {
+          // Flag without value
+          config[key] = null;
+          i++;
+        }
       } else {
         // Key=value pair
         config[arg.slice(2, equalIndex)] = arg.slice(equalIndex + 1);
+        i++;
       }
+    } else {
+      i++;
     }
   }
   return config;
 }
 const isTestMode = process.env.SSH_MCP_TEST === '1';
 const isCliEnabled = process.env.SSH_MCP_DISABLE_MAIN !== '1';
-const argvConfig = (isCliEnabled || isTestMode) ? parseArgv() : {} as Record<string, string>;
+// Always parse arguments to support static mode
+const argvConfig = parseArgv();
 
+// Static mode configuration (legacy - connection params at startup)
 const HOST = argvConfig.host;
 const PORT = argvConfig.port ? parseInt(argvConfig.port) : 22;
 const USER = argvConfig.user;
 const PASSWORD = argvConfig.password;
 const SUPASSWORD = argvConfig.suPassword;
 const SUDOPASSWORD = argvConfig.sudoPassword;
-const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
+const IAP_INSTANCE = argvConfig.iapInstance;
+const IAP_PROJECT = argvConfig.iapProject;
+const IAP_ZONE = argvConfig.iapZone;
+
+// Detect if we're in static mode (connection params provided at startup)
+const IS_STATIC_MODE = !!(HOST || IAP_INSTANCE);
+
+// HTTP/SSE transport configuration
+const HTTP_PORT = argvConfig.port ? parseInt(argvConfig.port) : undefined;
+
+// Global configuration
+const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
 // Max characters configuration:
 // - Default: 1000 characters
@@ -56,11 +93,29 @@ const MAX_CHARS = (() => {
   return 1000;
 })();
 
+// Default IAP local port
+const DEFAULT_IAP_LOCAL_PORT = 2222;
+
 function validateConfig(config: Record<string, string | null>) {
   const errors = [];
-  if (!config.host) errors.push('Missing required --host');
-  if (!config.user) errors.push('Missing required --user');
+
+  // Validate global parameters
+  if (config.timeout && isNaN(Number(config.timeout))) errors.push('Invalid --timeout');
+  if (config.maxChars && config.maxChars !== 'none' && isNaN(Number(config.maxChars))) errors.push('Invalid --maxChars');
   if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
+
+  // Validate static mode configuration (if connection params provided)
+  const isStaticMode = !!(config.host || config.iapInstance);
+  if (isStaticMode) {
+    // Either host or iapInstance+iapProject must be provided
+    if (config.host) {
+      if (!config.user) errors.push('Missing required --user for SSH mode');
+    } else if (config.iapInstance) {
+      if (!config.iapProject) errors.push('Missing required --iapProject for IAP mode');
+      if (!config.user) errors.push('Missing required --user for IAP mode');
+    }
+  }
+
   if (errors.length > 0) {
     throw new Error('Configuration error:\n' + errors.join('\n'));
   }
@@ -114,6 +169,163 @@ export interface SSHConfig {
   privateKey?: string;
   suPassword?: string;
   sudoPassword?: string;  // Password for sudo commands specifically (if different from suPassword)
+  // Google IAP tunnel configuration (optional)
+  iap?: {
+    enabled: boolean;
+    instanceName: string;
+    zone?: string;  // Optional: gcloud can auto-detect if instance name is unique
+    project: string;
+    localPort?: number;
+  };
+}
+
+// Google IAP Tunnel Manager
+// Connection parameters interface for dynamic connections
+export interface ConnectionParams {
+  // SSH direct mode
+  host?: string;
+  port?: number;
+  // IAP mode
+  iapInstance?: string;
+  iapProject?: string;
+  iapZone?: string;
+  iapLocalPort?: number;
+  // Authentication (common to both modes)
+  user: string;
+  password?: string;
+  privateKey?: string;
+  privateKeyPath?: string;
+  sudoPassword?: string;
+  suPassword?: string;
+}
+
+// Connection Pool for managing multiple dynamic connections
+export class ConnectionPool {
+  private connections: Map<string, SSHConnectionManager> = new Map();
+
+  /**
+   * Generate a unique key for a connection based on parameters
+   */
+  private getConnectionKey(params: ConnectionParams): string {
+    if (params.iapInstance && params.iapProject) {
+      return `iap:${params.iapProject}:${params.iapInstance}:${params.user}`;
+    } else if (params.host) {
+      return `ssh:${params.host}:${params.port || 22}:${params.user}`;
+    }
+    throw new Error('Either host or (iapInstance + iapProject) must be specified');
+  }
+
+  /**
+   * Convert ConnectionParams to SSHConfig
+   */
+  private async paramsToConfig(params: ConnectionParams): Promise<SSHConfig> {
+    // Validate connection parameters
+    if (!params.user) {
+      throw new McpError(ErrorCode.InvalidParams, 'Missing required parameter: user');
+    }
+
+    if (params.iapInstance && params.iapProject) {
+      // IAP mode
+      const config: SSHConfig = {
+        host: 'localhost',  // Will be overridden by tunnel
+        port: 22,           // Will be overridden by tunnel
+        username: params.user,
+        iap: {
+          enabled: true,
+          instanceName: params.iapInstance,
+          zone: params.iapZone,
+          project: params.iapProject,
+          localPort: params.iapLocalPort || DEFAULT_IAP_LOCAL_PORT
+        }
+      };
+
+      // Handle authentication
+      if (params.password) {
+        config.password = params.password;
+      } else if (params.privateKey) {
+        config.privateKey = params.privateKey;
+      } else if (params.privateKeyPath) {
+        const fs = await import('fs/promises');
+        config.privateKey = await fs.readFile(params.privateKeyPath, 'utf8');
+      }
+
+      if (params.sudoPassword) {
+        config.sudoPassword = sanitizePassword(params.sudoPassword);
+      }
+      if (params.suPassword) {
+        config.suPassword = sanitizePassword(params.suPassword);
+      }
+
+      return config;
+    } else if (params.host) {
+      // Direct SSH mode
+      const config: SSHConfig = {
+        host: params.host,
+        port: params.port || 22,
+        username: params.user
+      };
+
+      // Handle authentication
+      if (params.password) {
+        config.password = params.password;
+      } else if (params.privateKey) {
+        config.privateKey = params.privateKey;
+      } else if (params.privateKeyPath) {
+        const fs = await import('fs/promises');
+        config.privateKey = await fs.readFile(params.privateKeyPath, 'utf8');
+      }
+
+      if (params.sudoPassword) {
+        config.sudoPassword = sanitizePassword(params.sudoPassword);
+      }
+      if (params.suPassword) {
+        config.suPassword = sanitizePassword(params.suPassword);
+      }
+
+      return config;
+    } else {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'Either host or (iapInstance + iapProject) must be specified'
+      );
+    }
+  }
+
+  /**
+   * Get or create a connection for the given parameters
+   */
+  async getConnection(params: ConnectionParams): Promise<SSHConnectionManager> {
+    const key = this.getConnectionKey(params);
+
+    let manager = this.connections.get(key);
+
+    if (!manager || !manager.isConnected()) {
+      // Create new connection
+      const config = await this.paramsToConfig(params);
+      manager = new SSHConnectionManager(config);
+      await manager.connect();
+      this.connections.set(key, manager);
+    }
+
+    return manager;
+  }
+
+  /**
+   * Close all connections
+   */
+  closeAll(): void {
+    for (const manager of this.connections.values()) {
+      manager.close();
+    }
+    this.connections.clear();
+  }
+
+  /**
+   * Get connection count for debugging
+   */
+  getConnectionCount(): number {
+    return this.connections.size;
+  }
 }
 
 export class SSHConnectionManager {
@@ -124,12 +336,24 @@ export class SSHConnectionManager {
   private suShell: any = null;  // Store the elevated shell session
   private suPromise: Promise<void> | null = null;
   private isElevated = false;  // Track if we're in su mode
+  private originalHost: string;
+  private originalPort: number;
 
   constructor(config: SSHConfig) {
     this.sshConfig = config;
+    this.originalHost = config.host;
+    this.originalPort = config.port;
   }
 
   async connect(): Promise<void> {
+    // For IAP mode using gcloud ssh, we don't need a persistent connection
+    // Commands are executed directly via gcloud compute ssh
+    if (this.sshConfig.iap?.enabled) {
+      this.isConnecting = false;
+      this.connectionPromise = null;
+      return; // No connection needed for IAP mode
+    }
+
     if (this.conn && this.isConnected()) {
       return; // Already connected
     }
@@ -139,7 +363,7 @@ export class SSHConnectionManager {
     }
 
     this.isConnecting = true;
-    this.connectionPromise = new Promise((resolve, reject) => {
+    this.connectionPromise = new Promise(async (resolve, reject) => {
       this.conn = new Client();
 
       const timeoutId = setTimeout(() => {
@@ -199,6 +423,10 @@ export class SSHConnectionManager {
   }
 
   isConnected(): boolean {
+    // For IAP mode, we're always "connected" since we use gcloud ssh directly
+    if (this.sshConfig.iap?.enabled) {
+      return true;
+    }
     return this.conn !== null && (this.conn as any)._sock && !(this.conn as any)._sock.destroyed;
   }
 
@@ -336,11 +564,48 @@ export class SSHConnectionManager {
   }
 }
 
-let connectionManager: SSHConnectionManager | null = null;
+// Global connection pool for dynamic connections
+const connectionPool = new ConnectionPool();
+
+// Global static connection (for legacy static mode)
+let staticConnection: SSHConnectionManager | null = null;
+
+// Initialize static connection if in static mode
+async function initializeStaticConnection() {
+  if (!IS_STATIC_MODE) return;
+
+  const staticConfig: SSHConfig = {
+    host: HOST || 'localhost',
+    port: PORT,
+    username: USER!,
+    password: PASSWORD || undefined,
+    suPassword: SUPASSWORD || undefined,
+    sudoPassword: SUDOPASSWORD || undefined,
+  };
+
+  // Read private key from file if path provided
+  if (KEY) {
+    const fs = await import('fs/promises');
+    staticConfig.privateKey = await fs.readFile(KEY, 'utf8');
+  }
+
+  // Add IAP configuration if in IAP static mode
+  if (IAP_INSTANCE && IAP_PROJECT) {
+    staticConfig.iap = {
+      enabled: true,
+      instanceName: IAP_INSTANCE,
+      project: IAP_PROJECT,
+      zone: IAP_ZONE || undefined,
+      localPort: DEFAULT_IAP_LOCAL_PORT,
+    };
+  }
+
+  staticConnection = new SSHConnectionManager(staticConfig);
+}
 
 const server = new McpServer({
   name: 'SSH MCP Server',
-  version: '1.4.0',
+  version: '2.0.0',
   capabilities: {
     resources: {},
     tools: {},
@@ -349,49 +614,59 @@ const server = new McpServer({
 
 server.tool(
   "exec",
-  "Execute a shell command on the remote SSH server and return the output.",
+  IS_STATIC_MODE
+    ? "Execute a shell command on a remote server via SSH (direct) or Google IAP tunnel."
+    : "Execute a shell command on a remote server via SSH (direct) or Google IAP tunnel. Specify either 'host' for direct SSH or 'iapInstance+iapProject' for IAP mode.",
   {
-    command: z.string().describe("Shell command to execute on the remote SSH server"),
+    command: z.string().describe("Shell command to execute on the remote server"),
+    // SSH direct mode
+    host: z.string().optional().describe("SSH hostname or IP address (for direct SSH mode)"),
+    port: z.number().optional().describe("SSH port (default: 22)"),
+    // Google IAP mode
+    iapInstance: z.string().optional().describe("GCP VM instance name (for IAP tunnel mode)"),
+    iapProject: z.string().optional().describe("GCP project ID (for IAP tunnel mode)"),
+    iapZone: z.string().optional().describe("GCP zone (optional, gcloud can auto-detect if instance name is unique)"),
+    iapLocalPort: z.number().optional().describe("Local port for IAP tunnel (default: 2222)"),
+    // Authentication (common to both modes)
+    user: z.string().optional().describe("SSH username"),
+    password: z.string().optional().describe("SSH password"),
+    privateKey: z.string().optional().describe("SSH private key content (direct string)"),
+    privateKeyPath: z.string().optional().describe("Path to SSH private key file"),
+    sudoPassword: z.string().optional().describe("Password for sudo commands"),
+    suPassword: z.string().optional().describe("Password for persistent su elevation"),
   },
-  async ({ command }) => {
+  async (params) => {
+    const { command, ...connectionParams } = params;
     // Sanitize command input
     const sanitizedCommand = sanitizeCommand(command);
 
     try {
-      // Initialize connection manager if not already done
-      if (!connectionManager) {
-        if (!HOST || !USER) {
-          throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-        }
-        const sshConfig: SSHConfig = {
-          host: HOST,
-          port: PORT,
-          username: USER,
-        };
+      let manager: SSHConnectionManager;
 
-        if (PASSWORD) {
-          sshConfig.password = PASSWORD;
-        } else if (KEY) {
-          const fs = await import('fs/promises');
-          sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+      // Use static connection in static mode, otherwise use dynamic connection pool
+      if (IS_STATIC_MODE) {
+        if (!staticConnection) {
+          throw new McpError(ErrorCode.InternalError, 'Static connection not initialized');
         }
-
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          sshConfig.suPassword = sanitizePassword(SUPASSWORD);
+        manager = staticConnection;
+        // Connect if not already connected
+        await manager.connect();
+      } else {
+        // Dynamic mode: get or create connection from pool
+        // In dynamic mode, user is required since connection is not pre-configured
+        if (!connectionParams.user) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            'Missing required parameter: user (dynamic mode requires connection parameters with each command)'
+          );
         }
-        connectionManager = new SSHConnectionManager(sshConfig);
+        manager = await connectionPool.getConnection(connectionParams as ConnectionParams);
       }
 
-      // Ensure connection is active (reconnect if needed)
-      await connectionManager.ensureConnected();
-
-      // If a suPassword was provided, explicitly wait for elevation before executing.
-      // This is critical: ensureElevated is idempotent and will return immediately if
-      // already elevated, so this ensures we have a su shell before we try to use it.
-      if ((connectionManager as any).getSuPassword && (connectionManager as any).getSuPassword()) {
+      // If a suPassword was provided, explicitly wait for elevation before executing
+      if ((manager as any).getSuPassword && (manager as any).getSuPassword()) {
         try {
-          const elevationPromise = (connectionManager as any).ensureElevated();
-          // Add a short timeout for elevation to complete
+          const elevationPromise = (manager as any).ensureElevated();
           await Promise.race([
             elevationPromise,
             new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000))
@@ -401,7 +676,7 @@ server.tool(
         }
       }
 
-      const result = await execSshCommandWithConnection(connectionManager, sanitizedCommand);
+      const result = await execSshCommandWithConnection(manager, sanitizedCommand);
       return result;
     } catch (err: any) {
       // Wrap unexpected errors
@@ -415,67 +690,64 @@ server.tool(
 if (!DISABLE_SUDO) {
   server.tool(
     "sudo-exec",
-    "Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.",
+    IS_STATIC_MODE
+      ? "Execute a shell command with sudo elevation on a remote server via SSH (direct) or Google IAP tunnel."
+      : "Execute a shell command with sudo elevation on a remote server via SSH (direct) or Google IAP tunnel. Specify either 'host' for direct SSH or 'iapInstance+iapProject' for IAP mode.",
     {
-      command: z.string().describe("Shell command to execute with sudo on the remote SSH server"),
+      command: z.string().describe("Shell command to execute with sudo elevation"),
+      // SSH direct mode
+      host: z.string().optional().describe("SSH hostname or IP address (for direct SSH mode)"),
+      port: z.number().optional().describe("SSH port (default: 22)"),
+      // Google IAP mode
+      iapInstance: z.string().optional().describe("GCP VM instance name (for IAP tunnel mode)"),
+      iapProject: z.string().optional().describe("GCP project ID (for IAP tunnel mode)"),
+      iapZone: z.string().optional().describe("GCP zone (optional, gcloud can auto-detect if instance name is unique)"),
+      iapLocalPort: z.number().optional().describe("Local port for IAP tunnel (default: 2222)"),
+      // Authentication (common to both modes)
+      user: z.string().optional().describe("SSH username"),
+      password: z.string().optional().describe("SSH password"),
+      privateKey: z.string().optional().describe("SSH private key content (direct string)"),
+      privateKeyPath: z.string().optional().describe("Path to SSH private key file"),
+      sudoPassword: z.string().optional().describe("Password for sudo commands"),
+      suPassword: z.string().optional().describe("Password for persistent su elevation"),
     },
-    async ({ command }) => {
+    async (params) => {
+      const { command, ...connectionParams } = params;
       const sanitizedCommand = sanitizeCommand(command);
 
       try {
-        if (!connectionManager) {
-          if (!HOST || !USER) {
-            throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-          }
+        let manager: SSHConnectionManager;
 
-          const sshConfig: SSHConfig = {
-            host: HOST,
-            port: PORT || 22,
-            username: USER,
-          };
-          if (PASSWORD) {
-            sshConfig.password = PASSWORD;
-          } else if (KEY) {
-            const fs = await import('fs/promises');
-            sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+        // Use static connection in static mode, otherwise use dynamic connection pool
+        if (IS_STATIC_MODE) {
+          if (!staticConnection) {
+            throw new McpError(ErrorCode.InternalError, 'Static connection not initialized');
           }
-          if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-            sshConfig.suPassword = sanitizePassword(SUPASSWORD);
+          manager = staticConnection;
+          // Connect if not already connected
+          await manager.connect();
+        } else {
+          // Dynamic mode: get or create connection from pool
+          if (!connectionParams.user) {
+            throw new McpError(ErrorCode.InvalidParams, 'Missing required parameter: user');
           }
-          if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-            sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
-          }
-          connectionManager = new SSHConnectionManager(sshConfig);
+          manager = await connectionPool.getConnection(connectionParams as ConnectionParams);
         }
 
-        await connectionManager.ensureConnected();
-
-        // If suPassword or sudoPassword were provided on this call but the
-        // existing connection manager was created earlier without them,
-        // update the manager's values so the subsequent sudo-exec call uses
-        // the latest passwords.
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          await connectionManager.setSuPassword(sanitizePassword(SUPASSWORD));
-        }
-        if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-          // update sudoPassword on the manager instance
-          (connectionManager as any).sshConfig = { ...(connectionManager as any).sshConfig, sudoPassword: sanitizePassword(SUDOPASSWORD) };
-        }
-
+        // Wrap command with sudo
         let wrapped: string;
-        const sudoPassword = connectionManager.getSudoPassword();
+        const sudoPassword = manager.getSudoPassword();
 
         if (!sudoPassword) {
           // No password provided, use -n to fail if sudo requires a password
           wrapped = `sudo -n sh -c '${sanitizedCommand.replace(/'/g, "'\\''")}'`;
         } else {
-          // Password provided — pipe it into sudo using printf. This avoids complex
-          // PTY/stdin handling on the SSH channel and is simpler and more reliable.
+          // Password provided — pipe it into sudo using printf
           const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
           wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${sanitizedCommand.replace(/'/g, "'\\''")}'`;
         }
 
-        return await execSshCommandWithConnection(connectionManager, wrapped);
+        return await execSshCommandWithConnection(manager, wrapped);
       } catch (err: any) {
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
@@ -484,8 +756,141 @@ if (!DISABLE_SUDO) {
   );
 }
 
+// Auto-detect zone for an instance if not provided
+async function autoDetectZone(instance: string, project: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const listProcess = spawn('gcloud', [
+      'compute',
+      'instances',
+      'list',
+      `--project=${project}`,
+      `--filter=name=${instance}`,
+      '--format=value(zone)'
+    ], {
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    listProcess.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    listProcess.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    listProcess.on('exit', (code) => {
+      if (code === 0) {
+        const zone = stdout.trim();
+        if (zone) {
+          resolve(zone);
+        } else {
+          reject(new Error(`Instance ${instance} not found in project ${project}`));
+        }
+      } else {
+        reject(new Error(`Failed to list instances: ${stderr}`));
+      }
+    });
+
+    listProcess.on('error', (err) => {
+      reject(new Error(`Failed to execute gcloud instances list: ${err.message}`));
+    });
+  });
+}
+
+// Execute command via gcloud compute ssh (for IAP mode)
+export async function execViaGcloudSSH(
+  instance: string,
+  project: string,
+  zone: string | undefined,
+  user: string,
+  command: string
+): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+  return new Promise(async (resolve, reject) => {
+    // Auto-detect zone if not provided
+    let effectiveZone = zone;
+    if (!effectiveZone) {
+      try {
+        effectiveZone = await autoDetectZone(instance, project);
+      } catch (err: any) {
+        reject(new McpError(ErrorCode.InternalError, `Failed to auto-detect zone: ${err.message}`));
+        return;
+      }
+    }
+
+    const args = [
+      'compute',
+      'ssh',
+      `${user}@${instance}`,
+      '--tunnel-through-iap',
+      `--project=${project}`,
+      `--zone=${effectiveZone}`,
+      `--command=${command}`
+    ];
+
+    const gcloudProcess = spawn('gcloud', args, {
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    gcloudProcess.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    gcloudProcess.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    // Set up timeout
+    const timeoutId = setTimeout(() => {
+      gcloudProcess.kill('SIGTERM');
+      reject(new McpError(ErrorCode.InternalError, `Command execution timed out after ${DEFAULT_TIMEOUT}ms`));
+    }, DEFAULT_TIMEOUT);
+
+    gcloudProcess.on('exit', (code) => {
+      clearTimeout(timeoutId);
+
+      if (code === 0) {
+        resolve({
+          content: [{
+            type: 'text',
+            text: stdout,
+          }],
+        });
+      } else {
+        reject(new McpError(
+          ErrorCode.InternalError,
+          `gcloud ssh command failed with exit code ${code}.\nStderr: ${stderr}`
+        ));
+      }
+    });
+
+    gcloudProcess.on('error', (err) => {
+      clearTimeout(timeoutId);
+      reject(new McpError(ErrorCode.InternalError, `Failed to execute gcloud ssh: ${err.message}`));
+    });
+  });
+}
+
 // New function that uses persistent connection
 export async function execSshCommandWithConnection(manager: SSHConnectionManager, command: string, stdin?: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+  // Check if this is IAP mode - if so, use gcloud ssh directly
+  const iapConfig = (manager as any).sshConfig?.iap;
+  if (iapConfig && iapConfig.enabled) {
+    return execViaGcloudSSH(
+      iapConfig.instanceName,
+      iapConfig.project,
+      iapConfig.zone,
+      (manager as any).sshConfig.username,
+      command
+    );
+  }
+
+  // Otherwise use standard SSH connection
   return new Promise((resolve, reject) => {
     let timeoutId: NodeJS.Timeout;
     let isResolved = false;
@@ -681,33 +1086,67 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
 }
 
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("SSH MCP Server running on stdio");
+  // Initialize static connection if in static mode
+  await initializeStaticConnection();
 
   // Handle graceful shutdown
   const cleanup = () => {
     console.error("Shutting down SSH MCP Server...");
-    if (connectionManager) {
-      connectionManager.close();
-      connectionManager = null;
-    }
+    connectionPool.closeAll();
     process.exit(0);
   };
 
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
   process.on('exit', () => {
-    if (connectionManager) {
-      connectionManager.close();
-    }
+    connectionPool.closeAll();
   });
+
+  // Choose transport based on --port parameter
+  if (HTTP_PORT) {
+    // HTTP/SSE mode
+    const app = express();
+    app.use(cors());
+    app.use(express.json());
+
+    // Health check endpoint
+    app.get('/health', (_req, res) => {
+      res.json({ status: 'ok', mode: IS_STATIC_MODE ? 'static' : 'dynamic' });
+    });
+
+    // SSE endpoint for MCP
+    app.get('/sse', async (req, res) => {
+      console.error('New SSE connection established');
+      const transport = new SSEServerTransport('/message', res);
+      await server.connect(transport);
+    });
+
+    // Message endpoint for client requests
+    app.post('/message', async (req, res) => {
+      // This will be handled by SSEServerTransport
+      res.status(200).end();
+    });
+
+    app.listen(HTTP_PORT, () => {
+      console.error(`SSH MCP Server running on http://localhost:${HTTP_PORT}`);
+      console.error(`SSE endpoint: http://localhost:${HTTP_PORT}/sse`);
+      console.error(`Health check: http://localhost:${HTTP_PORT}/health`);
+    });
+  } else {
+    // Stdio mode (default)
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error("SSH MCP Server running on stdio");
+  }
 }
 
 // Initialize server in test mode for automated tests
 if (isTestMode) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(error => {
+  (async () => {
+    await initializeStaticConnection();
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  })().catch(error => {
     console.error("Fatal error connecting server:", error);
     process.exit(1);
   });
@@ -716,9 +1155,7 @@ if (isTestMode) {
 else if (isCliEnabled) {
   main().catch((error) => {
     console.error("Fatal error in main():", error);
-    if (connectionManager) {
-      connectionManager.close();
-    }
+    connectionPool.closeAll();
     process.exit(1);
   });
 }


### PR DESCRIPTION
## Changes
- Add Google IAP (Identity-Aware Proxy) support for accessing GCP instances without public IPs
- Implement dynamic connection mode allowing one MCP server to connect to unlimited remote systems
- Add HTTP/SSE transport support using Express for remote deployments
- Expose `/sse`, `/message`, and `/health` endpoints
- Add Dockerfile for containerized deployment
- Connection details (host/iapInstance, user, credentials) now specified per command instead of at startup
- Add automatic zone detection for IAP using gcloud instances list
- Update README with dynamic mode, HTTP/SSE documentation, and examples

## Testing
- Verify direct SSH connections (host/user/pass) works
- Verify Google IAP connections using `gcloud` credentials works
- Test HTTP/SSE mode connection via `/sse` endpoint
- Validate health check endpoint returns 200 OK
- Build Docker image and verify startup

## Risks
- Breaking change: Server no longer accepts static connection params at startup (except in legacy mode)
- New dependencies (express, cors) added
- HTTP mode exposes a network port (default 3000)

## Post-Deployment
- Update MCP client configurations to use new arguments or URL
- Monitor memory usage with new Express server integration