### PR TITLE
Exit server when stdin closes to prevent orphaned processes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -709,6 +709,8 @@ async function main() {
 
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
+  process.stdin.on('end', cleanup);
+  process.stdin.on('close', cleanup);
   process.on('exit', () => {
     if (connectionManager) {
       connectionManager.close();


### PR DESCRIPTION
## Problem

When `ssh-mcp` is used as a stdio MCP server tunneled over SSH (e.g. `ssh host node build/index.js`), the server process is **leaked on every disconnect**.

When the SSH transport drops, stdin closes — but the process keeps running because the internal `ssh2` client connection to the target host keeps Node's event loop alive. `main()` only wires `cleanup` to `SIGINT`/`SIGTERM`, neither of which fires when the stdio pipe simply closes.

In practice this means one orphaned `node build/index.js` process accumulates per reconnect. On a long-running host I found **34 orphaned processes** piled up over a few weeks of normal MCP client reconnects.

## Fix

Wire the existing `cleanup` handler to stdin `end`/`close` so the server exits when its transport goes away:

```js
process.on('SIGINT', cleanup);
process.on('SIGTERM', cleanup);
process.stdin.on('end', cleanup);    // added
process.stdin.on('close', cleanup);  // added
```

`cleanup` already closes the connection manager and calls `process.exit(0)`, so this reuses the existing teardown path — no new shutdown logic.

## Testing

- Built (`npm run build`) and ran as a stdio server; closing stdin now terminates the process cleanly instead of leaving it resident.
- No change to behavior while connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)