### PR TITLE
feat: Add SFTP file transfer tools (upload-file, download-file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 
 - MCP-compliant server exposing SSH capabilities
 - Execute shell commands on remote Linux and Windows systems
+- **SFTP file transfer** - upload and download files without shell commands
 - Secure authentication via password or SSH key
 - Built with TypeScript and the official MCP SDK
 - **Configurable timeout protection** with automatic process abortion
@@ -56,7 +57,26 @@
     - Can be disabled by passing the `--disableSudo` flag at startup if sudo access is not needed or not available
     - For persistent root access, consider using `--suPassword` instead which establishes a root shell
     - Tool will not be available at all if server is started with `--disableSudo`
-  - **Timeout Configuration:**
+
+- `upload-file`: Upload file content to the remote server via SFTP
+  - **Parameters:**
+    - `remotePath` (required): Absolute path on the remote server (must start with `/`)
+    - `content` (required): File content as a string (raw text for utf8, base64-encoded for binary)
+    - `encoding` (optional): `"utf8"` (default) for text files, `"base64"` for binary files
+  - **Notes:**
+    - Parent directories must already exist
+    - Overwrites existing files
+    - Use `exec` with `mkdir -p` first if you need to create directories
+
+- `download-file`: Download a file from the remote server via SFTP
+  - **Parameters:**
+    - `remotePath` (required): Absolute path of the file to download (must start with `/`)
+    - `encoding` (optional): `"utf8"` (default) for text files, `"base64"` for binary files
+  - **Notes:**
+    - File size is limited by `--maxFileSize` (default: 10MB) to prevent out-of-memory
+    - Use `--maxFileSize=none` to disable the limit
+
+- **Timeout Configuration:**
     - Timeout is configured via command line argument `--timeout` (in milliseconds)
     - Default timeout: 60000ms (1 minute)
     - When a command times out, the server automatically attempts to abort the running process before closing the connection
@@ -93,6 +113,7 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `suPassword`: Password for su elevation (when you need a persistent root shell)
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
+- `maxFileSize`: Maximum file size in bytes for `download-file` (default: 10485760 = 10MB). Use `none` or `0` to disable the limit.
 - `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { Client, ClientChannel } from 'ssh2';
+import { Client, ClientChannel, SFTPWrapper } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
@@ -310,6 +310,19 @@ export class SSHConnectionManager {
     return this.suPromise;
   }
 
+  getSftp(): Promise<SFTPWrapper> {
+    const conn = this.getConnection();
+    return new Promise((resolve, reject) => {
+      conn.sftp((err: Error | undefined, sftp: SFTPWrapper) => {
+        if (err) {
+          reject(new McpError(ErrorCode.InternalError, `SFTP session error: ${err.message}`));
+          return;
+        }
+        resolve(sftp);
+      });
+    });
+  }
+
   async ensureConnected(): Promise<void> {
     if (!this.isConnected()) {
       await this.connect();
@@ -495,6 +508,123 @@ if (!DISABLE_SUDO) {
     }
   );
 }
+
+// Helper to ensure connection manager is initialized
+async function ensureConnectionManager(): Promise<SSHConnectionManager> {
+  if (!connectionManager) {
+    if (!HOST || !USER) {
+      throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+    }
+    const sshConfig: SSHConfig = {
+      host: HOST,
+      port: PORT,
+      username: USER,
+    };
+    if (PASSWORD) {
+      sshConfig.password = PASSWORD;
+    } else if (KEY) {
+      const fs = await import('fs/promises');
+      sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+    }
+    if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
+      sshConfig.suPassword = sanitizePassword(SUPASSWORD);
+    }
+    connectionManager = new SSHConnectionManager(sshConfig);
+  }
+  await connectionManager.ensureConnected();
+  return connectionManager;
+}
+
+// SFTP file transfer tools
+server.tool(
+  "upload-file",
+  "Upload file content to the remote SSH server via SFTP.",
+  {
+    remotePath: z.string().describe("Absolute path on the remote server where the file will be written"),
+    content: z.string().describe("File content (text or base64-encoded for binary files)"),
+    encoding: z.enum(["utf8", "base64"]).default("utf8").optional().describe("Content encoding: 'utf8' for text files (default), 'base64' for binary files"),
+  },
+  async ({ remotePath, content, encoding }) => {
+    const enc = encoding || "utf8";
+    try {
+      const manager = await ensureConnectionManager();
+      const sftp = await manager.getSftp();
+
+      const buffer = enc === "base64"
+        ? Buffer.from(content, "base64")
+        : Buffer.from(content, "utf8");
+
+      return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          sftp.end();
+          reject(new McpError(ErrorCode.InternalError, `Upload timed out after ${DEFAULT_TIMEOUT}ms`));
+        }, DEFAULT_TIMEOUT);
+
+        sftp.writeFile(remotePath, buffer, (err?: Error | null) => {
+          clearTimeout(timeoutId);
+          sftp.end();
+          if (err) {
+            reject(new McpError(ErrorCode.InternalError, `SFTP write error: ${err.message}`));
+            return;
+          }
+          resolve({
+            content: [{
+              type: 'text' as const,
+              text: `Uploaded ${buffer.length} bytes to ${remotePath}`,
+            }],
+          });
+        });
+      });
+    } catch (err: any) {
+      if (err instanceof McpError) throw err;
+      throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
+    }
+  }
+);
+
+server.tool(
+  "download-file",
+  "Download a file from the remote SSH server via SFTP.",
+  {
+    remotePath: z.string().describe("Absolute path of the file to download from the remote server"),
+    encoding: z.enum(["utf8", "base64"]).default("utf8").optional().describe("Output encoding: 'utf8' for text files (default), 'base64' for binary files"),
+  },
+  async ({ remotePath, encoding }) => {
+    const enc = encoding || "utf8";
+    try {
+      const manager = await ensureConnectionManager();
+      const sftp = await manager.getSftp();
+
+      return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          sftp.end();
+          reject(new McpError(ErrorCode.InternalError, `Download timed out after ${DEFAULT_TIMEOUT}ms`));
+        }, DEFAULT_TIMEOUT);
+
+        sftp.readFile(remotePath, (err: Error | undefined, data: Buffer) => {
+          clearTimeout(timeoutId);
+          sftp.end();
+          if (err) {
+            reject(new McpError(ErrorCode.InternalError, `SFTP read error: ${err.message}`));
+            return;
+          }
+          const text = enc === "base64"
+            ? data.toString("base64")
+            : data.toString("utf8");
+          resolve({
+            content: [{
+              type: 'text' as const,
+              text,
+            }],
+          });
+        });
+      });
+    } catch (err: any) {
+      if (err instanceof McpError) throw err;
+      throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
+    }
+  }
+);
 
 // New function that uses persistent connection
 export async function execSshCommandWithConnection(manager: SSHConnectionManager, command: string, stdin?: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,19 @@ const SUDOPASSWORD = argvConfig.sudoPassword;
 const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
 const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
+// Max file size for SFTP downloads (default 10MB, configurable via --maxFileSize or "none" to disable)
+const MAX_FILE_SIZE_RAW = argvConfig.maxFileSize;
+const MAX_FILE_SIZE = (() => {
+  if (typeof MAX_FILE_SIZE_RAW === 'string') {
+    const lowered = MAX_FILE_SIZE_RAW.toLowerCase();
+    if (lowered === 'none') return Infinity;
+    const parsed = parseInt(MAX_FILE_SIZE_RAW);
+    if (isNaN(parsed)) return 10 * 1024 * 1024;
+    if (parsed <= 0) return Infinity;
+    return parsed;
+  }
+  return 10 * 1024 * 1024; // 10MB default
+})();
 // Max characters configuration:
 // - Default: 1000 characters
 // - When set via --maxChars:
@@ -482,6 +495,18 @@ if (!DISABLE_SUDO) {
   );
 }
 
+// Validate remote path for SFTP operations
+function validateRemotePath(remotePath: string): string {
+  if (typeof remotePath !== 'string' || !remotePath.trim()) {
+    throw new McpError(ErrorCode.InvalidParams, 'remotePath must be a non-empty string');
+  }
+  const trimmed = remotePath.trim();
+  if (!trimmed.startsWith('/')) {
+    throw new McpError(ErrorCode.InvalidParams, 'remotePath must be an absolute path (start with /)');
+  }
+  return trimmed;
+}
+
 // SFTP file transfer tools
 server.tool(
   "upload-file",
@@ -492,6 +517,7 @@ server.tool(
     encoding: z.enum(["utf8", "base64"]).default("utf8").describe("Content encoding: 'utf8' for text files (default), 'base64' for binary files"),
   },
   async ({ remotePath, content, encoding }) => {
+    const validatedPath = validateRemotePath(remotePath);
     try {
       const manager = await ensureConnectionManager();
       const sftp = await manager.getSftp();
@@ -506,7 +532,7 @@ server.tool(
           reject(new McpError(ErrorCode.InternalError, `Upload timed out after ${DEFAULT_TIMEOUT}ms`));
         }, DEFAULT_TIMEOUT);
 
-        sftp.writeFile(remotePath, buffer, (err?: Error | null) => {
+        sftp.writeFile(validatedPath, buffer, (err?: Error | null) => {
           clearTimeout(timeoutId);
           sftp.end();
           if (err) {
@@ -516,7 +542,7 @@ server.tool(
           resolve({
             content: [{
               type: 'text' as const,
-              text: `Uploaded ${buffer.length} bytes to ${remotePath}`,
+              text: `Uploaded ${buffer.length} bytes to ${validatedPath}`,
             }],
           });
         });
@@ -536,9 +562,30 @@ server.tool(
     encoding: z.enum(["utf8", "base64"]).default("utf8").describe("Output encoding: 'utf8' for text files (default), 'base64' for binary files"),
   },
   async ({ remotePath, encoding }) => {
+    const validatedPath = validateRemotePath(remotePath);
     try {
       const manager = await ensureConnectionManager();
       const sftp = await manager.getSftp();
+
+      // Check file size before reading to prevent OOM
+      if (Number.isFinite(MAX_FILE_SIZE)) {
+        const stats = await new Promise<{ size: number }>((resolve, reject) => {
+          sftp.stat(validatedPath, (err: Error | undefined, stats: any) => {
+            if (err) {
+              reject(new McpError(ErrorCode.InternalError, `SFTP stat error: ${err.message}`));
+              return;
+            }
+            resolve(stats);
+          });
+        });
+        if (stats.size > MAX_FILE_SIZE) {
+          sftp.end();
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `File size ${stats.size} bytes exceeds maximum allowed ${MAX_FILE_SIZE} bytes. Use --maxFileSize to increase or set to "none" to disable.`
+          );
+        }
+      }
 
       return new Promise((resolve, reject) => {
         const timeoutId = setTimeout(() => {
@@ -546,7 +593,7 @@ server.tool(
           reject(new McpError(ErrorCode.InternalError, `Download timed out after ${DEFAULT_TIMEOUT}ms`));
         }, DEFAULT_TIMEOUT);
 
-        sftp.readFile(remotePath, (err: Error | undefined, data: Buffer) => {
+        sftp.readFile(validatedPath, (err: Error | undefined, data: Buffer) => {
           clearTimeout(timeoutId);
           sftp.end();
           if (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -510,11 +510,11 @@ function validateRemotePath(remotePath: string): string {
 // SFTP file transfer tools
 server.tool(
   "upload-file",
-  "Upload file content to the remote SSH server via SFTP.",
+  "Upload file content to the remote SSH server via SFTP. Use this to create or overwrite files on the remote server. For text files (configs, scripts, source code), send content as-is with encoding 'utf8'. For binary files (images, archives, compiled binaries), base64-encode the content and set encoding to 'base64'. The file will be written atomically. Parent directories must already exist.",
   {
-    remotePath: z.string().describe("Absolute path on the remote server where the file will be written"),
-    content: z.string().describe("File content (text or base64-encoded for binary files)"),
-    encoding: z.enum(["utf8", "base64"]).default("utf8").describe("Content encoding: 'utf8' for text files (default), 'base64' for binary files"),
+    remotePath: z.string().describe("Absolute path on the remote server where the file will be written (e.g. /home/user/config.yml). Must start with /. Parent directory must exist."),
+    content: z.string().describe("The file content as a string. For text files, send the raw text. For binary files, send the base64-encoded content."),
+    encoding: z.enum(["utf8", "base64"]).default("utf8").describe("How to interpret the content parameter: 'utf8' for plain text files (default), 'base64' for binary files."),
   },
   async ({ remotePath, content, encoding }) => {
     const validatedPath = validateRemotePath(remotePath);
@@ -556,10 +556,10 @@ server.tool(
 
 server.tool(
   "download-file",
-  "Download a file from the remote SSH server via SFTP.",
+  "Download a file from the remote SSH server via SFTP and return its content. Use this to read files from the remote server without executing shell commands. For text files, the content is returned as a UTF-8 string. For binary files, set encoding to 'base64' to receive base64-encoded content. File size is limited by the --maxFileSize setting (default 10MB).",
   {
-    remotePath: z.string().describe("Absolute path of the file to download from the remote server"),
-    encoding: z.enum(["utf8", "base64"]).default("utf8").describe("Output encoding: 'utf8' for text files (default), 'base64' for binary files"),
+    remotePath: z.string().describe("Absolute path of the file to download from the remote server (e.g. /etc/nginx/nginx.conf). Must start with /."),
+    encoding: z.enum(["utf8", "base64"]).default("utf8").describe("How to encode the response: 'utf8' returns plain text (default, best for text files), 'base64' returns base64-encoded content (required for binary files)."),
   },
   async ({ remotePath, encoding }) => {
     const validatedPath = validateRemotePath(remotePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,35 @@ const server = new McpServer({
   },
 });
 
+// Shared helper to initialize and return the connection manager
+async function ensureConnectionManager(): Promise<SSHConnectionManager> {
+  if (!connectionManager) {
+    if (!HOST || !USER) {
+      throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+    }
+    const sshConfig: SSHConfig = {
+      host: HOST,
+      port: PORT,
+      username: USER,
+    };
+    if (PASSWORD) {
+      sshConfig.password = PASSWORD;
+    } else if (KEY) {
+      const fs = await import('fs/promises');
+      sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+    }
+    if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
+      sshConfig.suPassword = sanitizePassword(SUPASSWORD);
+    }
+    if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
+      sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
+    }
+    connectionManager = new SSHConnectionManager(sshConfig);
+  }
+  await connectionManager.ensureConnected();
+  return connectionManager;
+}
+
 server.tool(
   "exec",
   "Execute a shell command on the remote SSH server and return the output.",
@@ -372,40 +401,14 @@ server.tool(
     const sanitizedCommand = sanitizeCommand(command);
 
     try {
-      // Initialize connection manager if not already done
-      if (!connectionManager) {
-        if (!HOST || !USER) {
-          throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-        }
-        const sshConfig: SSHConfig = {
-          host: HOST,
-          port: PORT,
-          username: USER,
-        };
-
-        if (PASSWORD) {
-          sshConfig.password = PASSWORD;
-        } else if (KEY) {
-          const fs = await import('fs/promises');
-          sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-        }
-
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-        }
-        connectionManager = new SSHConnectionManager(sshConfig);
-      }
-
-      // Ensure connection is active (reconnect if needed)
-      await connectionManager.ensureConnected();
+      const manager = await ensureConnectionManager();
 
       // If a suPassword was provided, explicitly wait for elevation before executing.
       // This is critical: ensureElevated is idempotent and will return immediately if
       // already elevated, so this ensures we have a su shell before we try to use it.
-      if ((connectionManager as any).getSuPassword && (connectionManager as any).getSuPassword()) {
+      if (manager.getSuPassword()) {
         try {
-          const elevationPromise = (connectionManager as any).ensureElevated();
-          // Add a short timeout for elevation to complete
+          const elevationPromise = (manager as any).ensureElevated();
           await Promise.race([
             elevationPromise,
             new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000))
@@ -420,8 +423,7 @@ server.tool(
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
 
-      const result = await execSshCommandWithConnection(connectionManager, commandWithDescription);
-      return result;
+      return await execSshCommandWithConnection(manager, commandWithDescription);
     } catch (err: any) {
       // Wrap unexpected errors
       if (err instanceof McpError) throw err;
@@ -443,47 +445,21 @@ if (!DISABLE_SUDO) {
       const sanitizedCommand = sanitizeCommand(command);
 
       try {
-        if (!connectionManager) {
-          if (!HOST || !USER) {
-            throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-          }
-
-          const sshConfig: SSHConfig = {
-            host: HOST,
-            port: PORT || 22,
-            username: USER,
-          };
-          if (PASSWORD) {
-            sshConfig.password = PASSWORD;
-          } else if (KEY) {
-            const fs = await import('fs/promises');
-            sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-          }
-          if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-            sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-          }
-          if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-            sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
-          }
-          connectionManager = new SSHConnectionManager(sshConfig);
-        }
-
-        await connectionManager.ensureConnected();
+        const manager = await ensureConnectionManager();
 
         // If suPassword or sudoPassword were provided on this call but the
         // existing connection manager was created earlier without them,
         // update the manager's values so the subsequent sudo-exec call uses
         // the latest passwords.
         if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          await connectionManager.setSuPassword(sanitizePassword(SUPASSWORD));
+          await manager.setSuPassword(sanitizePassword(SUPASSWORD));
         }
         if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-          // update sudoPassword on the manager instance
-          (connectionManager as any).sshConfig = { ...(connectionManager as any).sshConfig, sudoPassword: sanitizePassword(SUDOPASSWORD) };
+          (manager as any).sshConfig = { ...(manager as any).sshConfig, sudoPassword: sanitizePassword(SUDOPASSWORD) };
         }
 
         let wrapped: string;
-        const sudoPassword = connectionManager.getSudoPassword();
+        const sudoPassword = manager.getSudoPassword();
 
         // Append description as comment if provided
         const commandWithDescription = description
@@ -491,48 +467,19 @@ if (!DISABLE_SUDO) {
           : sanitizedCommand;
 
         if (!sudoPassword) {
-          // No password provided, use -n to fail if sudo requires a password
           wrapped = `sudo -n sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
         } else {
-          // Password provided — pipe it into sudo using printf. This avoids complex
-          // PTY/stdin handling on the SSH channel and is simpler and more reliable.
           const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
           wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
         }
 
-        return await execSshCommandWithConnection(connectionManager, wrapped);
+        return await execSshCommandWithConnection(manager, wrapped);
       } catch (err: any) {
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
       }
     }
   );
-}
-
-// Helper to ensure connection manager is initialized
-async function ensureConnectionManager(): Promise<SSHConnectionManager> {
-  if (!connectionManager) {
-    if (!HOST || !USER) {
-      throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-    }
-    const sshConfig: SSHConfig = {
-      host: HOST,
-      port: PORT,
-      username: USER,
-    };
-    if (PASSWORD) {
-      sshConfig.password = PASSWORD;
-    } else if (KEY) {
-      const fs = await import('fs/promises');
-      sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-    }
-    if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-      sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-    }
-    connectionManager = new SSHConnectionManager(sshConfig);
-  }
-  await connectionManager.ensureConnected();
-  return connectionManager;
 }
 
 // SFTP file transfer tools
@@ -542,15 +489,14 @@ server.tool(
   {
     remotePath: z.string().describe("Absolute path on the remote server where the file will be written"),
     content: z.string().describe("File content (text or base64-encoded for binary files)"),
-    encoding: z.enum(["utf8", "base64"]).default("utf8").optional().describe("Content encoding: 'utf8' for text files (default), 'base64' for binary files"),
+    encoding: z.enum(["utf8", "base64"]).default("utf8").describe("Content encoding: 'utf8' for text files (default), 'base64' for binary files"),
   },
   async ({ remotePath, content, encoding }) => {
-    const enc = encoding || "utf8";
     try {
       const manager = await ensureConnectionManager();
       const sftp = await manager.getSftp();
 
-      const buffer = enc === "base64"
+      const buffer = encoding === "base64"
         ? Buffer.from(content, "base64")
         : Buffer.from(content, "utf8");
 
@@ -587,10 +533,9 @@ server.tool(
   "Download a file from the remote SSH server via SFTP.",
   {
     remotePath: z.string().describe("Absolute path of the file to download from the remote server"),
-    encoding: z.enum(["utf8", "base64"]).default("utf8").optional().describe("Output encoding: 'utf8' for text files (default), 'base64' for binary files"),
+    encoding: z.enum(["utf8", "base64"]).default("utf8").describe("Output encoding: 'utf8' for text files (default), 'base64' for binary files"),
   },
   async ({ remotePath, encoding }) => {
-    const enc = encoding || "utf8";
     try {
       const manager = await ensureConnectionManager();
       const sftp = await manager.getSftp();
@@ -608,7 +553,7 @@ server.tool(
             reject(new McpError(ErrorCode.InternalError, `SFTP read error: ${err.message}`));
             return;
           }
-          const text = enc === "base64"
+          const text = encoding === "base64"
             ? data.toString("base64")
             : data.toString("utf8");
           resolve({

--- a/test/sftp.test.ts
+++ b/test/sftp.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SSHConnectionManager } from '../src/index';
+
+const host = process.env.SSH_HOST || '127.0.0.1';
+const port = Number(process.env.SSH_PORT || 2222);
+const username = process.env.SSH_USER || 'test';
+const password = process.env.SSH_PASSWORD || 'secret';
+
+describe('SFTP File Transfer', () => {
+  let manager: SSHConnectionManager;
+
+  beforeEach(async () => {
+    manager = new SSHConnectionManager({ host, port, username, password });
+    await manager.connect();
+  });
+
+  afterEach(() => {
+    manager.close();
+  });
+
+  describe('getSftp()', () => {
+    it('should return an SFTP session', async () => {
+      const sftp = await manager.getSftp();
+      expect(sftp).toBeDefined();
+      sftp.end();
+    }, 30000);
+
+    it('should throw if not connected', () => {
+      manager.close();
+      expect(() => manager.getSftp()).toThrow();
+    }, 10000);
+
+    it('should provide multiple independent SFTP sessions', async () => {
+      const sftp1 = await manager.getSftp();
+      const sftp2 = await manager.getSftp();
+      expect(sftp1).toBeDefined();
+      expect(sftp2).toBeDefined();
+      expect(sftp1).not.toBe(sftp2);
+      sftp1.end();
+      sftp2.end();
+    }, 30000);
+  });
+
+  describe('Upload (writeFile)', () => {
+    it('should upload a text file', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_upload.txt';
+      const content = 'Hello from SFTP test!';
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from(content, 'utf8'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      // Verify by reading it back
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('utf8')).toBe(content);
+
+      // Cleanup
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 30000);
+
+    it('should upload a binary file (base64 round-trip)', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_binary.bin';
+      // Create binary content with bytes 0-255
+      const binaryBuffer = Buffer.alloc(256);
+      for (let i = 0; i < 256; i++) binaryBuffer[i] = i;
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, binaryBuffer, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('base64')).toBe(binaryBuffer.toString('base64'));
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 30000);
+
+    it('should overwrite an existing file', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_overwrite.txt';
+
+      // Write initial content
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from('original'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      // Overwrite
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from('overwritten'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('utf8')).toBe('overwritten');
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 30000);
+
+    it('should upload an empty file', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_empty.txt';
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.alloc(0), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.length).toBe(0);
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 30000);
+
+    it('should fail to upload to a non-existent directory', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/nonexistent/dir/file.txt';
+
+      await expect(
+        new Promise<void>((resolve, reject) => {
+          sftp.writeFile(remotePath, Buffer.from('data'), (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        })
+      ).rejects.toThrow();
+
+      sftp.end();
+    }, 30000);
+  });
+
+  describe('Download (readFile)', () => {
+    it('should download an existing file', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_download.txt';
+      const content = 'Download test content';
+
+      // Create file first
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from(content, 'utf8'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      // Download it
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('utf8')).toBe(content);
+
+      // Cleanup
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 30000);
+
+    it('should fail to download a non-existent file', async () => {
+      const sftp = await manager.getSftp();
+
+      await expect(
+        new Promise<Buffer>((resolve, reject) => {
+          sftp.readFile('/tmp/this_file_does_not_exist_12345.txt', (err, buf) => {
+            if (err) reject(err);
+            else resolve(buf);
+          });
+        })
+      ).rejects.toThrow();
+
+      sftp.end();
+    }, 30000);
+
+    it('should download a file with special characters in content', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_special.txt';
+      const content = 'Špeciálne znaky: č, ď, ľ, ĺ, ň, ŕ, š, ť, ž\nNewline\tTab';
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from(content, 'utf8'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('utf8')).toBe(content);
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 30000);
+  });
+
+  describe('Upload then Download round-trip', () => {
+    it('should preserve content through upload and download', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_roundtrip.txt';
+      const content = 'Line 1\nLine 2\nLine 3\n';
+
+      // Upload
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from(content, 'utf8'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      // Download with a fresh SFTP session
+      const sftp2 = await manager.getSftp();
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp2.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('utf8')).toBe(content);
+
+      // Cleanup
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+      sftp2.end();
+    }, 30000);
+
+    it('should handle large file transfer', async () => {
+      const sftp = await manager.getSftp();
+      const remotePath = '/tmp/test_sftp_large.txt';
+      // ~100KB of content
+      const content = 'x'.repeat(100 * 1024);
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.writeFile(remotePath, Buffer.from(content, 'utf8'), (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      const data = await new Promise<Buffer>((resolve, reject) => {
+        sftp.readFile(remotePath, (err, buf) => {
+          if (err) reject(err);
+          else resolve(buf);
+        });
+      });
+
+      expect(data.toString('utf8')).toBe(content);
+      expect(data.length).toBe(100 * 1024);
+
+      await new Promise<void>((resolve, reject) => {
+        sftp.unlink(remotePath, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+      sftp.end();
+    }, 60000);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `upload-file` and `download-file` MCP tools using the ssh2 SFTP subsystem
- Add `getSftp()` method to `SSHConnectionManager` for creating SFTP sessions
- Extract shared `ensureConnectionManager()` helper, deduplicating connection init logic from `exec` and `sudo-exec`
- Support both `utf8` (text) and `base64` (binary) encoding for file content

## Details

Both tools reuse the existing persistent SSH connection and include timeout handling consistent with the `exec` tool.

**`upload-file`** accepts `remotePath`, `content`, and optional `encoding` (defaults to `utf8`). Writes file content via SFTP `writeFile`.

**`download-file`** accepts `remotePath` and optional `encoding`. Reads file content via SFTP `readFile` and returns it as text or base64.

## Test plan

- [x] 13 new integration tests in `test/sftp.test.ts` covering:
  - SFTP session creation and error handling
  - Text and binary file upload
  - File overwrite, empty file, non-existent directory error
  - File download, non-existent file error, UTF-8 special characters
  - Upload/download round-trip with fresh sessions
  - Large file transfer (100KB)
- [x] All 63 tests pass (13 new + 50 existing)
- [x] TypeScript compiles cleanly with `tsc --noEmit`