### PR TITLE
feat: add passphrase support for encrypted SSH keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 - MCP-compliant server exposing SSH capabilities
 - Execute shell commands on remote Linux and Windows systems
-- Secure authentication via password or SSH key
+- Secure authentication via password or SSH key (with passphrase support)
 - Built with TypeScript and the official MCP SDK
 - **Configurable timeout protection** with automatic process abortion
 - **Graceful timeout handling** - attempts to kill hanging processes before closing connections
@@ -89,6 +89,7 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `port`: SSH port (default: 22)
 - `password`: SSH password (or use `key` for key-based auth)
 - `key`: Path to private SSH key
+- `passphrase`: Passphrase for encrypted private SSH keys (use with `key`)
 - `sudoPassword`: Password for sudo elevation (when executing commands with sudo)
 - `suPassword`: Password for su elevation (when you need a persistent root shell)
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
@@ -110,6 +111,7 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
                 "--user=root",
                 "--password=pass",
                 "--key=path/to/key",
+                "--passphrase=your_key_passphrase",
                 "--timeout=30000",
                 "--maxChars=none"
             ]
@@ -138,6 +140,11 @@ claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.1
 **With SSH Key Authentication:**
 ```bash
 claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=example.com --user=root --key=/path/to/private/key
+```
+
+**With SSH Key Authentication (Encrypted Key with Passphrase):**
+```bash
+claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=example.com --user=root --key=/path/to/private/key --passphrase=your_key_passphrase
 ```
 
 **With Custom Timeout and No Character Limit:**
@@ -201,4 +208,4 @@ This project follows a [Code of Conduct](./CODE_OF_CONDUCT.md) to ensure a welco
 
 ## Support
 
-If you find SSH MCP Server helpful, consider starring the repository or contributing! Pull requests and feedback are welcome. 
+If you find SSH MCP Server helpful, consider starring the repository or contributing! Pull requests and feedback are welcome.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
+// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --passphrase=keypass --timeout=5000 --disableSudo
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
@@ -36,6 +36,7 @@ const SUPASSWORD = argvConfig.suPassword;
 const SUDOPASSWORD = argvConfig.sudoPassword;
 const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
+const PASSPHRASE = argvConfig.passphrase;  // Passphrase for encrypted SSH keys
 const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
 // Max characters configuration:
 // - Default: 1000 characters
@@ -112,6 +113,7 @@ export interface SSHConfig {
   username: string;
   password?: string;
   privateKey?: string;
+  passphrase?: string;  // Passphrase for encrypted private keys
   suPassword?: string;
   sudoPassword?: string;  // Password for sudo commands specifically (if different from suPassword)
 }
@@ -375,6 +377,9 @@ server.tool(
         } else if (KEY) {
           const fs = await import('fs/promises');
           sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+          if (PASSPHRASE) {
+            sshConfig.passphrase = PASSPHRASE;
+          }
         }
 
         if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
@@ -445,6 +450,9 @@ if (!DISABLE_SUDO) {
           } else if (KEY) {
             const fs = await import('fs/promises');
             sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+            if (PASSPHRASE) {
+              sshConfig.passphrase = PASSPHRASE;
+            }
           }
           if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
             sshConfig.suPassword = sanitizePassword(SUPASSWORD);


### PR DESCRIPTION
## Summary

- Add `--passphrase` CLI argument for encrypted private SSH keys
- Pass passphrase to ssh2 connection config when using key-based auth
- Update SSHConfig interface to include passphrase field

## Motivation

Currently, ssh-mcp only supports unencrypted private keys. Many users have passphrase-protected SSH keys for security reasons, and the ssh2 library already supports passphrases natively. This PR enables that functionality.

## Usage

```bash
npx ssh-mcp -- --host=example.com --user=root --key=/path/to/encrypted/key --passphrase=your_key_passphrase
```

## Changes

- `src/index.ts`: Added PASSPHRASE constant and passphrase field to SSHConfig interface
- `README.md`: Documented the new `--passphrase` option

## Test

Tested with encrypted ed25519 and RSA keys with passphrases.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)