### PR TITLE
fix(deps): bump zod for fresh npx installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "ssh-mcp",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "ssh2": "^1.17.0",
-        "zod": "3.23.8"
+        "zod": "^3.25.28"
       },
       "bin": {
         "ssh-mcp": "build/index.js"
@@ -623,15 +623,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
@@ -5203,9 +5194,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
     "ssh2": "^1.17.0",
-    "zod": "3.23.8"
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",


### PR DESCRIPTION
## Summary
- relax and bump the direct `zod` dependency to `^3.25.28`
- update the lockfile so the local install uses `zod@3.25.76` without a nested SDK copy
- keeps the project on zod v3, preserving the existing SDK compatibility expectation that schemas expose `_parse`

## Why
Fresh installs can resolve a newer MCP SDK / `zod-to-json-schema` graph that imports `zod/v3`. `zod@3.23.8` does not export that subpath, so aligning the app dependency with `zod-to-json-schema`'s `^3.25.28 || ^4` expectation prevents `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Validation
- `npm ci --ignore-scripts`
- `npm run build`
- `npm exec -- vitest --run test/zod.compat.test.ts test/maxChars.test.ts`
- packed the local package and installed it in a fresh temp project; dependency graph resolves `@modelcontextprotocol/sdk@1.29.0`, `zod-to-json-schema@3.25.2`, and top-level `zod@3.25.76`
- `npm exec -y --package <local tarball> -- ssh-mcp --help` reaches the CLI configuration validation instead of failing during module resolution