### PR TITLE
Add HTTP MCP server for dynamic multi-host SSH execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,19 @@ jobs:
           SSH_PASSWORD: secret
         run: npm test
 
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ssh-mcp:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,4 +26,44 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public 
+        run: npm publish --access public
+
+  publish-docker:
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ssh-mcp
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies (including dev deps needed for TypeScript build)
+COPY package*.json ./
+RUN npm ci
+
+# Compile TypeScript → JavaScript
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+
+# Copy only production dependencies + compiled output
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/build ./build
+
+# Port the HTTP MCP server listens on
+EXPOSE 8080
+
+# Health check (matches the /health endpoint in http-server.ts)
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:8080/health || exit 1
+
+# Run the HTTP MCP server (not the stdio server)
+CMD ["node", "build/http-server.js"]

--- a/README.md
+++ b/README.md
@@ -11,14 +11,28 @@
 
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/tufantunc/ssh-mcp)](https://archestra.ai/mcp-catalog/tufantunc__ssh-mcp)
 
-**SSH MCP Server** is a local Model Context Protocol (MCP) server that exposes SSH control for Linux and Windows systems, enabling LLMs and other MCP clients to execute shell commands securely via SSH.
+**SSH MCP Server** is a Model Context Protocol (MCP) server that exposes SSH control for Linux and Windows systems, enabling LLMs and other MCP clients to execute shell commands securely via SSH.
+
+Two transport modes are available:
+
+| Mode | Transport | Use case |
+|------|-----------|----------|
+| **Stdio** (classic) | stdin/stdout | Single static host — one process per server |
+| **HTTP** (new) | Streamable HTTP `POST /mcp` | Dynamic multi-host — one container for many servers |
 
 ## Contents
 
 - [Quick Start](#quick-start)
 - [Features](#features)
 - [Installation](#installation)
-- [Client Setup](#client-setup)
+- [Stdio Server — Single Host](#stdio-server--single-host)
+  - [Client Setup](#client-setup)
+  - [Claude Code](#claude-code)
+- [HTTP Server — Dynamic Multi-Host](#http-server--dynamic-multi-host)
+  - [Docker Quick Start](#docker-quick-start)
+  - [Tools](#http-tools)
+  - [MCP Client Configuration](#mcp-client-configuration-http)
+  - [Environment Variables](#environment-variables)
 - [Testing](#testing)
 - [Disclaimer](#disclaimer)
 - [Support](#support)
@@ -26,9 +40,10 @@
 ## Quick Start
 
 - [Install](#installation) SSH MCP Server
-- [Configure](#configuration) SSH MCP Server
-- [Set up](#client-setup) your MCP Client (e.g. Claude Desktop, Cursor, etc)
-- Execute remote shell commands on your Linux or Windows server via natural language
+- Choose a transport mode:
+  - **Single host** → [Configure the stdio server](#client-setup) and point your MCP client at it
+  - **Multi-host / containerised** → [Pull and run the Docker image](#docker-quick-start) and point your MCP client at the HTTP endpoint
+- Execute remote shell commands via natural language
 
 ## Features
 
@@ -36,8 +51,42 @@
 - Execute shell commands on remote Linux and Windows systems
 - Secure authentication via password or SSH key
 - Built with TypeScript and the official MCP SDK
+- **Two transport modes** — stdio for single-host setups, HTTP for dynamic multi-host deployments
 - **Configurable timeout protection** with automatic process abortion
-- **Graceful timeout handling** - attempts to kill hanging processes before closing connections
+- **Graceful timeout handling** — attempts to kill hanging processes before closing connections
+- **Docker image** published to GitHub Container Registry (`ghcr.io`) on every release
+
+## Installation
+
+### From npm (stdio server)
+
+```bash
+npx ssh-mcp -- --host=YOUR_HOST --user=YOUR_USER --password=YOUR_PASSWORD
+```
+
+### From source
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/tufantunc/ssh-mcp.git
+   cd ssh-mcp
+   ```
+2. **Install dependencies:**
+   ```bash
+   npm install
+   ```
+
+### Docker (HTTP server)
+
+```bash
+docker pull ghcr.io/tufantunc/ssh-mcp:latest
+```
+
+---
+
+## Stdio Server — Single Host
+
+The stdio server connects to **one fixed SSH host** at startup. It is ideal for IDE integrations (Cursor, Windsurf, Claude Desktop, etc.) where each project targets a known server.
 
 ### Tools
 
@@ -45,7 +94,6 @@
   - **Parameters:**
     - `command` (required): Shell command to execute on the remote SSH server
     - `description` (optional): Optional description of what this command will do (appended as a comment)
-  - **Timeout Configuration:**
 
 - `sudo-exec`: Execute a shell command with sudo elevation
   - **Parameters:**
@@ -65,19 +113,7 @@
     - Default: `1000`
     - No-limit mode: set `--maxChars=none` or any `<= 0` value (e.g. `--maxChars=0`)
 
-## Installation
-
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/tufantunc/ssh-mcp.git
-   cd ssh-mcp
-   ```
-2. **Install dependencies:**
-   ```bash
-   npm install
-   ```
-
-## Client Setup
+### Client Setup
 
 You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use this MCP Server.
 
@@ -95,8 +131,7 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
 - `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
 
-
-```commandline
+```json
 {
     "mcpServers": {
         "ssh-mcp": {
@@ -169,7 +204,6 @@ You can specify the scope when adding the server:
   claude mcp add --transport stdio ssh-mcp --scope user -- npx -y ssh-mcp -- --host=YOUR_HOST --user=YOUR_USER --password=YOUR_PASSWORD
   ```
 
-
 **Verify Installation:**
 
 After adding the server, restart Claude Code and ask Cascade to execute a command:
@@ -178,6 +212,117 @@ After adding the server, restart Claude Code and ask Cascade to execute a comman
 ```
 
 For more information about MCP in Claude Code, see the [official documentation](https://docs.claude.com/en/docs/claude-code/mcp).
+
+---
+
+## HTTP Server — Dynamic Multi-Host
+
+The HTTP server exposes SSH execution over **Streamable HTTP** (`POST /mcp`). Unlike the stdio server, it accepts SSH connection parameters on **every tool call**, so a single running instance (or container) can reach any number of SSH hosts without restart.
+
+This mode is designed for tools like [HolmesGPT](https://github.com/robusta-dev/holmesgpt) that orchestrate investigations across many servers.
+
+### Docker Quick Start
+
+**Pull the image:**
+```bash
+docker pull ghcr.io/tufantunc/ssh-mcp:latest
+```
+
+**Run the container:**
+```bash
+docker run -d \
+  --name ssh-mcp \
+  -p 8080:8080 \
+  ghcr.io/tufantunc/ssh-mcp:latest
+```
+
+**Override the port or timeout:**
+```bash
+docker run -d \
+  --name ssh-mcp \
+  -p 9090:9090 \
+  -e PORT=9090 \
+  -e SSH_TIMEOUT_MS=120000 \
+  ghcr.io/tufantunc/ssh-mcp:latest
+```
+
+**Verify it is running:**
+```bash
+curl http://localhost:8080/health
+# {"status":"ok","service":"ssh-mcp-http","version":"1.5.0"}
+```
+
+### HTTP Tools
+
+Both tools open a **fresh SSH connection per call** and close it immediately after the command completes.
+
+#### `ssh_exec`
+
+Execute a shell command on any SSH server.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `host` | string | yes | SSH server hostname or IP address |
+| `port` | number | no | SSH port (default: `22`) |
+| `user` | string | yes | SSH login username |
+| `password` | string | one of | SSH password |
+| `private_key` | string | one of | PEM-encoded SSH private key — raw text or base64-encoded |
+| `command` | string | yes | Shell command to execute |
+
+#### `ssh_sudo_exec`
+
+Execute a shell command with `sudo` on any SSH server.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `host` | string | yes | SSH server hostname or IP address |
+| `port` | number | no | SSH port (default: `22`) |
+| `user` | string | yes | SSH login username |
+| `password` | string | one of | SSH password |
+| `private_key` | string | one of | PEM-encoded SSH private key — raw text or base64-encoded |
+| `command` | string | yes | Shell command to execute as root |
+| `sudo_password` | string | no | Password for `sudo`. Omit if passwordless sudo is configured. |
+
+> Either `password` or `private_key` must be provided for both tools.
+
+### MCP Client Configuration (HTTP)
+
+Point your MCP client at the running container's `/mcp` endpoint.
+
+**Generic JSON config:**
+```json
+{
+    "mcpServers": {
+        "ssh-mcp-http": {
+            "transport": "http",
+            "url": "http://localhost:8080/mcp"
+        }
+    }
+}
+```
+
+**HolmesGPT (`holmesgpt_config.yaml`):**
+```yaml
+toolsets:
+  - type: mcp
+    name: ssh-mcp-http
+    transport: http
+    url: http://ssh-mcp:8080/mcp
+```
+
+**Claude Code (HTTP transport):**
+```bash
+claude mcp add --transport http ssh-mcp-http http://localhost:8080/mcp
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `8080` | TCP port the HTTP server listens on |
+| `SSH_TIMEOUT_MS` | `60000` | SSH command execution timeout in milliseconds |
+
+---
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "ssh-mcp",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
+        "express": "^5.2.1",
         "ssh2": "^1.17.0",
         "zod": "3.23.8"
       },
@@ -17,6 +18,7 @@
         "ssh-mcp": "build/index.js"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^24.5.2",
         "@types/ssh2": "^1.15.5",
         "cross-env": "^7.0.3",
@@ -1099,6 +1101,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1107,6 +1120,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1146,6 +1169,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
@@ -1154,6 +1209,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ssh2": {
@@ -1681,22 +1771,27 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1797,6 +1892,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1809,6 +1905,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -2289,6 +2386,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2338,6 +2436,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2346,6 +2445,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2361,6 +2461,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2579,17 +2680,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -2795,6 +2898,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2831,6 +2935,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2901,6 +3006,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2919,6 +3025,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2938,29 +3045,39 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3218,6 +3335,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -3226,6 +3344,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3425,6 +3544,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3690,9 +3810,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -3732,17 +3853,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/readable-stream": {
@@ -4067,6 +4189,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -4085,6 +4208,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -4100,6 +4224,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4117,6 +4242,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -4208,9 +4334,10 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4638,6 +4765,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
+    "express": "^5.2.1",
     "ssh2": "^1.17.0",
     "zod": "3.23.8"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^24.5.2",
     "@types/ssh2": "^1.15.5",
     "cross-env": "^7.0.3",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+/**
+ * SSH MCP HTTP Server — dynamic multi-host SSH execution via Model Context Protocol.
+ *
+ * Unlike the stdio server (index.ts) which connects to a single static host at startup,
+ * this HTTP server accepts SSH connection parameters (host, user, password/key) on every
+ * tool call, enabling HolmesGPT (and other MCP clients) to reach different servers per
+ * investigation without restarting the container.
+ *
+ * Transport: Streamable HTTP (POST /mcp), stateless mode — one MCP session per request.
+ * Each tool call opens a fresh SSH connection, executes, and closes it.
+ *
+ * Start: node build/http-server.js   (PORT env var, default 8080)
+ */
+
+import express, { Request, Response } from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { Client, ClientChannel } from 'ssh2';
+import { z } from 'zod';
+
+const PORT = process.env.PORT ? parseInt(process.env.PORT) : 8080;
+const DEFAULT_TIMEOUT_MS = process.env.SSH_TIMEOUT_MS
+  ? parseInt(process.env.SSH_TIMEOUT_MS)
+  : 60_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SshConnectConfig {
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  privateKey?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Core SSH execution (per-call, fresh connection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Opens an SSH connection using the given config, runs `command`, returns stdout.
+ * Rejects if stderr is non-empty (matches upstream ssh-mcp behaviour).
+ * Always closes the connection when done.
+ */
+function runSshCommand(
+  config: SshConnectConfig,
+  command: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const conn = new Client();
+    let settled = false;
+
+    const done = (err?: Error, result?: string) => {
+      if (settled) return;
+      settled = true;
+      conn.end();
+      if (err) reject(err);
+      else resolve(result ?? '');
+    };
+
+    const timer = setTimeout(() => {
+      done(
+        new McpError(
+          ErrorCode.InternalError,
+          `SSH command timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+        ),
+      );
+    }, DEFAULT_TIMEOUT_MS);
+
+    conn.on('ready', () => {
+      conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
+        if (err) {
+          clearTimeout(timer);
+          done(new McpError(ErrorCode.InternalError, `SSH exec error: ${err.message}`));
+          return;
+        }
+
+        let stdout = '';
+        let stderr = '';
+
+        try { stream.end(); } catch (_) { /* ignore */ }
+
+        stream.on('data', (data: Buffer) => { stdout += data.toString(); });
+        stream.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+
+        stream.on('close', (code: number) => {
+          clearTimeout(timer);
+          if (stderr) {
+            done(
+              new McpError(
+                ErrorCode.InternalError,
+                `Command failed (exit ${code}):\n${stderr}`,
+              ),
+            );
+          } else {
+            done(undefined, stdout);
+          }
+        });
+      });
+    });
+
+    conn.on('error', (err: Error) => {
+      clearTimeout(timer);
+      done(new McpError(ErrorCode.InternalError, `SSH connection error: ${err.message}`));
+    });
+
+    conn.connect(config);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode a private key that may be either a raw PEM string or base64-encoded PEM.
+ */
+function decodePrivateKey(raw: string): string {
+  if (raw.startsWith('-----')) return raw;
+  try {
+    const decoded = Buffer.from(raw, 'base64').toString('utf8');
+    if (decoded.startsWith('-----')) return decoded;
+  } catch (_) { /* fall through */ }
+  return raw;
+}
+
+function buildConnectConfig(params: {
+  host: string;
+  port?: number;
+  user: string;
+  password?: string;
+  private_key?: string;
+}): SshConnectConfig {
+  if (!params.password && !params.private_key) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'Either password or private_key must be provided',
+    );
+  }
+
+  const cfg: SshConnectConfig = {
+    host: params.host,
+    port: params.port ?? 22,
+    username: params.user,
+  };
+
+  if (params.password) {
+    cfg.password = params.password;
+  } else if (params.private_key) {
+    cfg.privateKey = decodePrivateKey(params.private_key);
+  }
+
+  return cfg;
+}
+
+/** Wrap a command with sudo, optionally piping in a password. */
+function wrapSudo(command: string, sudoPassword?: string): string {
+  const escaped = command.replace(/'/g, "'\\''");
+  if (!sudoPassword) {
+    return `sudo -n sh -c '${escaped}'`;
+  }
+  const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
+  return `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${escaped}'`;
+}
+
+// ---------------------------------------------------------------------------
+// MCP Server factory
+// ---------------------------------------------------------------------------
+
+function makeMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'SSH MCP HTTP Server',
+    version: '1.5.0',
+    capabilities: { tools: {} },
+  });
+
+  // ------------------------------------------------------------------
+  // Tool: ssh_exec
+  // ------------------------------------------------------------------
+  server.tool(
+    'ssh_exec',
+    'Execute a shell command on any remote SSH server. ' +
+    'Dynamically connects to the specified host using password or SSH private key authentication. ' +
+    'A fresh connection is opened per call so each investigation can target a different machine. ' +
+    'Returns stdout; fails if stderr is non-empty.',
+    {
+      host: z.string().describe('SSH server hostname or IP address'),
+      port: z.number().int().min(1).max(65535).optional().default(22).describe('SSH port (default: 22)'),
+      user: z.string().describe('SSH login username'),
+      password: z.string().optional().describe(
+        'SSH password. Provide either password or private_key, not both.',
+      ),
+      private_key: z.string().optional().describe(
+        'PEM-encoded SSH private key (raw text or base64-encoded). ' +
+        'Provide either password or private_key, not both.',
+      ),
+      command: z.string().describe('Shell command to execute on the remote server'),
+    },
+    async ({ host, port, user, password, private_key, command }) => {
+      const cfg = buildConnectConfig({ host, port, user, password, private_key });
+      const output = await runSshCommand(cfg, command);
+      return { content: [{ type: 'text' as const, text: output }] };
+    },
+  );
+
+  // ------------------------------------------------------------------
+  // Tool: ssh_sudo_exec
+  // ------------------------------------------------------------------
+  server.tool(
+    'ssh_sudo_exec',
+    'Execute a shell command with sudo on any remote SSH server. ' +
+    'Dynamically connects using password or SSH private key authentication. ' +
+    'A fresh connection is opened per call. ' +
+    'If sudo_password is omitted, passwordless sudo is assumed (uses sudo -n).',
+    {
+      host: z.string().describe('SSH server hostname or IP address'),
+      port: z.number().int().min(1).max(65535).optional().default(22).describe('SSH port (default: 22)'),
+      user: z.string().describe('SSH login username'),
+      password: z.string().optional().describe(
+        'SSH password. Provide either password or private_key, not both.',
+      ),
+      private_key: z.string().optional().describe(
+        'PEM-encoded SSH private key (raw text or base64-encoded). ' +
+        'Provide either password or private_key, not both.',
+      ),
+      command: z.string().describe('Shell command to execute on the remote server'),
+      sudo_password: z.string().optional().describe(
+        'Password for sudo. Omit if passwordless sudo is configured on the target host.',
+      ),
+    },
+    async ({ host, port, user, password, private_key, command, sudo_password }) => {
+      const cfg = buildConnectConfig({ host, port, user, password, private_key });
+      const wrapped = wrapSudo(command, sudo_password);
+      const output = await runSshCommand(cfg, wrapped);
+      return { content: [{ type: 'text' as const, text: output }] };
+    },
+  );
+
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// Express app
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const app = express();
+  app.use(express.json());
+
+  // Health check — used by K8s readiness/liveness probes
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', service: 'ssh-mcp-http', version: '1.5.0' });
+  });
+
+  // MCP endpoint — stateless: each POST creates an independent MCP session
+  app.post('/mcp', async (req: Request, res: Response) => {
+    try {
+      const mcpServer = makeMcpServer();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined, // stateless mode
+      });
+      await mcpServer.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('MCP request error:', msg);
+      if (!res.headersSent) {
+        res.status(500).json({ error: msg });
+      }
+    }
+  });
+
+  app.listen(PORT, () => {
+    console.error(`SSH MCP HTTP Server listening on port ${PORT}`);
+  });
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `src/http-server.ts` — a Streamable HTTP MCP server that accepts SSH connection parameters (host, user, password/private_key) on every tool call, enabling dynamic multi-host SSH execution without restarting the container
- Adds `Dockerfile` — multi-stage Node 20 alpine build for containerised deployment
- Bumps version to `1.5.0` and adds `express` as a dependency

### Key differences from the stdio server (`index.ts`)

- **Transport:** HTTP POST `/mcp` (StreamableHTTPServerTransport, stateless mode)
- **Connection model:** fresh SSH connection per call — no persistent session
- **Auth:** password and SSH private key (raw PEM or base64-encoded) per call
- **Tools:** `ssh_exec`, `ssh_sudo_exec` with full connection params per invocation
- **Health endpoint:** `GET /health` for Kubernetes liveness/readiness probes
- **Port:** 8080 (configurable via `PORT` env var)

### Use case

Designed for tools like [HolmesGPT](https://github.com/robusta-dev/holmesgpt) that need to connect to different servers per investigation without restarting the container.

#### Test plan

- [ ] `npm run build` compiles without errors
- [ ] Docker image builds: `docker build -t ssh-mcp .`
- [ ] Health endpoint responds: `curl http://localhost:8080/health`
- [ ] `ssh_exec` tool executes commands over SSH via HTTP transport

Generated with [Devin](https://cli.devin.ai/docs)