### PR TITLE
fix: bump zod to ^3.25.28 for SDK compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
     "ssh2": "^1.17.0",
-    "zod": "3.23.8"
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",


### PR DESCRIPTION
The exact pinned `zod@3.23.8` causes `ERR_PACKAGE_PATH_NOT_EXPORTED` when `zod-to-json-schema` tries to import `zod/v3`. Bumping to `^3.25.28` resolves the incompatibility with `@modelcontextprotocol/sdk`.

Fixes #1831