### PR TITLE
Fix exec elevation separation and client-side descriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sshd:
-        image: lscr.io/linuxserver/openssh-server:latest
+        image: ghcr.io/linuxserver/openssh-server:latest
         env:
           USER_NAME: test
           PASSWORD_ACCESS: "true"

--- a/README.md
+++ b/README.md
@@ -41,21 +41,27 @@
 
 ### Tools
 
-- `exec`: Execute a shell command on the remote server
+- `exec`: Execute a shell command on the remote server without elevation. This tool is always available and always uses a normal SSH exec channel, even when elevated passwords are configured.
   - **Parameters:**
     - `command` (required): Shell command to execute on the remote SSH server
-    - `description` (optional): Optional description of what this command will do (appended as a comment)
+    - `description` (optional): Optional client-side description of what this command will do. This is not sent to the remote shell.
   - **Timeout Configuration:**
+
+- `su-exec`: Execute a shell command through a persistent `su` shell
+  - **Parameters:**
+    - `command` (required): Shell command to execute as root using `su`
+    - `description` (optional): Optional client-side description of what this command will do. This is not sent to the remote shell.
+  - **Notes:**
+    - Only available when `--suPassword` is configured
 
 - `sudo-exec`: Execute a shell command with sudo elevation
   - **Parameters:**
     - `command` (required): Shell command to execute as root using sudo
-    - `description` (optional): Optional description of what this command will do (appended as a comment)
+    - `description` (optional): Optional client-side description of what this command will do. This is not sent to the remote shell.
   - **Notes:**
-    - Requires `--sudoPassword` to be set for password-protected sudo
+    - Only available when `--sudoPassword` is configured
     - Can be disabled by passing the `--disableSudo` flag at startup if sudo access is not needed or not available
-    - For persistent root access, consider using `--suPassword` instead which establishes a root shell
-    - Tool will not be available at all if server is started with `--disableSudo`
+    - For persistent root access, use `su-exec` with `--suPassword`
   - **Timeout Configuration:**
     - Timeout is configured via command line argument `--timeout` (in milliseconds)
     - Default timeout: 60000ms (1 minute)
@@ -89,8 +95,8 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `port`: SSH port (default: 22)
 - `password`: SSH password (or use `key` for key-based auth)
 - `key`: Path to private SSH key
-- `sudoPassword`: Password for sudo elevation (when executing commands with sudo)
-- `suPassword`: Password for su elevation (when you need a persistent root shell)
+- `sudoPassword`: Password for sudo elevation; enables the `sudo-exec` tool
+- `suPassword`: Password for su elevation; enables the `su-exec` tool
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
 - `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
@@ -201,4 +207,4 @@ This project follows a [Code of Conduct](./CODE_OF_CONDUCT.md) to ensure a welco
 
 ## Support
 
-If you find SSH MCP Server helpful, consider starring the repository or contributing! Pull requests and feedback are welcome. 
+If you find SSH MCP Server helpful, consider starring the repository or contributing! Pull requests and feedback are welcome.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ssh:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest
     environment:
       - USER_NAME=test
       - PASSWORD_ACCESS=true

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,15 @@ function sanitizePassword(password: string | undefined): string | undefined {
   return password;
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function shellBase64Decode(value: string): string {
+  const encoded = Buffer.from(value, 'utf8').toString('base64');
+  return `printf '%s' ${shellQuote(encoded)} | base64 -d`;
+}
+
 // Escape command for use in shell contexts (like pkill)
 export function escapeCommandForShell(command: string): string {
   // Replace single quotes with escaped single quotes
@@ -153,20 +162,6 @@ export class SSHConnectionManager {
       this.conn.on('ready', async () => {
         clearTimeout(timeoutId);
         this.isConnecting = false;
-
-        // In test mode, don't wait for su elevation during connection setup, as it
-        // may cause JSON-RPC server initialization to hang. Instead, elevation will
-        // be triggered on-demand when a command is executed.
-        // In production, elevation during connection is desirable for robustness.
-        if (this.sshConfig.suPassword && !process.env.SSH_MCP_TEST) {
-          try {
-            await this.ensureElevated();
-          } catch (err) {
-            // Do not reject the connection; just log the error. Subsequent commands
-            // will either use the su shell if available or fall back to normal execution.
-          }
-        }
-
         resolve();
       });
 
@@ -228,7 +223,7 @@ export class SSHConnectionManager {
     }
   }
 
-  private async ensureElevated(): Promise<void> {
+  async ensureElevated(): Promise<void> {
     if (this.isElevated && this.suShell) return;
     if (!this.sshConfig.suPassword) return;
 
@@ -253,6 +248,7 @@ export class SSHConnectionManager {
 
         let buffer = '';
         let passwordSent = false;
+        const readyMarker = `__SSH_MCP_SU_READY_${Date.now()}_${Math.random().toString(36).slice(2)}__`;
         const cleanup = () => {
           try { stream.removeAllListeners('data'); } catch (e) { /* ignore */ }
         };
@@ -264,22 +260,17 @@ export class SSHConnectionManager {
           // If we haven't sent the password yet, look for the password prompt
           if (!passwordSent && /password[: ]/i.test(buffer)) {
             passwordSent = true;
-            stream.write(this.sshConfig.suPassword + '\n');
-            // Don't return; keep looking for root prompt
+            stream.write(`${this.sshConfig.suPassword}\nstty -echo\n${shellBase64Decode(readyMarker)}; printf '\\n'\n`);
           }
 
-          // After password is sent, look for any root indicator
-          // Look for '#' which indicates root prompt (may be followed by spaces, escape codes, etc)
-          if (passwordSent) {
-            if (/#/.test(buffer)) {
-              clearTimeout(timeoutId);
-              cleanup();
-              this.suShell = stream;
-              this.isElevated = true;
-              this.suPromise = null;
-              resolve();
-              return;
-            }
+          if (passwordSent && buffer.replace(/\r/g, '').includes(readyMarker)) {
+            clearTimeout(timeoutId);
+            cleanup();
+            this.suShell = stream;
+            this.isElevated = true;
+            this.suPromise = null;
+            resolve();
+            return;
           }
 
           // Detect authentication failure messages
@@ -323,6 +314,13 @@ export class SSHConnectionManager {
     return this.conn;
   }
 
+  getSuShell(): ClientChannel {
+    if (!this.suShell || !this.isElevated) {
+      throw new McpError(ErrorCode.InternalError, 'su shell not established');
+    }
+    return this.suShell;
+  }
+
   close(): void {
     if (this.conn) {
       if (this.suShell) {
@@ -338,6 +336,44 @@ export class SSHConnectionManager {
 
 let connectionManager: SSHConnectionManager | null = null;
 
+async function createSshConfig(): Promise<SSHConfig> {
+  if (!HOST || !USER) {
+    throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+  }
+
+  const sshConfig: SSHConfig = {
+    host: HOST,
+    port: PORT,
+    username: USER,
+  };
+
+  if (PASSWORD) {
+    sshConfig.password = PASSWORD;
+  } else if (KEY) {
+    const fs = await import('fs/promises');
+    sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
+  }
+
+  const suPassword = sanitizePassword(SUPASSWORD ?? undefined);
+  if (suPassword) {
+    sshConfig.suPassword = suPassword;
+  }
+
+  const sudoPassword = sanitizePassword(SUDOPASSWORD ?? undefined);
+  if (sudoPassword) {
+    sshConfig.sudoPassword = sudoPassword;
+  }
+
+  return sshConfig;
+}
+
+async function getConnectionManager(): Promise<SSHConnectionManager> {
+  if (!connectionManager) {
+    connectionManager = new SSHConnectionManager(await createSshConfig());
+  }
+  return connectionManager;
+}
+
 const server = new McpServer({
   name: 'SSH MCP Server',
   version: '1.5.0',
@@ -352,141 +388,65 @@ server.tool(
   "Execute a shell command on the remote SSH server and return the output.",
   {
     command: z.string().describe("Shell command to execute on the remote SSH server"),
-    description: z.string().optional().describe("Optional description of what this command will do"),
+    description: z.string().optional().describe("Optional client-side description; not sent to the remote shell"),
   },
-  async ({ command, description }) => {
-    // Sanitize command input
+  async ({ command }) => {
     const sanitizedCommand = sanitizeCommand(command);
 
     try {
-      // Initialize connection manager if not already done
-      if (!connectionManager) {
-        if (!HOST || !USER) {
-          throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-        }
-        const sshConfig: SSHConfig = {
-          host: HOST,
-          port: PORT,
-          username: USER,
-        };
-
-        if (PASSWORD) {
-          sshConfig.password = PASSWORD;
-        } else if (KEY) {
-          const fs = await import('fs/promises');
-          sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-        }
-
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-        }
-        connectionManager = new SSHConnectionManager(sshConfig);
-      }
-
-      // Ensure connection is active (reconnect if needed)
+      const connectionManager = await getConnectionManager();
       await connectionManager.ensureConnected();
-
-      // If a suPassword was provided, explicitly wait for elevation before executing.
-      // This is critical: ensureElevated is idempotent and will return immediately if
-      // already elevated, so this ensures we have a su shell before we try to use it.
-      if ((connectionManager as any).getSuPassword && (connectionManager as any).getSuPassword()) {
-        try {
-          const elevationPromise = (connectionManager as any).ensureElevated();
-          // Add a short timeout for elevation to complete
-          await Promise.race([
-            elevationPromise,
-            new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000))
-          ]);
-        } catch (err) {
-          // Log but don't fail; fall back to non-elevated execution if elevation times out
-        }
-      }
-
-      // Append description as comment if provided
-      const commandWithDescription = description
-        ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
-        : sanitizedCommand;
-
-      const result = await execSshCommandWithConnection(connectionManager, commandWithDescription);
-      return result;
+      return await execSshCommandWithConnection(connectionManager, sanitizedCommand);
     } catch (err: any) {
-      // Wrap unexpected errors
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
     }
   }
 );
 
-// Expose sudo-exec tool unless explicitly disabled
-if (!DISABLE_SUDO) {
+if (sanitizePassword(SUPASSWORD ?? undefined)) {
   server.tool(
-    "sudo-exec",
-    "Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.",
+    "su-exec",
+    "Execute a shell command on the remote SSH server through an elevated su shell.",
     {
-      command: z.string().describe("Shell command to execute with sudo on the remote SSH server"),
-      description: z.string().optional().describe("Optional description of what this command will do"),
+      command: z.string().describe("Shell command to execute with su on the remote SSH server"),
+      description: z.string().optional().describe("Optional client-side description; not sent to the remote shell"),
     },
-    async ({ command, description }) => {
+    async ({ command }) => {
       const sanitizedCommand = sanitizeCommand(command);
 
       try {
-        if (!connectionManager) {
-          if (!HOST || !USER) {
-            throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-          }
-
-          const sshConfig: SSHConfig = {
-            host: HOST,
-            port: PORT || 22,
-            username: USER,
-          };
-          if (PASSWORD) {
-            sshConfig.password = PASSWORD;
-          } else if (KEY) {
-            const fs = await import('fs/promises');
-            sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-          }
-          if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-            sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-          }
-          if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-            sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
-          }
-          connectionManager = new SSHConnectionManager(sshConfig);
-        }
-
+        const connectionManager = await getConnectionManager();
         await connectionManager.ensureConnected();
+        return await execSshCommandWithSuConnection(connectionManager, sanitizedCommand);
+      } catch (err: any) {
+        if (err instanceof McpError) throw err;
+        throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
+      }
+    }
+  );
+}
 
-        // If suPassword or sudoPassword were provided on this call but the
-        // existing connection manager was created earlier without them,
-        // update the manager's values so the subsequent sudo-exec call uses
-        // the latest passwords.
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          await connectionManager.setSuPassword(sanitizePassword(SUPASSWORD));
-        }
-        if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-          // update sudoPassword on the manager instance
-          (connectionManager as any).sshConfig = { ...(connectionManager as any).sshConfig, sudoPassword: sanitizePassword(SUDOPASSWORD) };
-        }
+if (!DISABLE_SUDO && sanitizePassword(SUDOPASSWORD ?? undefined)) {
+  server.tool(
+    "sudo-exec",
+    "Execute a shell command on the remote SSH server using sudo and the configured sudo password.",
+    {
+      command: z.string().describe("Shell command to execute with sudo on the remote SSH server"),
+      description: z.string().optional().describe("Optional client-side description; not sent to the remote shell"),
+    },
+    async ({ command }) => {
+      const sanitizedCommand = sanitizeCommand(command);
 
-        let wrapped: string;
+      try {
+        const connectionManager = await getConnectionManager();
+        await connectionManager.ensureConnected();
         const sudoPassword = connectionManager.getSudoPassword();
-
-        // Append description as comment if provided
-        const commandWithDescription = description
-          ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
-          : sanitizedCommand;
-
         if (!sudoPassword) {
-          // No password provided, use -n to fail if sudo requires a password
-          wrapped = `sudo -n sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
-        } else {
-          // Password provided — pipe it into sudo using printf. This avoids complex
-          // PTY/stdin handling on the SSH channel and is simpler and more reliable.
-          const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
-          wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
+          throw new McpError(ErrorCode.InvalidParams, 'sudo-exec requires --sudoPassword');
         }
 
+        const wrapped = `printf '%s\\n' ${shellQuote(sudoPassword)} | sudo -p "" -S sh -c ${shellQuote(sanitizedCommand)}`;
         return await execSshCommandWithConnection(connectionManager, wrapped);
       } catch (err: any) {
         if (err instanceof McpError) throw err;
@@ -503,7 +463,6 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
     let isResolved = false;
 
     const conn = manager.getConnection();
-    const shell = (manager as any).suShell;  // Use su shell if available
 
     // Set up timeout
     timeoutId = setTimeout(() => {
@@ -513,44 +472,8 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
       }
     }, DEFAULT_TIMEOUT);
 
-    // If we have an active su shell, use it directly (commands run as root in session)
-    if (shell) {
-      let buffer = '';
-
-      const dataHandler = (data: Buffer) => {
-        const text = data.toString();
-        buffer += text;
-
-        // Wait for root prompt (#) to know command is complete
-        // Match # which indicates root prompt (may be followed by spaces, escape codes, etc)
-        if (/#/.test(buffer)) {
-          if (!isResolved) {
-            isResolved = true;
-            clearTimeout(timeoutId);
-
-            // Extract output: remove the command echo and final prompt
-            const lines = buffer.split('\n');
-            // First line is often the echoed command; last line is the prompt
-            let output = lines.slice(1, -1).join('\n');
-
-            resolve({
-              content: [{
-                type: 'text',
-                text: output + (output ? '\n' : ''),
-              }],
-            });
-          }
-          shell.removeListener('data', dataHandler);
-        }
-      };
-
-      shell.on('data', dataHandler);
-      // Send command immediately; shell is ready after elevation
-      shell.write(command + '\n');
-      return;
-    }
-
-    // No persistent su shell; use normal exec with optional password piping
+    // Always use a normal SSH exec channel here. Elevated execution is exposed
+    // through explicit su-exec and sudo-exec tools.
     conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
       if (err) {
         if (!isResolved) {
@@ -599,6 +522,57 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
         }
       });
     });
+  });
+}
+
+export async function execSshCommandWithSuConnection(manager: SSHConnectionManager, command: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+  await manager.ensureElevated();
+
+  return new Promise((resolve, reject) => {
+    const shell = manager.getSuShell();
+    const marker = `SSH_MCP_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const startMarker = `__${marker}_START__`;
+    const endMarker = `__${marker}_END__`;
+    let buffer = '';
+    let isResolved = false;
+
+    const dataHandler = (data: Buffer) => {
+      buffer += data.toString();
+      const normalized = buffer.replace(/\r/g, '');
+      const lines = normalized.split('\n');
+      const startLineIndex = lines.findIndex(line => line.endsWith(startMarker));
+      if (startLineIndex === -1) return;
+
+      const endLineIndex = lines.findIndex((line, index) => index > startLineIndex && line.includes(`${endMarker}:`));
+      if (endLineIndex === -1) return;
+
+      let output = lines.slice(startLineIndex + 1, endLineIndex).join('\n');
+      finish(output ? `${output}\n` : '');
+    };
+
+    const timeoutId = setTimeout(() => {
+      if (!isResolved) {
+        isResolved = true;
+        shell.removeListener('data', dataHandler);
+        reject(new McpError(ErrorCode.InternalError, `Command execution timed out after ${DEFAULT_TIMEOUT}ms`));
+      }
+    }, DEFAULT_TIMEOUT);
+
+    const finish = (output: string) => {
+      if (isResolved) return;
+      isResolved = true;
+      clearTimeout(timeoutId);
+      shell.removeListener('data', dataHandler);
+      resolve({
+        content: [{
+          type: 'text',
+          text: output,
+        }],
+      });
+    };
+
+    shell.on('data', dataHandler);
+    shell.write(`${shellBase64Decode(startMarker)}; printf '\\n'; sh -c ${shellQuote(command)}; status=$?; printf '\\n'; ${shellBase64Decode(endMarker)}; printf ':%s\\n' "$status"\n`);
   });
 }
 

--- a/test/description.test.ts
+++ b/test/description.test.ts
@@ -75,22 +75,48 @@ describe('command description functionality', () => {
     expect(res.result?.content?.[0]?.text).toContain('test without description');
   });
 
-  it('should execute commands with simple description', async () => {
-    const res = await runMcpCommand('echo "test with description"', 'This is a test command');
+  it('should accept a description without sending it to the remote shell', async () => {
+    const res = await runMcpCommand('printf "command-only\\n"', 'SHOULD_NOT_APPEAR # description marker');
     expect(res.error).toBeUndefined();
-    expect(res.result?.content?.[0]?.text).toContain('test with description');
+    const output = res.result?.content?.[0]?.text || '';
+    expect(output).toContain('command-only');
+    expect(output).not.toContain('SHOULD_NOT_APPEAR');
+    expect(output).not.toContain('description marker');
   });
 
   it('should handle descriptions with special characters', async () => {
-    const res = await runMcpCommand('ls -la', 'List all files # detailed format');
+    const res = await runMcpCommand('printf "special-description-ok\\n"', 'List all files # detailed format');
     expect(res.error).toBeUndefined();
-    // The command should execute successfully even with special characters in description
+    const output = res.result?.content?.[0]?.text || '';
+    expect(output).toContain('special-description-ok');
+    expect(output).not.toContain('List all files');
   });
 
-  it('should work with sudo-exec tool and description', async () => {
-    const res = await runMcpCommand('whoami', 'Check current user identity', ['--sudoPassword=secret'], 'sudo-exec');
+  it('should not send descriptions through sudo-exec', async () => {
+    const res = await runMcpCommand('printf "sudo-command-only\\n"', 'SHOULD_NOT_APPEAR_SUDO', ['--sudoPassword=secret'], 'sudo-exec');
     expect(res.error).toBeUndefined();
-    // Should execute successfully with sudo
+    const output = res.result?.content?.[0]?.text || '';
+    expect(output).toContain('sudo-command-only');
+    expect(output).not.toContain('SHOULD_NOT_APPEAR_SUDO');
+  });
+
+  it('should not send descriptions through su-exec', async () => {
+    const res = await runMcpCommand('printf "su-command-only\\n"', 'SHOULD_NOT_APPEAR_SU', ['--suPassword=secret'], 'su-exec');
+    expect(res.error).toBeUndefined();
+    const output = res.result?.content?.[0]?.text || '';
+    expect(output).toContain('su-command-only');
+    expect(output).not.toContain('SHOULD_NOT_APPEAR_SU');
+  });
+
+  it('should allow su-exec commands that contain shell comments', async () => {
+    const command = 'printf "before\\n"\n# shell comment inside the command\nprintf "after\\n"';
+    const res = await runMcpCommand(command, 'client-side description with # marker', ['--suPassword=secret'], 'su-exec');
+    expect(res.error).toBeUndefined();
+    const output = res.result?.content?.[0]?.text || '';
+    expect(output).toContain('before');
+    expect(output).toContain('after');
+    expect(output).not.toContain('shell comment inside');
+    expect(output).not.toContain('client-side description');
   });
 
   it('should handle empty description parameter', async () => {

--- a/test/maxChars.test.ts
+++ b/test/maxChars.test.ts
@@ -4,219 +4,107 @@ import { join } from 'path';
 
 describe('maxChars CLI configuration', () => {
   const testServerPath = join(process.cwd(), 'build', 'index.js');
-  
-  describe('default behavior (1000 chars)', () => {
-    it('should reject commands over 1000 characters by default', () => {
-      const longCommand = 'echo ' + 'x'.repeat(1000);
-      const args = [
-        '--host=127.0.0.1',
-        '--user=test',
-        '--password=secret',
-        '--timeout=5000'
-      ];
-      
-      const child = spawn('node', [testServerPath, ...args], {
-        stdio: ['pipe', 'pipe', 'pipe']
-      });
-      
-      // Send a tool call with a long command
-      const toolCall = {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: {
-          name: 'exec',
-          arguments: {
-            command: longCommand
+
+  function responseText(response: any): string {
+    return (
+      response.error?.message ||
+      response.result?.content?.[0]?.text ||
+      JSON.stringify(response)
+    );
+  }
+
+  function runExec(command: string, extraArgs: string[] = []): Promise<any> {
+    const args = [
+      testServerPath,
+      '--host=127.0.0.1',
+      '--port=2222',
+      '--user=test',
+      '--password=secret',
+      '--timeout=5000',
+      ...extraArgs,
+    ];
+
+    return new Promise((resolve, reject) => {
+      const child = spawn('node', args, { stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env, SSH_MCP_TEST: '1' } });
+      let buffer = '';
+      const startup = setTimeout(() => {
+        child.kill();
+        reject(new Error('Server start timeout'));
+      }, 10000);
+
+      const initMsg = { jsonrpc: '2.0', id: 0, method: 'initialize', params: { capabilities: {}, clientInfo: { name: 't', version: '1' }, protocolVersion: '0.1.0' } };
+      const toolCall = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'exec', arguments: { command } } };
+
+      child.stdout.on('data', (data) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id === 0) {
+              child.stdin.write(JSON.stringify(toolCall) + '\n');
+            } else if (msg.id === 1) {
+              clearTimeout(startup);
+              resolve(msg);
+              child.kill();
+              return;
+            }
+          } catch (e) {
+            // ignore non-json
           }
         }
-      };
-      
-      child.stdin.write(JSON.stringify(toolCall) + '\n');
-      
-      let output = '';
-      child.stdout.on('data', (data) => {
-        output += data.toString();
       });
-      
-      child.on('close', () => {
-        const response = JSON.parse(output);
-        expect(response.error.message).toContain('Command is too long (max 1000 characters)');
-      });
-      
-      child.stdin.end();
+
+      child.stderr.on('data', () => { /* ignore */ });
+      child.on('error', (err) => { clearTimeout(startup); reject(err); });
+
+      setTimeout(() => {
+        child.stdin.write(JSON.stringify(initMsg) + '\n');
+      }, 100);
+    });
+  }
+
+  describe('default behavior (1000 chars)', () => {
+    it('should reject commands over 1000 characters by default', async () => {
+      const longCommand = 'echo ' + 'x'.repeat(1000);
+      const response = await runExec(longCommand);
+
+      expect(responseText(response)).toContain('Command is too long (max 1000 characters)');
     });
   });
 
   describe('custom maxChars limit', () => {
-    it('should respect custom positive limit', () => {
+    it('should respect custom positive limit', async () => {
       const longCommand = 'echo ' + 'x'.repeat(50);
-      const args = [
-        '--host=127.0.0.1',
-        '--user=test',
-        '--password=secret',
-        '--timeout=5000',
-        '--maxChars=50'
-      ];
-      
-      const child = spawn('node', [testServerPath, ...args], {
-        stdio: ['pipe', 'pipe', 'pipe']
-      });
-      
-      const toolCall = {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: {
-          name: 'exec',
-          arguments: {
-            command: longCommand
-          }
-        }
-      };
-      
-      child.stdin.write(JSON.stringify(toolCall) + '\n');
-      
-      let output = '';
-      child.stdout.on('data', (data) => {
-        output += data.toString();
-      });
-      
-      child.on('close', () => {
-        const response = JSON.parse(output);
-        expect(response.error.message).toContain('Command is too long (max 50 characters)');
-      });
-      
-      child.stdin.end();
+      const response = await runExec(longCommand, ['--maxChars=50']);
+
+      expect(responseText(response)).toContain('Command is too long (max 50 characters)');
     });
   });
 
   describe('no-limit mode', () => {
-    it('should allow unlimited characters with maxChars=none', () => {
+    it('should allow unlimited characters with maxChars=none', async () => {
       const veryLongCommand = 'echo ' + 'x'.repeat(10000);
-      const args = [
-        '--host=127.0.0.1',
-        '--user=test',
-        '--password=secret',
-        '--timeout=5000',
-        '--maxChars=none'
-      ];
-      
-      const child = spawn('node', [testServerPath, ...args], {
-        stdio: ['pipe', 'pipe', 'pipe']
-      });
-      
-      const toolCall = {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: {
-          name: 'exec',
-          arguments: {
-            command: veryLongCommand
-          }
-        }
-      };
-      
-      child.stdin.write(JSON.stringify(toolCall) + '\n');
-      
-      let output = '';
-      child.stdout.on('data', (data) => {
-        output += data.toString();
-      });
-      
-      child.on('close', () => {
-        const response = JSON.parse(output);
-        // Should not have a length error - might have SSH connection error instead
-        expect(response.error.message).not.toContain('Command is too long');
-      });
-      
-      child.stdin.end();
+      const response = await runExec(veryLongCommand, ['--maxChars=none']);
+
+      expect(responseText(response)).not.toContain('Command is too long');
     });
 
-    it('should allow unlimited characters with maxChars=0', () => {
+    it('should allow unlimited characters with maxChars=0', async () => {
       const veryLongCommand = 'echo ' + 'x'.repeat(10000);
-      const args = [
-        '--host=127.0.0.1',
-        '--user=test',
-        '--password=secret',
-        '--timeout=5000',
-        '--maxChars=0'
-      ];
-      
-      const child = spawn('node', [testServerPath, ...args], {
-        stdio: ['pipe', 'pipe', 'pipe']
-      });
-      
-      const toolCall = {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: {
-          name: 'exec',
-          arguments: {
-            command: veryLongCommand
-          }
-        }
-      };
-      
-      child.stdin.write(JSON.stringify(toolCall) + '\n');
-      
-      let output = '';
-      child.stdout.on('data', (data) => {
-        output += data.toString();
-      });
-      
-      child.on('close', () => {
-        const response = JSON.parse(output);
-        // Should not have a length error - might have SSH connection error instead
-        expect(response.error.message).not.toContain('Command is too long');
-      });
-      
-      child.stdin.end();
+      const response = await runExec(veryLongCommand, ['--maxChars=0']);
+
+      expect(responseText(response)).not.toContain('Command is too long');
     });
   });
 
   describe('invalid maxChars values', () => {
-    it('should fall back to default for invalid string values', () => {
+    it('should fall back to default for invalid string values', async () => {
       const longCommand = 'echo ' + 'x'.repeat(1000);
-      const args = [
-        '--host=127.0.0.1',
-        '--user=test',
-        '--password=secret',
-        '--timeout=5000',
-        '--maxChars=invalid'
-      ];
-      
-      const child = spawn('node', [testServerPath, ...args], {
-        stdio: ['pipe', 'pipe', 'pipe']
-      });
-      
-      const toolCall = {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: {
-          name: 'exec',
-          arguments: {
-            command: longCommand
-          }
-        }
-      };
-      
-      child.stdin.write(JSON.stringify(toolCall) + '\n');
-      
-      let output = '';
-      child.stdout.on('data', (data) => {
-        output += data.toString();
-      });
-      
-      child.on('close', () => {
-        const response = JSON.parse(output);
-        expect(response.error.message).toContain('Command is too long (max 1000 characters)');
-      });
-      
-      child.stdin.end();
+      const response = await runExec(longCommand, ['--maxChars=invalid']);
+
+      expect(responseText(response)).toContain('Command is too long (max 1000 characters)');
     });
   });
 });

--- a/test/sudo-exec.test.ts
+++ b/test/sudo-exec.test.ts
@@ -2,19 +2,27 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { spawn } from 'child_process';
 import { join } from 'path';
 
-// Very small, focused tests for the sudo-exec MCP tool. This file is intentionally
+// Very small, focused tests for the elevated MCP tools. This file is intentionally
 // small and straightforward (no heavy debug plumbing) — the integration surface
 // is: start the MCP server in test mode, send an initialize request, then call
-// the sudo-exec tool and assert the returned JSON-RPC response.
+// a tool and assert the returned JSON-RPC response.
 
 const testServerPath = join(process.cwd(), 'build', 'index.js');
-const START_TIMEOUT = 10000;  // 10 seconds for server startup with su elevation
+const START_TIMEOUT = 10000;
 
 beforeAll(() => {
   process.env.SSH_MCP_TEST = '1';
 });
 
-function runMcpCommand(command: string, extraArgs: string[] = [], toolName = 'sudo-exec'): Promise<any> {
+function responseText(res: any): string {
+  return (
+    res.error?.message ||
+    res.result?.content?.[0]?.text ||
+    JSON.stringify(res)
+  ).toLowerCase();
+}
+
+function runMcpCommand(command: string, extraArgs: string[] = [], toolName = 'sudo-exec', description?: string): Promise<any> {
   const args = [
     testServerPath,
     '--host=127.0.0.1',
@@ -34,7 +42,12 @@ function runMcpCommand(command: string, extraArgs: string[] = [], toolName = 'su
     }, START_TIMEOUT);
 
     const initMsg = { jsonrpc: '2.0', id: 0, method: 'initialize', params: { capabilities: {}, clientInfo: { name: 't', version: '1' }, protocolVersion: '0.1.0' } };
-    const toolCall = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: toolName, arguments: { command } } };
+    const toolCall = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: toolName, arguments: { command, ...(description ? { description } : {}) } },
+    };
 
     child.stdout.on('data', (d) => {
       buffer += d.toString();
@@ -67,10 +80,61 @@ function runMcpCommand(command: string, extraArgs: string[] = [], toolName = 'su
   });
 }
 
-// Helper that runs a command using the server's `--suPassword` option.
-// It establishes an elevated su session at connection time so all commands run as root.
+function listMcpTools(extraArgs: string[] = []): Promise<string[]> {
+  const args = [
+    testServerPath,
+    '--host=127.0.0.1',
+    '--port=2222',
+    '--user=test',
+    '--password=secret',
+    '--timeout=60000',
+    ...extraArgs,
+  ];
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', args, { stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env, SSH_MCP_TEST: '1' } });
+    let buffer = '';
+    const startup = setTimeout(() => {
+      child.kill();
+      reject(new Error('Server start timeout'));
+    }, START_TIMEOUT);
+
+    const initMsg = { jsonrpc: '2.0', id: 0, method: 'initialize', params: { capabilities: {}, clientInfo: { name: 't', version: '1' }, protocolVersion: '0.1.0' } };
+    const listTools = { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} };
+
+    child.stdout.on('data', (d) => {
+      buffer += d.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === 0) {
+            child.stdin.write(JSON.stringify(listTools) + '\n');
+          } else if (msg.id === 1) {
+            clearTimeout(startup);
+            resolve((msg.result?.tools || []).map((tool: any) => tool.name));
+            child.kill();
+            return;
+          }
+        } catch (e) {
+          // ignore non-json
+        }
+      }
+    });
+
+    child.stderr.on('data', () => { /* ignore */ });
+    child.on('error', (err) => { clearTimeout(startup); reject(err); });
+
+    setTimeout(() => {
+      child.stdin.write(JSON.stringify(initMsg) + '\n');
+    }, 100);
+  });
+}
+
+// Helper that runs a command through the explicit su-exec tool.
 function runSuMcpCommand(command: string, suPassword = 'secret', extraArgs: string[] = []): Promise<any> {
-  return runMcpCommand(command, [`--suPassword=${suPassword}`, ...extraArgs], 'exec');
+  return runMcpCommand(command, [`--suPassword=${suPassword}`, ...extraArgs], 'su-exec');
 }
 
 describe('sudo-exec tool authentication', () => {
@@ -109,33 +173,54 @@ describe('sudo-exec tool authentication', () => {
   it('executes su when provided --suPassword', async () => {
     const res = await runSuMcpCommand('whoami', 'secret');
     expect(res.error).toBeUndefined();
-    const out = (res.result?.content?.[0]?.text || '').toLowerCase();
+    const out = responseText(res);
     expect(out).toContain('root');
   }, 60000);
 
-  it('fails when sudo requires password but none provided', async () => {
+  it('keeps plain exec non-elevated when --suPassword is configured', async () => {
+    const res = await runMcpCommand('whoami', ['--suPassword=secret'], 'exec');
+    expect(res.error).toBeUndefined();
+    const out = responseText(res);
+    expect(out).toContain('test');
+    expect(out).not.toContain('root');
+  }, 60000);
+
+  it('keeps plain exec output intact when description contains shell-comment marker', async () => {
+    const res = await runMcpCommand('printf "alpha\\nbeta\\n"', ['--suPassword=secret'], 'exec', 'description with # marker');
+    expect(res.error).toBeUndefined();
+    const out = responseText(res);
+    expect(out).toContain('alpha');
+    expect(out).toContain('beta');
+    expect(out).not.toContain('description with');
+  }, 60000);
+
+  it('does not expose sudo-exec when sudo password is not configured', async () => {
     const res = await runMcpCommand('whoami');
-    const text = (res.result?.content?.[0]?.text || '').toLowerCase();
-    expect(text).toContain('sudo: a password is required');
+    expect(responseText(res)).toMatch(/not found|unknown tool|not registered/);
   });
 
   it('reports empty command as invalid', async () => {
     const res = await runMcpCommand('', ['--sudoPassword=secret']);
-    const text = (res.result?.content?.[0]?.text || '').toLowerCase();
-    expect(text).toContain('command cannot be empty');
+    expect(responseText(res)).toContain('command cannot be empty');
   });
 
   it('rejects wrong sudo password', async () => {
     const res = await runMcpCommand('whoami', ['--sudoPassword=wrongpass']);
-    const text = (res.result?.content?.[0]?.text || '').toLowerCase();
     // The sshd/sudo stack may return different messages across platforms; look for common indicator
-    expect(text).toMatch(/sorry|incorrect|authentication/);
+    expect(responseText(res)).toMatch(/sorry|incorrect|authentication/);
   });
 
   it('executes with correct sudo password', async () => {
     const res = await runMcpCommand('id', ['--sudoPassword=secret']);
     expect(res.error).toBeUndefined();
-    const out = (res.result?.content?.[0]?.text || '').toLowerCase();
+    const out = responseText(res);
     expect(out).toContain('uid=0');
+  });
+
+  it('exposes elevated tools only when their password is configured', async () => {
+    await expect(listMcpTools()).resolves.toEqual(['exec']);
+    await expect(listMcpTools(['--suPassword=secret'])).resolves.toEqual(['exec', 'su-exec']);
+    await expect(listMcpTools(['--sudoPassword=secret'])).resolves.toEqual(['exec', 'sudo-exec']);
+    await expect(listMcpTools(['--suPassword=secret', '--sudoPassword=secret'])).resolves.toEqual(['exec', 'su-exec', 'sudo-exec']);
   });
 });


### PR DESCRIPTION
## Summary
- keep plain exec on a normal SSH exec channel even when suPassword is configured
- expose su-exec and sudo-exec only when their corresponding passwords are configured
- keep description as client-side metadata instead of appending it to the remote shell command
- harden su shell readiness with a generated marker instead of prompt/# detection
- update README and regression tests for description handling, shell comments, and tool registration

## Tests
- npm run build
- npm test (6 files, 55 tests)