### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 - [Disclaimer](#disclaimer)
 - [Support](#support)
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tufantunc-ssh-mcp).
+
 ## Quick Start
 
 - [Install](#installation) SSH MCP Server


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/tufantunc-ssh-mcp).