### PR TITLE
Add default working directory support via --workdir parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `suPassword`: Password for su elevation (when you need a persistent root shell)
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
+- `workdir`: Default working directory for all command executions (all commands will be prefixed with `cd <workdir> &&`)
 - `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
 
 
@@ -111,7 +112,8 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
                 "--password=pass",
                 "--key=path/to/key",
                 "--timeout=30000",
-                "--maxChars=none"
+                "--maxChars=none",
+                "--workdir=/var/www"
             ]
         }
     }
@@ -140,15 +142,21 @@ claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.1
 claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=example.com --user=root --key=/path/to/private/key
 ```
 
-**With Custom Timeout and No Character Limit:**
+**With Custom Timeout, No Character Limit, and Default Working Directory:**
 ```bash
-claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --user=admin --password=your_password --timeout=120000 --maxChars=none
+claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --user=admin --password=your_password --timeout=120000 --maxChars=none --workdir=/var/www
 ```
 
 **With Sudo and Su Support:**
 ```bash
 claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --user=admin --password=your_password --sudoPassword=sudo_pass --suPassword=root_pass
 ```
+
+**With Default Working Directory:**
+```bash
+claude mcp add --transport stdio ssh-mcp -- npx -y ssh-mcp -- --host=192.168.1.100 --user=admin --key=/path/to/key --workdir=/var/www/myapp
+```
+All commands executed will automatically run from `/var/www/myapp` (e.g., `cd /var/www/myapp && command`).
 
 **Installation Scopes:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
+// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --workdir=/var/www --disableSudo
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
@@ -37,6 +37,7 @@ const SUDOPASSWORD = argvConfig.sudoPassword;
 const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
 const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
+const WORKDIR = argvConfig.workdir; // Optional default working directory
 // Max characters configuration:
 // - Default: 1000 characters
 // - When set via --maxChars:
@@ -105,6 +106,12 @@ export function escapeCommandForShell(command: string): string {
   return command.replace(/'/g, "'\"'\"'");
 }
 
+// Prepend working directory change if configured
+export function prependWorkdir(command: string, workdir?: string): string {
+  if (!workdir) return command;
+  return `cd '${workdir.replace(/'/g, "'\\''")}' && ${command}`;
+}
+
 // SSH Connection Manager to maintain persistent connection
 export interface SSHConfig {
   host: string;
@@ -114,6 +121,7 @@ export interface SSHConfig {
   privateKey?: string;
   suPassword?: string;
   sudoPassword?: string;  // Password for sudo commands specifically (if different from suPassword)
+  workdir?: string;  // Default working directory for command execution
 }
 
 export class SSHConnectionManager {
@@ -380,6 +388,11 @@ server.tool(
         if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
           sshConfig.suPassword = sanitizePassword(SUPASSWORD);
         }
+
+        if (WORKDIR) {
+          sshConfig.workdir = WORKDIR;
+        }
+
         connectionManager = new SSHConnectionManager(sshConfig);
       }
 
@@ -407,7 +420,10 @@ server.tool(
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
 
-      const result = await execSshCommandWithConnection(connectionManager, commandWithDescription);
+      // Prepend working directory if configured
+      const commandWithWorkdir = prependWorkdir(commandWithDescription, (connectionManager as any).sshConfig?.workdir);
+
+      const result = await execSshCommandWithConnection(connectionManager, commandWithWorkdir);
       return result;
     } catch (err: any) {
       // Wrap unexpected errors
@@ -452,6 +468,9 @@ if (!DISABLE_SUDO) {
           if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
             sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
           }
+          if (WORKDIR) {
+            sshConfig.workdir = WORKDIR;
+          }
           connectionManager = new SSHConnectionManager(sshConfig);
         }
 
@@ -477,14 +496,17 @@ if (!DISABLE_SUDO) {
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
 
+        // Prepend working directory if configured
+        const commandWithWorkdir = prependWorkdir(commandWithDescription, (connectionManager as any).sshConfig?.workdir);
+
         if (!sudoPassword) {
           // No password provided, use -n to fail if sudo requires a password
-          wrapped = `sudo -n sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
+          wrapped = `sudo -n sh -c '${commandWithWorkdir.replace(/'/g, "'\\''")}'`;
         } else {
           // Password provided — pipe it into sudo using printf. This avoids complex
           // PTY/stdin handling on the SSH channel and is simpler and more reliable.
           const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
-          wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
+          wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${commandWithWorkdir.replace(/'/g, "'\\''")}'`;
         }
 
         return await execSshCommandWithConnection(connectionManager, wrapped);


### PR DESCRIPTION
- Add --workdir CLI parameter to set default working directory
- Automatically prepend 'cd <workdir> &&' to all executed commands
- Works with both exec and sudo-exec tools
- Handles command quoting and special characters in paths
- Update README with documentation and examples