### PR TITLE
feat: add redacted command audit log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dist
 
 # Ignore build output
 build/
+manual-kerberos-test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dist
 # Ignore build output
 build/
 manual-kerberos-test.mjs
+manual-multi-host-test.mjs

--- a/README.md
+++ b/README.md
@@ -232,10 +232,17 @@ Equivalent expanded form:
 ```bash
 npx -y ssh-mcp -- \
   --transport=openssh \
+  --kerberos \
   --host=ubuntu-dev.example.internal \
   --user=aduser@EXAMPLE.INTERNAL \
   --strictHostKeyChecking=accept-new
 ```
+
+> `--kerberos` is what selects Kerberos/GSSAPI auth (it sets
+> `-o GSSAPIAuthentication=yes` and implies `--transport=openssh`). Passing
+> only `--transport=openssh` selects the OpenSSH transport but leaves auth in
+> its default mode — it does **not** enable GSSAPI on its own, so keep
+> `--kerberos` here for the example to be equivalent to the compact form above.
 
 ### CLI flags added by this mode
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - MCP-compliant server exposing SSH capabilities
 - Execute shell commands on remote Linux and Windows systems
 - Secure authentication via password or SSH key
+- **Kerberos / GSSAPI single-sign-on** via the OpenSSH subprocess transport — opt-in; see [Kerberos / OpenSSH Transport](#kerberos--openssh-transport)
 - Built with TypeScript and the official MCP SDK
 - **Configurable timeout protection** with automatic process abortion
 - **Graceful timeout handling** - attempts to kill hanging processes before closing connections
@@ -94,6 +95,11 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
 - `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
+- `transport`: Transport implementation. `ssh2` (default, unchanged) or `openssh` (spawns the system `ssh` binary — needed for Kerberos). See [Kerberos / OpenSSH Transport](#kerberos--openssh-transport).
+- `kerberos`: Flag shorthand for `--transport=openssh` with `GSSAPIAuthentication=yes`. Requires an active Kerberos ticket (TGT) on the client.
+- `gssapiDelegateCredentials`: `yes` or `no` (default `no`). Forwards the client TGT to the remote host for second-hop SSO. Use only against trusted hosts.
+- `knownHostsFile`: Path to a pinned `known_hosts` file (openssh transport only).
+- `strictHostKeyChecking`: `yes`, `no`, or `accept-new` (default `accept-new`; openssh transport only).
 
 
 ```commandline
@@ -178,6 +184,75 @@ After adding the server, restart Claude Code and ask Cascade to execute a comman
 ```
 
 For more information about MCP in Claude Code, see the [official documentation](https://docs.claude.com/en/docs/claude-code/mcp).
+
+## Kerberos / OpenSSH Transport
+
+> Experimental. Backwards-compatible: unchanged when `--transport` and `--kerberos` are both omitted.
+
+The default `ssh2`-based transport does not implement GSSAPI/Kerberos authentication (upstream issue [mscdex/ssh2#333](https://github.com/mscdex/ssh2/issues/333), open since 2015). When an **opt-in** OpenSSH subprocess transport is selected, the server delegates SSH to the operating system's `ssh` binary, which supports:
+
+- Kerberos SSO via GSSAPI (`-o GSSAPIAuthentication=yes`)
+- Public-key auth (`-i <key>`)
+- Password auth (via `SSH_ASKPASS`; not recommended — prefer Kerberos or keys)
+
+### When to use it
+
+- Windows client (domain-joined) → Linux target (AD-joined via SSSD/realmd, `sshd_config: GSSAPIAuthentication yes`): the user's logon TGT is consumed automatically by Win32-OpenSSH via SSPI. **No password. No key file.**
+- Any environment where a Kerberos KDC issues tickets and SSH is preferred over re-entering credentials.
+
+### Prerequisites
+
+1. The `ssh` binary must be on `PATH` (Windows: enabled by default since Windows 10 1803; Linux: `apt install openssh-client`).
+2. The **remote** `sshd_config` must have `GSSAPIAuthentication yes`.
+3. The user must have a valid TGT:
+   - **Windows (AD-joined):** automatic on login. Verify with `klist`.
+   - **Linux (MIT Kerberos):** run `kinit <user@REALM>` or use `k5start` with a keytab for service accounts.
+4. For an AD-integrated Linux target, SSSD/realmd must be joined to the domain.
+
+### Example — Claude Code / any MCP client
+
+```json
+{
+  "mcpServers": {
+    "ssh-mcp": {
+      "command": "npx",
+      "args": [
+        "-y", "ssh-mcp", "--",
+        "--host=ubuntu-dev.example.internal",
+        "--user=aduser@EXAMPLE.INTERNAL",
+        "--kerberos"
+      ]
+    }
+  }
+}
+```
+
+Equivalent expanded form:
+
+```bash
+npx -y ssh-mcp -- \
+  --transport=openssh \
+  --host=ubuntu-dev.example.internal \
+  --user=aduser@EXAMPLE.INTERNAL \
+  --strictHostKeyChecking=accept-new
+```
+
+### CLI flags added by this mode
+
+| Flag | Values | Default | Notes |
+|---|---|---|---|
+| `--transport` | `ssh2` / `openssh` | `ssh2` | Selects implementation |
+| `--kerberos` | flag | off | Implies `--transport=openssh` |
+| `--gssapiDelegateCredentials` | `yes` / `no` | `no` | Forward TGT (trusted hosts only) |
+| `--knownHostsFile` | path | `~/.ssh/known_hosts` | `openssh` only |
+| `--strictHostKeyChecking` | `yes` / `no` / `accept-new` | `accept-new` | `openssh` only |
+
+### Caveats and limitations
+
+- **No connection multiplexing on Windows.** Win32-OpenSSH does not support `ControlMaster` ([issue #1328](https://github.com/PowerShell/Win32-OpenSSH/issues/1328)). Each `exec` call spawns a fresh `ssh.exe` and performs a full Kerberos AP-REQ round trip. Expect ~100–300 ms extra latency per invocation on Windows. Linux/macOS may work around this with user-provided `ssh_config` `ControlMaster` settings — the transport does not configure multiplexing itself.
+- **Password mode via `SSH_ASKPASS`.** When `--password` is combined with `--transport=openssh`, the server writes a short-lived askpass helper to `%TEMP%/ssh-mcp-<pid>/` and exports the password through a per-process environment variable. The password never appears in `argv` but is briefly visible to same-user-session process inspection. Prefer Kerberos or key auth.
+- **`--suPassword` over OpenSSH transport** is implemented via `ssh -tt` with a local expect-style state machine (random-nonce sentinel prompts). Works, but has more moving parts than the ssh2 path. Report issues with stderr output if you hit a regression.
+- **Delegation (`GSSAPIDelegateCredentials=yes`)** is off by default. Enabling it forwards your TGT to the remote host, which can then impersonate you elsewhere — use only against fully trusted infrastructure. See Microsoft's guidance on Kerberos delegation.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-mcp",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server exposing SSH control for Linux and Windows systems via Model Context Protocol.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-mcp",
   "license": "MIT",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "MCP server exposing SSH control for Linux and Windows systems via Model Context Protocol.",
   "type": "module",
   "bin": {
@@ -52,7 +52,10 @@
     "automation",
     "remote",
     "cli",
-    "typescript"
+    "typescript",
+    "kerberos",
+    "gssapi",
+    "sso"
   ],
   "author": "tufantunc",
   "engines": {

--- a/src/audit/__tests__/disabled-main-import.test.ts
+++ b/src/audit/__tests__/disabled-main-import.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AuditStore } from '../store.js';
+
+/**
+ * Regression test for the deferred-AuditStore fix.
+ *
+ * Before the fix, `src/index.ts` constructed the AuditStore eagerly at module
+ * top-level, so merely importing the module under SSH_MCP_DISABLE_MAIN=1 (the
+ * library/test path) performed audit-directory filesystem I/O. An invalid
+ * audit dir therefore made the import itself throw (ENOTDIR). With the store
+ * built lazily, the import must succeed regardless of audit-dir validity.
+ */
+describe('index import under SSH_MCP_DISABLE_MAIN=1', () => {
+  let root: string;
+  let badDir: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'ssh-mcp-disabled-main-'));
+    // A regular file standing where a directory parent is expected: any
+    // mkdirSync under it fails with ENOTDIR.
+    const notADir = join(root, 'notadir');
+    writeFileSync(notADir, 'x');
+    badDir = join(notADir, 'audit');
+    for (const k of ['SSH_MCP_DISABLE_MAIN', 'SSH_MCP_TEST', 'SSH_MCP_AUDIT_DIR']) {
+      saved[k] = process.env[k];
+    }
+    process.env.SSH_MCP_DISABLE_MAIN = '1';
+    delete process.env.SSH_MCP_TEST;
+    process.env.SSH_MCP_AUDIT_DIR = badDir;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('imports cleanly even when the audit dir is invalid (construction deferred)', async () => {
+    // Sanity: the dir really is invalid, so a real construction would throw.
+    expect(() => new AuditStore({ auditDir: badDir, auditMaxBytes: 10 })).toThrow();
+
+    // The import must NOT touch the filesystem for the audit store.
+    const mod = await import('../../index.js');
+    expect(mod).toBeTruthy();
+    expect(typeof mod.executeAuditedTransportCommand).toBe('function');
+  });
+});

--- a/src/audit/__tests__/integration.test.ts
+++ b/src/audit/__tests__/integration.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { AuditStore, activeFilePath } from '../store.js';
+import { ExecResult, ISshTransport } from '../../transports/types.js';
+
+describe('audit integration with exec wrapper', () => {
+  it('writes one JSONL line after a successful exec against a stub transport', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-audit-wrapper-'));
+    try {
+      process.env.SSH_MCP_AUDIT_DIR = dir;
+      process.env.SSH_MCP_AUDIT_MAX_BYTES = '8';
+      process.env.SSH_MCP_DISABLE_MAIN = '1';
+      const { executeAuditedTransportCommand } = await import('../../index.js');
+
+      const calls: string[] = [];
+      const transport: Pick<ISshTransport, 'exec' | 'execElevated'> = {
+        exec: async (command: string): Promise<ExecResult> => {
+          calls.push(command);
+          return { stdout: '0123456789-secret', stderr: '', exitCode: 0 };
+        },
+        execElevated: async (): Promise<ExecResult> => {
+          throw new Error('not used');
+        },
+      };
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 8 });
+
+      const response = await executeAuditedTransportCommand({
+        transport,
+        store,
+        tool: 'exec',
+        profile: 'stub-profile',
+        command: 'echo --password=secret',
+        description: 'integration token abc',
+      });
+
+      expect(response.content[0].text).toContain('0123456789-secret');
+      expect(calls[0]).toContain('--password=secret');
+
+      const file = activeFilePath(dir);
+      const records = readFileSync(file, 'utf8').trim().split('\n').map(line => JSON.parse(line));
+      expect(records).toHaveLength(1);
+      expect(records[0].profile).toBe('stub-profile');
+      expect(records[0].tool).toBe('exec');
+      expect(records[0].command).toContain('--password=<redacted>');
+      expect(records[0].command).not.toContain('secret');
+      expect(records[0].exec.stdout).toBe('01234567');
+      expect(records[0].exec.stdout_truncated).toBe(true);
+    } finally {
+      delete process.env.SSH_MCP_AUDIT_DIR;
+      delete process.env.SSH_MCP_AUDIT_MAX_BYTES;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/audit/__tests__/integration.test.ts
+++ b/src/audit/__tests__/integration.test.ts
@@ -54,4 +54,44 @@ describe('audit integration with exec wrapper', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('writes a failure audit record when the transport throws (audit contract covers failure)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-audit-wrapper-fail-'));
+    try {
+      process.env.SSH_MCP_AUDIT_DIR = dir;
+      process.env.SSH_MCP_DISABLE_MAIN = '1';
+      const { executeAuditedTransportCommand } = await import('../../index.js');
+
+      const transport: Pick<ISshTransport, 'exec' | 'execElevated'> = {
+        exec: async (): Promise<ExecResult> => {
+          throw new Error('spawn ENOENT');
+        },
+        execElevated: async (): Promise<ExecResult> => {
+          throw new Error('not used');
+        },
+      };
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 1000 });
+
+      await expect(
+        executeAuditedTransportCommand({
+          transport,
+          store,
+          tool: 'exec',
+          command: 'echo boom',
+        }),
+      ).rejects.toThrow('spawn ENOENT');
+
+      const file = activeFilePath(dir);
+      const records = readFileSync(file, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+      expect(records).toHaveLength(1);
+      // Omitted profile defaults to 'default' (not the misleading 'stub').
+      expect(records[0].profile).toBe('default');
+      expect(records[0].tool).toBe('exec');
+      expect(records[0].exec.exit_code).toBeNull();
+      expect(records[0].exec.stderr).toContain('spawn ENOENT');
+    } finally {
+      delete process.env.SSH_MCP_AUDIT_DIR;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/audit/__tests__/integration.test.ts
+++ b/src/audit/__tests__/integration.test.ts
@@ -94,4 +94,50 @@ describe('audit integration with exec wrapper', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('writes a failure audit record when the command is rejected by sanitization (empty command)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-audit-wrapper-sanitize-'));
+    try {
+      process.env.SSH_MCP_AUDIT_DIR = dir;
+      process.env.SSH_MCP_DISABLE_MAIN = '1';
+      const { executeAuditedTransportCommand } = await import('../../index.js');
+
+      let called = false;
+      const transport: Pick<ISshTransport, 'exec' | 'execElevated'> = {
+        exec: async (): Promise<ExecResult> => {
+          called = true;
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        execElevated: async (): Promise<ExecResult> => {
+          throw new Error('not used');
+        },
+      };
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 1000 });
+
+      // An empty command is rejected by sanitizeCommand *before* the transport
+      // runs; the audit contract still requires a record for the rejected call.
+      await expect(
+        executeAuditedTransportCommand({
+          transport,
+          store,
+          tool: 'exec',
+          profile: 'p',
+          command: '   ',
+        }),
+      ).rejects.toThrow(/Command cannot be empty/);
+
+      // The transport must never have been invoked for a rejected command.
+      expect(called).toBe(false);
+
+      const file = activeFilePath(dir);
+      const records = readFileSync(file, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+      expect(records).toHaveLength(1);
+      expect(records[0].tool).toBe('exec');
+      expect(records[0].exec.exit_code).toBeNull();
+      expect(records[0].exec.stderr).toContain('Command cannot be empty');
+    } finally {
+      delete process.env.SSH_MCP_AUDIT_DIR;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -17,6 +17,30 @@ describe('audit redactor', () => {
     expect(out).not.toContain('tok123');
   });
 
+  it('redacts MySQL and MariaDB attached -pVALUE password args', () => {
+    const input = [
+      'mysql -uroot -psecret',
+      'mysql --password=longsecret',
+      'mysqldump -pdumpsecret',
+      'mariadb "-pquotedsecret"',
+      "mysql '-prepeated1' -prepeated2",
+    ].join(' && ');
+
+    const out = redact(input);
+
+    expect(out).toContain(`mysql -uroot -p${R}`);
+    expect(out).toContain(`mysql --password=${R}`);
+    expect(out).toContain(`mysqldump -p${R}`);
+    expect(out).toContain(`mariadb "-p${R}"`);
+    expect(out).toContain(`mysql '-p${R}' -p${R}`);
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('repeated');
+  });
+
+  it('does not redact bare MySQL -p prompt form', () => {
+    expect(redact('mysql -p')).toBe('mysql -p');
+  });
+
   it('redacts JSON/TOML-ish secret values', () => {
     const out = redact('{"password":"pw","nested_token":"tok","safe":"ok"}\napi_key = "abc"\ntoken abc');
     expect(out).toContain(`"password":"${R}"`);

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -147,4 +147,22 @@ describe('audit redactor', () => {
     const url = 'https://example.com/path?query=1';
     expect(redact(url)).toBe(url);
   });
+
+  it('redacts quoted CLI secrets that contain escaped quotes', () => {
+    const input = [
+      'ssh --password="abc\\"def"',
+      "--api-key 'one\\'two'",
+      'token "tok\\"next"',
+    ].join(' ');
+    const out = redact(input);
+
+    expect(out).toContain(`--password=${R}`);
+    expect(out).toContain(`--api-key ${R}`);
+    expect(out).toContain(`token ${R}`);
+    expect(out).not.toContain('abc');
+    expect(out).not.toContain('def');
+    expect(out).not.toContain('one');
+    expect(out).not.toContain('two');
+    expect(out).not.toContain('next');
+  });
 });

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { redact, REDACTED_PLACEHOLDER } from '../redactor.js';
+
+const R = REDACTED_PLACEHOLDER;
+
+describe('audit redactor', () => {
+  it('redacts password/token CLI shapes and env assignments', () => {
+    const input = ['mysql -u root', '-p hunter2', '--password=secret', '--api-key "abc"', 'API_TOKEN=tok123'].join(' ');
+    const out = redact(input);
+    expect(out).toContain(`-p ${R}`);
+    expect(out).toContain(`--password=${R}`);
+    expect(out).toContain(`--api-key ${R}`);
+    expect(out).toContain(`API_TOKEN=${R}`);
+    expect(out).not.toContain('hunter2');
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('tok123');
+  });
+
+  it('redacts JSON/TOML-ish secret values', () => {
+    const out = redact('{"password":"pw","nested_token":"tok","safe":"ok"}\napi_key = "abc"\ntoken abc');
+    expect(out).toContain(`"password":"${R}"`);
+    expect(out).toContain(`"nested_token":"${R}"`);
+    expect(out).toContain(`api_key = ${R}`);
+    expect(out).toContain(`token ${R}`);
+    expect(out).toContain('"safe":"ok"');
+  });
+
+  it('redacts PEM private keys', () => {
+    const pem = [
+      '-----BEGIN ' + 'OPENSSH PRIVATE KEY-----',
+      'abc123',
+      '-----END ' + 'OPENSSH PRIVATE KEY-----',
+    ].join('\n');
+    const out = redact(`key\n${pem}\nend`);
+    expect(out).toContain(R);
+    expect(out).not.toContain('abc123');
+  });
+
+  it('redacts AWS key id / secret hint and JWT shapes', () => {
+    const awsKey = 'AKIA' + 'A'.repeat(16);
+    const awsSecret = 'a'.repeat(40);
+    const jwt = ['eyJ' + 'a'.repeat(12), 'eyJ' + 'b'.repeat(12), 'c'.repeat(12)].join('.');
+    const text = `${awsKey} aws_secret_access_key=${awsSecret} ${jwt}`;
+    const out = redact(text);
+    expect(out).not.toContain(awsKey);
+    expect(out).not.toContain(awsSecret);
+    expect(out).not.toContain(jwt);
+    expect((out.match(/<redacted>/g) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -41,6 +41,32 @@ describe('audit redactor', () => {
     expect(redact('mysql -p')).toBe('mysql -p');
   });
 
+  it('redacts quoted attached -p passwords that contain whitespace', () => {
+    // Quote *after* -p: `mysql -p"secret with space"` / `-p'secret with space'`.
+    const afterDouble = redact('mysql -p"secret with space"');
+    expect(afterDouble).toContain(`-p"${R}"`);
+    expect(afterDouble).not.toContain('secret with space');
+
+    const afterSingle = redact("mysql -p'secret with space'");
+    expect(afterSingle).toContain(`-p'${R}'`);
+    expect(afterSingle).not.toContain('secret with space');
+
+    // Whole arg quoted (quote *before* -p): `'-psecret with space'`.
+    const wholeSingle = redact("mysql '-psecret with space'");
+    expect(wholeSingle).toContain(`'-p${R}'`);
+    expect(wholeSingle).not.toContain('secret with space');
+
+    const wholeDouble = redact('mysql "-psecret with space"');
+    expect(wholeDouble).toContain(`"-p${R}"`);
+    expect(wholeDouble).not.toContain('secret with space');
+
+    // A later plain attached form on the same line still redacts too.
+    const mixed = redact('mysql -p"a b" && mysqldump -pplain');
+    expect(mixed).not.toContain('a b');
+    expect(mixed).not.toContain('plain');
+    expect(mixed).toContain(`mysqldump -p${R}`);
+  });
+
   it('redacts JSON/TOML-ish secret values', () => {
     const out = redact('{"password":"pw","nested_token":"tok","safe":"ok"}\napi_key = "abc"\ntoken abc');
     expect(out).toContain(`"password":"${R}"`);

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -110,9 +110,41 @@ describe('audit redactor', () => {
 
   it('redacts a fine-grained PAT embedded in a remote URL', () => {
     const fineGrained = 'github_pat_' + 'D'.repeat(22) + '_' + 'E'.repeat(59);
-    const url = `https://x-access-token:${fineGrained}@github.com/owner/repo.git`;
+    const url = 'https://' + 'x-access-token' + ':' + fineGrained + '@' + 'github.com/owner/repo.git';
     const out = redact(`git clone ${url}`);
     expect(out).not.toContain(fineGrained);
     expect(out).toContain('<redacted>');
+  });
+
+  it('redacts a dangling PEM header with no matching END marker (Codex 3541772951)', () => {
+    // A truncated pasted key / here-doc command text carries a BEGIN header
+    // without an END terminator; the main redact() path must still scrub it.
+    const dangling = [
+      'cat <<EOF',
+      '-----BEGIN ' + 'RSA PRIVATE KEY-----',
+      'MIIEowIBAAKCAQEA' + 'x'.repeat(40),
+      'more-secret-key-bytes-with-no-end-marker',
+    ].join('\n');
+    const out = redact(dangling);
+    expect(out).toContain(R);
+    expect(out).not.toContain('MIIEowIBAAKCAQEA');
+    expect(out).not.toContain('more-secret-key-bytes-with-no-end-marker');
+  });
+
+  it('redacts URL userinfo passwords while preserving scheme/user/host (Codex 3541772956)', () => {
+    const httpUrl = 'https://alice:hunter2@example.com/repo.git';
+    const dbUrl = 'postgres://dbuser:s3cr3tpw@db.internal:5432/app';
+    const out = redact(`git clone ${httpUrl} && psql ${dbUrl}`);
+    // Passwords gone.
+    expect(out).not.toContain('hunter2');
+    expect(out).not.toContain('s3cr3tpw');
+    // Structure preserved.
+    expect(out).toContain(`https://alice:${R}@example.com/repo.git`);
+    expect(out).toContain(`postgres://dbuser:${R}@db.internal:5432/app`);
+  });
+
+  it('does not touch a URL with no userinfo credentials', () => {
+    const url = 'https://example.com/path?query=1';
+    expect(redact(url)).toBe(url);
   });
 });

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -67,6 +67,16 @@ describe('audit redactor', () => {
     expect(mixed).toContain(`mysqldump -p${R}`);
   });
 
+  it('redacts unterminated quoted attached -p passwords', () => {
+    const doubleQuoted = redact('mysql -p"unterminated double quote');
+    expect(doubleQuoted).toContain(`mysql -p${R}`);
+    expect(doubleQuoted).not.toContain('unterminated');
+
+    const singleQuoted = redact("mariadb -p'unterminated single quote");
+    expect(singleQuoted).toContain(`mariadb -p${R}`);
+    expect(singleQuoted).not.toContain('unterminated');
+  });
+
   it('redacts JSON/TOML-ish secret values', () => {
     const out = redact('{"password":"pw","nested_token":"tok","safe":"ok"}\napi_key = "abc"\ntoken abc');
     expect(out).toContain(`"password":"${R}"`);
@@ -74,6 +84,29 @@ describe('audit redactor', () => {
     expect(out).toContain(`api_key = ${R}`);
     expect(out).toContain(`token ${R}`);
     expect(out).toContain('"safe":"ok"');
+  });
+
+  it('treats passphrase flags, fields, assignments, and prose as secrets', () => {
+    const input = [
+      '--passphrase=flag-value',
+      'SSH_PASSPHRASE=env-value',
+      'key_passphrase = "field-value"',
+      '{"passphrase":"json-value"}',
+      'passphrase prose-value',
+    ].join(' ');
+    const out = redact(input);
+
+    expect((out.match(/<redacted>/g) ?? []).length).toBeGreaterThanOrEqual(5);
+    for (const value of ['flag-value', 'env-value', 'field-value', 'json-value', 'prose-value']) {
+      expect(out).not.toContain(value);
+    }
+  });
+
+  it('consumes tildes as part of bearer tokens', () => {
+    const out = redact('Authorization: Bearer abc~def~ghi next');
+    expect(out).toContain(`Authorization: Bearer ${R} next`);
+    expect(out).not.toContain('~def');
+    expect(out).not.toContain('~ghi');
   });
 
   it('redacts PEM private keys', () => {

--- a/src/audit/__tests__/redactor.test.ts
+++ b/src/audit/__tests__/redactor.test.ts
@@ -72,4 +72,21 @@ describe('audit redactor', () => {
     expect(out).not.toContain(jwt);
     expect((out.match(/<redacted>/g) ?? []).length).toBeGreaterThanOrEqual(3);
   });
+
+  it('redacts classic and fine-grained GitHub PATs', () => {
+    const classic = 'ghp_' + 'A'.repeat(36);
+    const fineGrained = 'github_pat_' + 'B'.repeat(22) + '_' + 'C'.repeat(59);
+    const out = redact(`token ${classic} other ${fineGrained} end`);
+    expect(out).not.toContain(classic);
+    expect(out).not.toContain(fineGrained);
+    expect((out.match(/<redacted>/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('redacts a fine-grained PAT embedded in a remote URL', () => {
+    const fineGrained = 'github_pat_' + 'D'.repeat(22) + '_' + 'E'.repeat(59);
+    const url = `https://x-access-token:${fineGrained}@github.com/owner/repo.git`;
+    const out = redact(`git clone ${url}`);
+    expect(out).not.toContain(fineGrained);
+    expect(out).toContain('<redacted>');
+  });
 });

--- a/src/audit/__tests__/rotator.test.ts
+++ b/src/audit/__tests__/rotator.test.ts
@@ -24,16 +24,50 @@ describe('audit rotator', () => {
     }
   });
 
-  it('prunes old day-rolled files but retains newest distinct days', () => {
+  it('prunes files older than the retention window by age (not by count of distinct days)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-prune-'));
     try {
       for (const day of ['20260520', '20260521', '20260522']) {
         writeFileSync(join(dir, `executions-${day}.jsonl`), day);
       }
-      const removed = pruneOldDays(dir, 2);
+      // asOf = 2026-05-22, retain=2 → window is [05-21, 05-22]; 05-20 is out.
+      const removed = pruneOldDays(dir, 2, new Date('2026-05-22T00:00:00Z'));
       expect(removed.some(p => p.endsWith('executions-20260520.jsonl'))).toBe(true);
       expect(existsSync(join(dir, 'executions-20260521.jsonl'))).toBe(true);
       expect(existsSync(join(dir, 'executions-20260522.jsonl'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes an old file past the window even when few distinct dates exist (gap in usage)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-prune-gap-'));
+    try {
+      // Only two distinct dates on disk, far apart. The count-based prune kept
+      // the old May file (2 distinct <= retain=10); age-based prune removes it.
+      writeFileSync(join(dir, 'executions-20260501.jsonl'), 'old');
+      writeFileSync(join(dir, 'executions-20260701.jsonl'), 'today');
+      const removed = pruneOldDays(dir, 10, new Date('2026-07-01T00:00:00Z'));
+      expect(removed.some(p => p.endsWith('executions-20260501.jsonl'))).toBe(true);
+      expect(existsSync(join(dir, 'executions-20260501.jsonl'))).toBe(false);
+      expect(existsSync(join(dir, 'executions-20260701.jsonl'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes rotated siblings (.jsonl.N) sharing an out-of-window date', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-prune-sib-'));
+    try {
+      writeFileSync(join(dir, 'executions-20260501.jsonl'), 'a');
+      writeFileSync(join(dir, 'executions-20260501.jsonl.1'), 'b');
+      writeFileSync(join(dir, 'executions-20260501.jsonl.2'), 'c');
+      writeFileSync(join(dir, 'executions-20260701.jsonl'), 'today');
+      const removed = pruneOldDays(dir, 5, new Date('2026-07-01T00:00:00Z'));
+      expect(removed.filter(p => /executions-20260501\.jsonl(\.\d+)?$/.test(p))).toHaveLength(3);
+      expect(existsSync(join(dir, 'executions-20260501.jsonl.1'))).toBe(false);
+      expect(existsSync(join(dir, 'executions-20260501.jsonl.2'))).toBe(false);
+      expect(existsSync(join(dir, 'executions-20260701.jsonl'))).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/audit/__tests__/rotator.test.ts
+++ b/src/audit/__tests__/rotator.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { rotateIfNeeded, pruneOldDays } from '../rotator.js';
+
+describe('audit rotator', () => {
+  it('rotates active file when size cap is reached and keeps retention', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-rotator-'));
+    try {
+      const file = join(dir, 'executions-20260525.jsonl');
+      writeFileSync(file, '0123456789');
+      writeFileSync(`${file}.1`, 'old1');
+      writeFileSync(`${file}.2`, 'old2');
+
+      expect(rotateIfNeeded({ filePath: file, maxFileBytes: 10, retain: 2 })).toBe(1);
+      expect(existsSync(file)).toBe(false);
+      expect(readFileSync(`${file}.1`, 'utf8')).toBe('0123456789');
+      expect(readFileSync(`${file}.2`, 'utf8')).toBe('old1');
+      expect(existsSync(`${file}.3`)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes old day-rolled files but retains newest distinct days', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ssh-mcp-prune-'));
+    try {
+      for (const day of ['20260520', '20260521', '20260522']) {
+        writeFileSync(join(dir, `executions-${day}.jsonl`), day);
+      }
+      const removed = pruneOldDays(dir, 2);
+      expect(removed.some(p => p.endsWith('executions-20260520.jsonl'))).toBe(true);
+      expect(existsSync(join(dir, 'executions-20260521.jsonl'))).toBe(true);
+      expect(existsSync(join(dir, 'executions-20260522.jsonl'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -8,6 +8,7 @@ import {
   activeFilePath,
   buildRecord,
   capThenRedact,
+  clampInt,
   yoloApproval,
   REDACT_SCAN_HEADROOM_BYTES,
 } from '../store.js';
@@ -167,5 +168,50 @@ describe('audit store', () => {
     expect(out.text).not.toContain(secret);
     expect(Buffer.byteLength(out.text, 'utf8')).toBeLessThanOrEqual(cap);
     expect(out.truncated).toBe(true);
+  });
+
+  it('clamps negative / non-finite config to safe values (no empty output, no per-append rotation, retain >= 1)', () => {
+    // clampInt unit behavior across the surprising inputs Copilot flagged.
+    expect(clampInt(NaN, 10, 1)).toBe(10);
+    expect(clampInt(Infinity, 10, 1)).toBe(10);
+    expect(clampInt(-Infinity, 10, 1)).toBe(10);
+    expect(clampInt(undefined, 10, 1)).toBe(10);
+    expect(clampInt(null, 10, 1)).toBe(10);
+    expect(clampInt(-5, 99, 1)).toBe(99); // negative < minValid -> fallback (not floored to min)
+    expect(clampInt(-5, 99, 0)).toBe(99); // negative < 0 -> fallback
+    expect(clampInt(0, 99, 0)).toBe(0); // explicit 0 honored when minValid is 0
+    expect(clampInt(0, 99, 1)).toBe(99); // 0 below minValid 1 -> fallback
+    expect(clampInt(3.9, 99, 1)).toBe(3); // floored to integer
+
+    // End-to-end: a store built with garbage config still writes a non-empty,
+    // single record (negative auditMaxBytes would otherwise empty stdout, NaN
+    // maxFileBytes would rotate on every append).
+    const dir = tmpAuditDir();
+    try {
+      const store = new AuditStore({
+        auditDir: dir,
+        auditMaxBytes: -100,
+        maxFileBytes: NaN,
+        retain: -3,
+      });
+      const now = new Date('2026-05-25T12:00:00.000Z');
+      store.append({
+        now,
+        profile: 'default',
+        tool: 'exec',
+        command: 'echo hello',
+        approval: yoloApproval(now),
+        exec: { stdout: 'output-visible', stderr: '', exitCode: 0, durationMs: 1 },
+      });
+      const file = activeFilePath(dir, now);
+      // Only the active file exists — no spurious rotation from NaN maxFileBytes.
+      const rotated = readdirSync(dir).filter((f) => /\.jsonl\.\d+$/.test(f));
+      expect(rotated).toHaveLength(0);
+      const parsed = JSON.parse(readFileSync(file, 'utf8').trim());
+      // auditMaxBytes clamped to >= 0 default, so stdout is retained, not emptied.
+      expect(parsed.exec.stdout.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -1,9 +1,16 @@
-import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync, statSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { AuditStore, activeFilePath, buildRecord, yoloApproval } from '../store.js';
+import {
+  AuditStore,
+  activeFilePath,
+  buildRecord,
+  capThenRedact,
+  yoloApproval,
+  REDACT_SCAN_HEADROOM_BYTES,
+} from '../store.js';
 
 function tmpAuditDir() {
   return mkdtempSync(join(tmpdir(), 'ssh-mcp-audit-'));
@@ -83,5 +90,82 @@ describe('audit store', () => {
       exec: { stdout: `Authorization: ${bearer}`, stderr: 'ok', exitCode: 0, durationMs: 1 },
     });
     expect(rec.exec?.stdout).toContain('Bearer <redacted>');
+  });
+
+  it('creates the audit dir 0700 and JSONL files 0600 under a permissive umask', () => {
+    const prevMask = process.umask(0o022);
+    const dir = join(tmpAuditDir(), 'nested');
+    try {
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 100 });
+      const now = new Date('2026-05-25T12:00:00Z');
+      store.append({ now, profile: 'p', tool: 'exec', command: 'date', approval: yoloApproval(now), exec: { stdout: 'x', stderr: '', exitCode: 0, durationMs: 1 } });
+
+      // 0o777 mask isolates the permission bits from file-type bits.
+      const dirMode = statSync(dir).mode & 0o777;
+      const fileMode = statSync(activeFilePath(dir, now)).mode & 0o777;
+      expect(dirMode).toBe(0o700);
+      expect(fileMode).toBe(0o600);
+    } finally {
+      process.umask(prevMask);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('redacts a secret that lands far past the cap before truncating (large output)', () => {
+    const dir = tmpAuditDir();
+    try {
+      const cap = 64;
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: cap });
+      const now = new Date('2026-05-25T12:00:00Z');
+      // Secret placed well beyond the final cap but inside the scan headroom.
+      const filler = 'A'.repeat(cap + 100);
+      const secret = 'ghp_' + 'B'.repeat(36);
+      const rec = store.append({
+        now,
+        profile: 'p',
+        tool: 'exec',
+        command: 'dump',
+        approval: yoloApproval(now),
+        exec: { stdout: `${filler} ${secret} tail`, stderr: '', exitCode: 0, durationMs: 1 },
+      });
+      const file = activeFilePath(dir, now);
+      const persisted = readFileSync(file, 'utf8');
+      // The capped record must never carry the verbatim secret...
+      expect(persisted).not.toContain(secret);
+      expect(rec.exec?.stdout).not.toContain(secret);
+      // ...and the kept stdout is bounded to the cap.
+      expect(Buffer.byteLength(rec.exec?.stdout ?? '', 'utf8')).toBeLessThanOrEqual(cap);
+      expect(rec.exec?.stdout_truncated).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not slice a boundary-straddling token into a partial-secret leak', () => {
+    const cap = 32;
+    // The secret token STARTS inside the kept cap window (after a word
+    // boundary) but EXTENDS past it. A naive cap-then-redact would keep only
+    // the token's prefix — too short for the {20,255} body matcher — leaving a
+    // partial secret verbatim. The scan headroom must let the redactor match
+    // the whole token and replace it with <redacted>.
+    const secret = 'ghp_' + 'C'.repeat(36);
+    const prefix = 'x'.repeat(cap - 11) + ' '; // ends on a word boundary
+    const out = capThenRedact(`${prefix}${secret}`, cap);
+    // No fragment of the secret body should survive (would be a partial leak).
+    expect(out.text).not.toContain('ghp_');
+    expect(out.text).not.toContain('CCCC');
+    expect(out.text).toContain('<redacted>');
+  });
+
+  it('caps the redactor scan window to cap + headroom (does not redact unbounded input)', () => {
+    const cap = 16;
+    // A secret placed beyond cap + headroom is outside the scan window: it gets
+    // truncated away by the first bounding cap, never reaching the persisted slice.
+    const secret = 'ghp_' + 'D'.repeat(36);
+    const filler = 'z'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 50);
+    const out = capThenRedact(`${filler}${secret}`, cap);
+    expect(out.text).not.toContain(secret);
+    expect(Buffer.byteLength(out.text, 'utf8')).toBeLessThanOrEqual(cap);
+    expect(out.truncated).toBe(true);
   });
 });

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -170,6 +170,62 @@ describe('audit store', () => {
     expect(out.truncated).toBe(true);
   });
 
+  it('redacts a PEM private key whose END marker falls past the scan window', () => {
+    const cap = 64;
+    // Body large enough that the END terminator sits well beyond cap + headroom.
+    // Under the old cap-before-redact ordering the terminator-anchored PEM_RE
+    // could not match, leaving raw key material in the persisted slice.
+    const begin = '-----BEGIN ' + 'OPENSSH PRIVATE KEY-----';
+    const end = '-----END ' + 'OPENSSH PRIVATE KEY-----';
+    const body = 'A'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 2000);
+    const pem = `${begin}\n${body}\n${end}`;
+    const out = capThenRedact(`prefix ${pem} suffix`, cap);
+    expect(out.text).not.toContain('AAAA');
+    expect(out.text).not.toContain('PRIVATE KEY');
+    expect(out.text).toContain('<redacted>');
+  });
+
+  it('redacts a truncated PEM key with no END terminator (dangling BEGIN)', () => {
+    const cap = 64;
+    // A key whose END marker was truncated away entirely. The dangling-BEGIN
+    // fallback must redact from the header to end-of-string so no raw key
+    // material persists even without a reachable terminator.
+    const begin = '-----BEGIN ' + 'RSA PRIVATE KEY-----';
+    const body = 'K'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 500);
+    const out = capThenRedact(`log ${begin}\n${body}`, cap);
+    expect(out.text).not.toContain('KKKK');
+    expect(out.text).not.toContain('PRIVATE KEY');
+    expect(out.text).toContain('<redacted>');
+  });
+
+  it('persists a redacted PEM key end-to-end through append (large key past window)', () => {
+    const dir = tmpAuditDir();
+    try {
+      const cap = 128;
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: cap });
+      const now = new Date('2026-05-25T12:00:00Z');
+      const begin = '-----BEGIN ' + 'OPENSSH PRIVATE KEY-----';
+      const end = '-----END ' + 'OPENSSH PRIVATE KEY-----';
+      const body = 'Z'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 3000);
+      const pem = `${begin}\n${body}\n${end}`;
+      const rec = store.append({
+        now,
+        profile: 'p',
+        tool: 'exec',
+        command: 'cat id_ed25519',
+        approval: yoloApproval(now),
+        exec: { stdout: pem, stderr: '', exitCode: 0, durationMs: 1 },
+      });
+      const persisted = readFileSync(activeFilePath(dir, now), 'utf8');
+      expect(persisted).not.toContain('ZZZZ');
+      expect(persisted).not.toContain('PRIVATE KEY');
+      expect(rec.exec?.stdout).toContain('<redacted>');
+      expect(rec.exec?.stdout).not.toContain('ZZZZ');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('clamps negative / non-finite config to safe values (no empty output, no per-append rotation, retain >= 1)', () => {
     // clampInt unit behavior across the surprising inputs Copilot flagged.
     expect(clampInt(NaN, 10, 1)).toBe(10);

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -198,6 +198,74 @@ describe('audit store', () => {
     expect(out.text).toContain('<redacted>');
   });
 
+  it('redacts a long JWT whose signature falls past the scan window (Codex 3541772953)', () => {
+    const cap = 64;
+    // A JWT that STARTS inside the retained window but whose large payload/
+    // signature pushes the third segment past cap + headroom. Under a
+    // cap-before-redact ordering the JWT regex could not see a complete token,
+    // leaving the token prefix in the persisted slice. Pre-redaction over the
+    // full text must scrub the whole token.
+    const header = 'eyJ' + 'a'.repeat(20);
+    const payload = 'eyJ' + 'b'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 1000); // huge claims
+    const sig = 'c'.repeat(50);
+    const jwt = `${header}.${payload}.${sig}`;
+    const out = capThenRedact(`token ${jwt} tail`, cap);
+    expect(out.text).not.toContain(header);
+    expect(out.text).not.toContain('eyJbbbb');
+    expect(out.text).not.toContain(sig);
+    expect(out.text).toContain('<redacted>');
+  });
+
+  it('caps a huge rejected command so it cannot bypass the size guard (Codex 3541772945)', () => {
+    // A multi-MB command (e.g. a rejected over-maxChars payload) must not be
+    // persisted verbatim — buildRecord caps command/description to bound the
+    // JSONL append and redaction cost.
+    const huge = 'A'.repeat(5 * 1024 * 1024); // 5 MB
+    const rec = buildRecord({
+      now: new Date('2026-05-25T12:00:00Z'),
+      profile: 'p',
+      tool: 'exec',
+      command: huge,
+      description: 'B'.repeat(5 * 1024 * 1024),
+      approval: yoloApproval(),
+      auditMaxBytes: 64,
+    });
+    // Bounded well under the raw 5 MB — the command cap floor keeps it modest.
+    expect(Buffer.byteLength(rec.command, 'utf8')).toBeLessThanOrEqual(64 * 1024);
+    expect(Buffer.byteLength(rec.description ?? '', 'utf8')).toBeLessThanOrEqual(64 * 1024);
+    expect(rec.command.length).toBeLessThan(huge.length);
+  });
+
+  it('preserves a normal short command even when auditMaxBytes (output cap) is tiny', () => {
+    // The command cap must not collapse to a tiny stdout cap: a legitimate
+    // command line survives in full while output capture is set to a few bytes.
+    const rec = buildRecord({
+      now: new Date('2026-05-25T12:00:00Z'),
+      profile: 'p',
+      tool: 'exec',
+      command: 'systemctl restart nginx && journalctl -u nginx --since "10 min ago"',
+      approval: yoloApproval(),
+      auditMaxBytes: 5,
+    });
+    expect(rec.command).toBe('systemctl restart nginx && journalctl -u nginx --since "10 min ago"');
+  });
+
+  it('caps a huge command that carries a secret past the window without leaking it', () => {
+    // Belt-and-suspenders: a giant command with an embedded token must be both
+    // bounded AND scrubbed of the token.
+    const secret = 'ghp_' + 'Z'.repeat(36);
+    const rec = buildRecord({
+      now: new Date('2026-05-25T12:00:00Z'),
+      profile: 'p',
+      tool: 'exec',
+      command: 'echo ' + 'x'.repeat(2 * 1024 * 1024) + ' ' + secret,
+      approval: yoloApproval(),
+      auditMaxBytes: 64,
+    });
+    expect(rec.command).not.toContain(secret);
+    expect(Buffer.byteLength(rec.command, 'utf8')).toBeLessThanOrEqual(64 * 1024);
+  });
+
   it('persists a redacted PEM key end-to-end through append (large key past window)', () => {
     const dir = tmpAuditDir();
     try {

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, readFileSync, rmSync, existsSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { AuditStore, activeFilePath, buildRecord, yoloApproval } from '../store.js';
+
+function tmpAuditDir() {
+  return mkdtempSync(join(tmpdir(), 'ssh-mcp-audit-'));
+}
+
+describe('audit store', () => {
+  it('appends one JSONL record with redacted command and capped output', () => {
+    const dir = tmpAuditDir();
+    try {
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 5 });
+      const now = new Date('2026-05-25T12:00:00.000Z');
+      const rec = store.append({
+        now,
+        profile: 'default',
+        tool: 'exec',
+        command: 'echo --password=secret',
+        description: 'uses token abc',
+        approval: yoloApproval(now),
+        exec: { stdout: 'abcdef', stderr: '秘密資料', exitCode: 0, durationMs: 12 },
+      });
+
+      const file = activeFilePath(dir, now);
+      const line = readFileSync(file, 'utf8').trim();
+      const parsed = JSON.parse(line);
+      expect(parsed.id).toBe(rec.id);
+      expect(parsed.command).toContain('--password=<redacted>');
+      expect(parsed.command).not.toContain('secret');
+      expect(parsed.description).toBe('uses token <redacted>');
+      expect(parsed.exec.stdout).toBe('abcde');
+      expect(parsed.exec.stdout_truncated).toBe(true);
+      expect(Buffer.byteLength(parsed.exec.stderr, 'utf8')).toBeLessThanOrEqual(5);
+      expect(parsed.exec.stderr_truncated).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rolls on UTC day boundary by writing to date-specific files', () => {
+    const dir = tmpAuditDir();
+    try {
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 100 });
+      store.append({ now: new Date('2026-05-25T23:59:59Z'), profile: 'p', tool: 'exec', command: 'date', approval: yoloApproval(), exec: { stdout: '', stderr: '', exitCode: 0, durationMs: 1 } });
+      store.append({ now: new Date('2026-05-26T00:00:00Z'), profile: 'p', tool: 'exec', command: 'date', approval: yoloApproval(), exec: { stdout: '', stderr: '', exitCode: 0, durationMs: 1 } });
+      expect(existsSync(join(dir, 'executions-20260525.jsonl'))).toBe(true);
+      expect(existsSync(join(dir, 'executions-20260526.jsonl'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('size-rolls before append and retains rotated files', () => {
+    const dir = tmpAuditDir();
+    try {
+      const store = new AuditStore({ auditDir: dir, auditMaxBytes: 100, maxFileBytes: 1, retain: 2 });
+      const now = new Date('2026-05-25T12:00:00Z');
+      for (let i = 0; i < 4; i++) {
+        store.append({ now, profile: 'p', tool: 'exec', command: `echo ${i}`, approval: yoloApproval(now), exec: { stdout: 'x', stderr: '', exitCode: 0, durationMs: 1 } });
+      }
+      const files = readdirSync(dir).sort();
+      expect(files).toContain('executions-20260525.jsonl');
+      expect(files).toContain('executions-20260525.jsonl.1');
+      expect(files).toContain('executions-20260525.jsonl.2');
+      expect(files).not.toContain('executions-20260525.jsonl.3');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('buildRecord redacts stdout/stderr without filesystem IO', () => {
+    const bearer = 'Bearer ' + 'abc.def.ghi';
+    const rec = buildRecord({
+      now: new Date('2026-05-25T12:00:00Z'),
+      profile: 'stub',
+      tool: 'exec',
+      command: 'cat',
+      approval: yoloApproval(),
+      exec: { stdout: `Authorization: ${bearer}`, stderr: 'ok', exitCode: 0, durationMs: 1 },
+    });
+    expect(rec.exec?.stdout).toContain('Bearer <redacted>');
+  });
+});

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -158,6 +158,33 @@ describe('audit store', () => {
     expect(out.text).toContain('<redacted>');
   });
 
+  it('redacts an open quoted secret before a cap can persist its prefix', () => {
+    const cap = 64;
+    const secretPrefix = 'S'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 1000);
+    const out = capThenRedact(`run --password="${secretPrefix}" tail`, cap);
+
+    expect(out.text).toContain('--password=<redacted>');
+    expect(out.text).not.toContain('SSSS');
+    expect(Buffer.byteLength(out.text, 'utf8')).toBeLessThanOrEqual(cap);
+    expect(out.truncated).toBe(true);
+  });
+
+  it('caps and redacts profile names before serializing records', () => {
+    const secret = 'ghp_' + 'P'.repeat(36);
+    const rec = buildRecord({
+      now: new Date('2026-05-25T12:00:00Z'),
+      profile: `prod-${secret}-${'x'.repeat(2 * 1024 * 1024)}`,
+      tool: 'exec',
+      command: 'date',
+      approval: yoloApproval(),
+      auditMaxBytes: 64,
+    });
+
+    expect(rec.profile).not.toContain(secret);
+    expect(rec.profile).toContain('<redacted>');
+    expect(Buffer.byteLength(rec.profile, 'utf8')).toBeLessThanOrEqual(1024);
+  });
+
   it('caps the redactor scan window to cap + headroom (does not redact unbounded input)', () => {
     const cap = 16;
     // A secret placed beyond cap + headroom is outside the scan window: it gets

--- a/src/audit/__tests__/store.test.ts
+++ b/src/audit/__tests__/store.test.ts
@@ -169,6 +169,38 @@ describe('audit store', () => {
     expect(out.truncated).toBe(true);
   });
 
+  it('redacts an open quoted JSON secret before a cap can persist its prefix', () => {
+    const cap = 64;
+    const value = 'J'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 1000);
+    const out = capThenRedact(`{"nested":{"api_token":"${value}"}}`, cap);
+
+    expect(out.text).toContain('"api_token":"<redacted>"');
+    expect(out.text).not.toContain('JJJJ');
+    expect(Buffer.byteLength(out.text, 'utf8')).toBeLessThanOrEqual(cap);
+    expect(out.truncated).toBe(true);
+  });
+
+  it('redacts a quoted attached -p password whose closing quote falls past the scan window', () => {
+    const cap = 64;
+    const value = 'M'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 1000);
+    const out = capThenRedact(`mysql -p"${value}"`, cap);
+
+    expect(out.text).toContain('mysql -p<redacted>');
+    expect(out.text).not.toContain('MMMM');
+    expect(Buffer.byteLength(out.text, 'utf8')).toBeLessThanOrEqual(cap);
+    expect(out.truncated).toBe(true);
+  });
+
+  it('redacts a URL userinfo password whose at-sign falls past the scan window', () => {
+    const cap = 64;
+    const password = 'U'.repeat(cap + REDACT_SCAN_HEADROOM_BYTES + 1000);
+    const out = capThenRedact(`clone https://alice:${password}@example.com/repo.git`, cap);
+
+    expect(out.text).toContain('https://alice:<redacted>@example.com');
+    expect(out.text).not.toContain('UUUU');
+    expect(Buffer.byteLength(out.text, 'utf8')).toBeLessThanOrEqual(cap);
+  });
+
   it('caps and redacts profile names before serializing records', () => {
     const secret = 'ghp_' + 'P'.repeat(36);
     const rec = buildRecord({

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -22,27 +22,52 @@
 
 const REDACTED = '<redacted>';
 
+const SECRET_FLAG = String.raw`(?:password|passwd|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer)`;
+const SECRET_KEY = String.raw`[A-Za-z0-9_.-]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[A-Za-z0-9_.-]*`;
+const SHELL_SECRET_KEY = String.raw`[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET)[A-Z0-9_]*`;
+const DQ_VALUE = String.raw`"(?:[^"\\]|\\.)*"`;
+const SQ_VALUE = String.raw`'(?:[^'\\]|\\.)*'`;
+const OPEN_DQ_VALUE = String.raw`"(?:[^"\\]|\\.)*$`;
+const OPEN_SQ_VALUE = String.raw`'(?:[^'\\]|\\.)*$`;
+
 // 1a. --password=VALUE (and friends), value can be quoted or bare.
-const CLI_LONG_EQ_RE =
-  /(--(?:password|passwd|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer)\s*=)\s*(?:"[^"]*"|'[^']*'|\S+)/gi;
+// Open-quoted fallbacks must run before the normal rules: if a cap removes the
+// closing delimiter, the normal `\S+` fallback would redact only the first
+// whitespace-delimited chunk and leave the rest of the secret prefix persisted.
+const CLI_LONG_EQ_OPEN_QUOTED_RE = new RegExp(
+  String.raw`(--${SECRET_FLAG}\s*=)\s*(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  'gi',
+);
+const CLI_LONG_EQ_RE = new RegExp(
+  String.raw`(--${SECRET_FLAG}\s*=)\s*(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
+  'gi',
+);
 
 // 1b. --password VALUE (space-separated)
-const CLI_LONG_SPACE_RE =
-  /(--(?:password|passwd|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer))\s+(?:"[^"]*"|'[^']*'|\S+)/gi;
+const CLI_LONG_SPACE_OPEN_QUOTED_RE = new RegExp(
+  String.raw`(--${SECRET_FLAG})\s+(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  'gi',
+);
+const CLI_LONG_SPACE_RE = new RegExp(
+  String.raw`(--${SECRET_FLAG})\s+(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
+  'gi',
+);
 
 // 1c. -p VALUE  (MySQL-style short flag).
-const CLI_SHORT_P_RE = /(^|\s)(-p)\s+(?:"[^"]*"|'[^']*'|[^\s]+)/g;
+const CLI_SHORT_P_RE = new RegExp(String.raw`(^|\s)(-p)\s+(?:${DQ_VALUE}|${SQ_VALUE}|[^\s]+)`, 'g');
 
 // 1d. -p"VALUE" / -p'VALUE' — quote *after* -p, value may contain whitespace.
 //     `mysql -p"secret with space"` / `mysql -p'secret with space'`. The
 //     attached rule below only accepts non-space chars, so quoted attached
 //     values with spaces would otherwise bypass redaction.
-const CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE =
-  /(^|\s)-p("(?:[^"\\]|\\.)*"|'[^']*')/g;
+const CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE = new RegExp(
+  String.raw`(^|\s)-p(${DQ_VALUE}|${SQ_VALUE})`,
+  'g',
+);
 
 // 1e. "-pVALUE" / '-pVALUE' — whole arg quoted (quote *before* -p), value may
 //     contain whitespace. `mysql '-psecret with space'` / `"-psecret with space"`.
-const CLI_SHORT_P_QUOTED_ARG_RE = /(^|\s)(["'])-p[^"']*\2/g;
+const CLI_SHORT_P_QUOTED_ARG_RE = /(^|\s)("-p(?:[^"\\]|\\.)*"|'-p(?:[^'\\]|\\.)*')/g;
 
 // 1f. -pVALUE / "-pVALUE" / '-pVALUE' (MySQL attached password form, no space).
 const CLI_SHORT_P_ATTACHED_RE = /(^|\s)(["']?)-p([^\s"']+)(\2)/g;
@@ -52,20 +77,38 @@ const AUTH_HEADER_RE =
   /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_\-\.=+\/]+)/gi;
 
 // 2. Shell env-style assignment, e.g. MY_PASSWORD=foo or API_TOKEN='x y'.
-const SHELL_ASSIGN_RE =
-  /\b([A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET)[A-Z0-9_]*)=(?:"[^"]*"|'[^']*'|\S+)/g;
+const SHELL_ASSIGN_OPEN_QUOTED_RE = new RegExp(
+  String.raw`\b(${SHELL_SECRET_KEY}=)\s*(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  'g',
+);
+const SHELL_ASSIGN_RE = new RegExp(
+  String.raw`\b(${SHELL_SECRET_KEY}=)(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
+  'g',
+);
 
 // 3. JSON / TOML "key": "value" (case-insensitive).
 const JSON_KV_RE =
   /("[^"\\]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*"/gi;
 
 // 3b. TOML / dotenv bare keys: password = "value", token='value'.
-const BARE_KV_RE =
-  /\b([A-Za-z0-9_.-]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[A-Za-z0-9_.-]*\s*[:=]\s*)(?:"[^"]*"|'[^']*'|\S+)/gi;
+const BARE_KV_OPEN_QUOTED_RE = new RegExp(
+  String.raw`\b(${SECRET_KEY}\s*[:=]\s*)(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  'gi',
+);
+const BARE_KV_RE = new RegExp(
+  String.raw`\b(${SECRET_KEY}\s*[:=]\s*)(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
+  'gi',
+);
 
 // 3c. Human prose: "password hunter2", "token abc".
-const SIMPLE_SECRET_WORD_RE =
-  /\b(password|passwd|secret|token)\s+(?:"[^"]*"|'[^']*'|\S+)/gi;
+const SIMPLE_SECRET_WORD_OPEN_QUOTED_RE = new RegExp(
+  String.raw`\b(password|passwd|secret|token)\s+(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  'gi',
+);
+const SIMPLE_SECRET_WORD_RE = new RegExp(
+  String.raw`\b(password|passwd|secret|token)\s+(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
+  'gi',
+);
 
 // 4. PEM private-key blocks.
 const PEM_RE =
@@ -112,20 +155,25 @@ interface Rule {
 }
 
 const RULES: Rule[] = [
+  { re: CLI_LONG_EQ_OPEN_QUOTED_RE, replace: (_m, key) => `${key}${REDACTED}` },
   { re: CLI_LONG_EQ_RE, replace: (_m, key) => `${key}${REDACTED}` },
+  { re: CLI_LONG_SPACE_OPEN_QUOTED_RE, replace: (_m, key) => `${key} ${REDACTED}` },
   { re: CLI_LONG_SPACE_RE, replace: (_m, key) => `${key} ${REDACTED}` },
   { re: CLI_SHORT_P_RE, replace: (_m, lead, flag) => `${lead}${flag} ${REDACTED}` },
   // Quoted attached -p forms (value may contain whitespace) must run before the
   // plain attached rule, which only consumes non-space chars.
   { re: CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE, replace: (_m, lead, val) => `${lead}-p${val[0]}${REDACTED}${val[0]}` },
-  { re: CLI_SHORT_P_QUOTED_ARG_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
+  { re: CLI_SHORT_P_QUOTED_ARG_RE, replace: (_m, lead, arg) => `${lead}${arg[0]}-p${REDACTED}${arg[0]}` },
   { re: CLI_SHORT_P_ATTACHED_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
   { re: AUTH_HEADER_RE, replace: (_m, hdr, scheme) => `${hdr}${scheme} ${REDACTED}` },
   // URL userinfo password: keep scheme://user, drop the password, keep @host.
   { re: URL_USERINFO_RE, replace: (_m, head, _pw, at) => `${head}${REDACTED}${at}` },
-  { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}=${REDACTED}` },
+  { re: SHELL_ASSIGN_OPEN_QUOTED_RE, replace: (_m, key) => `${key}${REDACTED}` },
+  { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}${REDACTED}` },
   { re: JSON_KV_RE, replace: (_m, head) => `${head}"${REDACTED}"` },
+  { re: BARE_KV_OPEN_QUOTED_RE, replace: (_m, head) => `${head}${REDACTED}` },
   { re: BARE_KV_RE, replace: (_m, head) => `${head}${REDACTED}` },
+  { re: SIMPLE_SECRET_WORD_OPEN_QUOTED_RE, replace: (_m, word) => `${word} ${REDACTED}` },
   { re: SIMPLE_SECRET_WORD_RE, replace: (_m, word) => `${word} ${REDACTED}` },
   // Complete PEM blocks first, then any dangling BEGIN with no reachable END
   // (truncated pasted key / here-doc). Applying the dangling rule in the main

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -33,10 +33,21 @@ const CLI_LONG_SPACE_RE =
 // 1c. -p VALUE  (MySQL-style short flag).
 const CLI_SHORT_P_RE = /(^|\s)(-p)\s+(?:"[^"]*"|'[^']*'|[^\s]+)/g;
 
-// 1d. -pVALUE / "-pVALUE" / '-pVALUE' (MySQL attached password form).
+// 1d. -p"VALUE" / -p'VALUE' — quote *after* -p, value may contain whitespace.
+//     `mysql -p"secret with space"` / `mysql -p'secret with space'`. The
+//     attached rule below only accepts non-space chars, so quoted attached
+//     values with spaces would otherwise bypass redaction.
+const CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE =
+  /(^|\s)-p("(?:[^"\\]|\\.)*"|'[^']*')/g;
+
+// 1e. "-pVALUE" / '-pVALUE' — whole arg quoted (quote *before* -p), value may
+//     contain whitespace. `mysql '-psecret with space'` / `"-psecret with space"`.
+const CLI_SHORT_P_QUOTED_ARG_RE = /(^|\s)(["'])-p[^"']*\2/g;
+
+// 1f. -pVALUE / "-pVALUE" / '-pVALUE' (MySQL attached password form, no space).
 const CLI_SHORT_P_ATTACHED_RE = /(^|\s)(["']?)-p([^\s"']+)(\2)/g;
 
-// 1e. Authorization: Bearer ***  / Authorization: Basic ***
+// 1g. Authorization: Bearer ***  / Authorization: Basic ***
 const AUTH_HEADER_RE =
   /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_\-\.=+\/]+)/gi;
 
@@ -59,6 +70,12 @@ const SIMPLE_SECRET_WORD_RE =
 // 4. PEM private-key blocks.
 const PEM_RE =
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
+
+// 4b. Dangling PEM private-key header with no matching END terminator — e.g. a
+//     key whose `END` marker was truncated away or falls past a bounded scan
+//     window. Redact from the BEGIN marker to end-of-string so raw key material
+//     can never persist when the terminator is unreachable.
+const PEM_OPEN_RE = /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*$/g;
 
 // 5. AWS access-key-id
 const AWS_ACCESS_KEY_RE = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
@@ -90,6 +107,10 @@ const RULES: Rule[] = [
   { re: CLI_LONG_EQ_RE, replace: (_m, key) => `${key}${REDACTED}` },
   { re: CLI_LONG_SPACE_RE, replace: (_m, key) => `${key} ${REDACTED}` },
   { re: CLI_SHORT_P_RE, replace: (_m, lead, flag) => `${lead}${flag} ${REDACTED}` },
+  // Quoted attached -p forms (value may contain whitespace) must run before the
+  // plain attached rule, which only consumes non-space chars.
+  { re: CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE, replace: (_m, lead, val) => `${lead}-p${val[0]}${REDACTED}${val[0]}` },
+  { re: CLI_SHORT_P_QUOTED_ARG_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
   { re: CLI_SHORT_P_ATTACHED_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
   { re: AUTH_HEADER_RE, replace: (_m, hdr, scheme) => `${hdr}${scheme} ${REDACTED}` },
   { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}=${REDACTED}` },
@@ -112,6 +133,28 @@ export function redact(input: string | undefined | null): string {
     out = out.replace(rule.re as RegExp, rule.replace as any);
   }
   return out;
+}
+
+/**
+ * Redact PEM private-key blocks over the FULL input, independent of any
+ * downstream byte cap.
+ *
+ * `PEM_RE` is terminator-anchored (`BEGIN...END`), so a key whose `END` marker
+ * falls past a bounded pre-redaction scan window would never match and its raw
+ * prefix could persist in the capped audit output. Callers that cap before
+ * redacting (see `capThenRedact`) must run this on the un-capped text first:
+ *   1. Redact every complete `BEGIN...END` block.
+ *   2. Redact any remaining dangling `BEGIN` with no reachable `END` (truncated
+ *      key / terminator beyond the buffer) all the way to end-of-string.
+ *
+ * Scanning the full output with a single BEGIN-anchored regex is cheap when no
+ * key is present (fast literal prefix scan, no backtracking); the cost is only
+ * paid when key material actually exists — which is exactly when it must be
+ * redacted.
+ */
+export function redactPemBlocks(input: string | undefined | null): string {
+  if (!input) return '';
+  return input.replace(PEM_RE, REDACTED).replace(PEM_OPEN_RE, REDACTED);
 }
 
 export const REDACTED_PLACEHOLDER = REDACTED;

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -22,9 +22,9 @@
 
 const REDACTED = '<redacted>';
 
-const SECRET_FLAG = String.raw`(?:password|passwd|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer)`;
-const SECRET_KEY = String.raw`[A-Za-z0-9_.-]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[A-Za-z0-9_.-]*`;
-const SHELL_SECRET_KEY = String.raw`[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET)[A-Z0-9_]*`;
+const SECRET_FLAG = String.raw`(?:password|passwd|passphrase|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer)`;
+const SECRET_KEY = String.raw`[A-Za-z0-9_.-]*(?:password|passwd|passphrase|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[A-Za-z0-9_.-]*`;
+const SHELL_SECRET_KEY = String.raw`[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|PASSPHRASE|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET)[A-Z0-9_]*`;
 const DQ_VALUE = String.raw`"(?:[^"\\]|\\.)*"`;
 const SQ_VALUE = String.raw`'(?:[^'\\]|\\.)*'`;
 const OPEN_DQ_VALUE = String.raw`"(?:[^"\\]|\\.)*$`;
@@ -60,6 +60,10 @@ const CLI_SHORT_P_RE = new RegExp(String.raw`(^|\s)(-p)\s+(?:${DQ_VALUE}|${SQ_VA
 //     `mysql -p"secret with space"` / `mysql -p'secret with space'`. The
 //     attached rule below only accepts non-space chars, so quoted attached
 //     values with spaces would otherwise bypass redaction.
+const CLI_SHORT_P_ATTACHED_OPEN_QUOTED_VALUE_RE = new RegExp(
+  String.raw`(^|\s)-p(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  'g',
+);
 const CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE = new RegExp(
   String.raw`(^|\s)-p(${DQ_VALUE}|${SQ_VALUE})`,
   'g',
@@ -74,7 +78,7 @@ const CLI_SHORT_P_ATTACHED_RE = /(^|\s)(["']?)-p([^\s"']+)(\2)/g;
 
 // 1g. Authorization: Bearer ***  / Authorization: Basic ***
 const AUTH_HEADER_RE =
-  /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_\-\.=+\/]+)/gi;
+  /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_~\-\.=+\/]+)/gi;
 
 // 2. Shell env-style assignment, e.g. MY_PASSWORD=foo or API_TOKEN='x y'.
 const SHELL_ASSIGN_OPEN_QUOTED_RE = new RegExp(
@@ -87,8 +91,10 @@ const SHELL_ASSIGN_RE = new RegExp(
 );
 
 // 3. JSON / TOML "key": "value" (case-insensitive).
+const JSON_KV_OPEN_QUOTED_RE =
+  /("[^"\\]*(?:password|passwd|passphrase|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*$/gi;
 const JSON_KV_RE =
-  /("[^"\\]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*"/gi;
+  /("[^"\\]*(?:password|passwd|passphrase|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*"/gi;
 
 // 3b. TOML / dotenv bare keys: password = "value", token='value'.
 const BARE_KV_OPEN_QUOTED_RE = new RegExp(
@@ -102,11 +108,11 @@ const BARE_KV_RE = new RegExp(
 
 // 3c. Human prose: "password hunter2", "token abc".
 const SIMPLE_SECRET_WORD_OPEN_QUOTED_RE = new RegExp(
-  String.raw`\b(password|passwd|secret|token)\s+(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
+  String.raw`\b(password|passwd|passphrase|secret|token)\s+(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`,
   'gi',
 );
 const SIMPLE_SECRET_WORD_RE = new RegExp(
-  String.raw`\b(password|passwd|secret|token)\s+(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
+  String.raw`\b(password|passwd|passphrase|secret|token)\s+(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`,
   'gi',
 );
 
@@ -149,6 +155,14 @@ const GOOGLE_API_KEY_RE = /\bAIza[0-9A-Za-z_\-]{35}\b/g;
 const URL_USERINFO_RE =
   /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s:/@]+:)([^\s/@]+)(@)/g;
 
+function redactUrlUserinfo(input: string): string {
+  // Avoid running the scheme regex over arbitrarily large non-URL output. A
+  // quick literal search is linear and lets the full-input pre-redaction path
+  // return immediately for the overwhelmingly common no-URL case.
+  if (!input.includes('://')) return input;
+  return input.replace(URL_USERINFO_RE, (_m, head, _pw, at) => `${head}${REDACTED}${at}`);
+}
+
 interface Rule {
   re: RegExp;
   replace: string | ((substring: string, ...groups: string[]) => string);
@@ -162,6 +176,7 @@ const RULES: Rule[] = [
   { re: CLI_SHORT_P_RE, replace: (_m, lead, flag) => `${lead}${flag} ${REDACTED}` },
   // Quoted attached -p forms (value may contain whitespace) must run before the
   // plain attached rule, which only consumes non-space chars.
+  { re: CLI_SHORT_P_ATTACHED_OPEN_QUOTED_VALUE_RE, replace: (_m, lead) => `${lead}-p${REDACTED}` },
   { re: CLI_SHORT_P_ATTACHED_QUOTED_VALUE_RE, replace: (_m, lead, val) => `${lead}-p${val[0]}${REDACTED}${val[0]}` },
   { re: CLI_SHORT_P_QUOTED_ARG_RE, replace: (_m, lead, arg) => `${lead}${arg[0]}-p${REDACTED}${arg[0]}` },
   { re: CLI_SHORT_P_ATTACHED_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
@@ -170,6 +185,7 @@ const RULES: Rule[] = [
   { re: URL_USERINFO_RE, replace: (_m, head, _pw, at) => `${head}${REDACTED}${at}` },
   { re: SHELL_ASSIGN_OPEN_QUOTED_RE, replace: (_m, key) => `${key}${REDACTED}` },
   { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}${REDACTED}` },
+  { re: JSON_KV_OPEN_QUOTED_RE, replace: (_m, head) => `${head}"${REDACTED}"` },
   { re: JSON_KV_RE, replace: (_m, head) => `${head}"${REDACTED}"` },
   { re: BARE_KV_OPEN_QUOTED_RE, replace: (_m, head) => `${head}${REDACTED}` },
   { re: BARE_KV_RE, replace: (_m, head) => `${head}${REDACTED}` },
@@ -226,14 +242,16 @@ export function redactPemBlocks(input: string | undefined | null): string {
  *
  * `capThenRedact` bounds the bytes the general redaction rules scan to
  * `cap + REDACT_SCAN_HEADROOM_BYTES` so a multi-MB stdout doesn't pay full
- * regex cost. But two secret shapes can legitimately exceed that headroom and
+ * But three secret shapes can legitimately exceed that headroom and
  * would be sliced mid-token — leaking a prefix — if only matched inside the
  * bounded window:
  *   - PEM private-key blocks (BEGIN...END), including a dangling BEGIN whose
  *     END terminator falls past the window.
  *   - JWTs, whose signature/claims (cert chains, large payloads) can push the
  *     third segment past the 4 KiB headroom (Codex 3541772953).
- * Both are matched here over the whole input first, so their full extent is
+ *   - URL userinfo passwords, whose `@` delimiter can fall past the bounded
+ *     scan window when the credential is long.
+ * All three are matched here over the whole input first, so their full extent is
  * replaced with `<redacted>` regardless of where the cap lands. The full scan
  * is cheap when neither shape is present (fast literal prefix scan); the cost
  * is paid only when key/token material actually exists — exactly when it must
@@ -241,10 +259,11 @@ export function redactPemBlocks(input: string | undefined | null): string {
  */
 export function preRedactUnboundedTokens(input: string | undefined | null): string {
   if (!input) return '';
-  return input
+  const tokensRedacted = input
     .replace(PEM_RE, REDACTED)
     .replace(PEM_OPEN_RE, REDACTED)
     .replace(JWT_RE, REDACTED);
+  return redactUrlUserinfo(tokensRedacted);
 }
 
 export const REDACTED_PLACEHOLDER = REDACTED;

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -33,7 +33,10 @@ const CLI_LONG_SPACE_RE =
 // 1c. -p VALUE  (MySQL-style short flag).
 const CLI_SHORT_P_RE = /(^|\s)(-p)\s+(?:"[^"]*"|'[^']*'|[^\s]+)/g;
 
-// 1d. Authorization: Bearer <token>  / Authorization: Basic <token>
+// 1d. -pVALUE / "-pVALUE" / '-pVALUE' (MySQL attached password form).
+const CLI_SHORT_P_ATTACHED_RE = /(^|\s)(["']?)-p([^\s"']+)(\2)/g;
+
+// 1e. Authorization: Bearer ***  / Authorization: Basic ***
 const AUTH_HEADER_RE =
   /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_\-\.=+\/]+)/gi;
 
@@ -85,6 +88,7 @@ const RULES: Rule[] = [
   { re: CLI_LONG_EQ_RE, replace: (_m, key) => `${key}${REDACTED}` },
   { re: CLI_LONG_SPACE_RE, replace: (_m, key) => `${key} ${REDACTED}` },
   { re: CLI_SHORT_P_RE, replace: (_m, lead, flag) => `${lead}${flag} ${REDACTED}` },
+  { re: CLI_SHORT_P_ATTACHED_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
   { re: AUTH_HEADER_RE, replace: (_m, hdr, scheme) => `${hdr}${scheme} ${REDACTED}` },
   { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}=${REDACTED}` },
   { re: JSON_KV_RE, replace: (_m, head) => `${head}"${REDACTED}"` },

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -1,0 +1,111 @@
+/**
+ * Secret redactor.
+ *
+ * Applied to `command`, `description`, `stdout`, and `stderr` BEFORE the
+ * audit record is serialized to disk. Rules are intentionally
+ * over-aggressive — false positives ("<redacted>" in normal output) are
+ * vastly preferable to credentials leaking into the JSONL.
+ *
+ * Rule order (each runs on the previous step's output):
+ *   1. CLI flag patterns: `--password=VALUE`, `--token=VALUE`, `-p VALUE`,
+ *      `--api-key=VALUE`, `--secret VALUE`, `Authorization: Bearer ...`.
+ *   2. Inline `KEY=value` env-style pairs (KEY matches PASSWORD/TOKEN/SECRET/...).
+ *   3. JSON / TOML quoted `"key": "value"` pairs for the same key set.
+ *   4. PEM blocks (BEGIN/END *PRIVATE KEY*).
+ *   5. AWS access-key-id shapes (AKIA/ASIA + 16 chars).
+ *   6. AWS secret-access-key when on the same line as a hint.
+ *   7. JWT tokens (three base64url segments).
+ *   8. GitHub PATs (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`).
+ *   9. Slack tokens (`xox[abprs]-...`).
+ *  10. Google API keys (`AIza...`, 39 chars).
+ */
+
+const REDACTED = '<redacted>';
+
+// 1a. --password=VALUE (and friends), value can be quoted or bare.
+const CLI_LONG_EQ_RE =
+  /(--(?:password|passwd|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer)\s*=)\s*(?:"[^"]*"|'[^']*'|\S+)/gi;
+
+// 1b. --password VALUE (space-separated)
+const CLI_LONG_SPACE_RE =
+  /(--(?:password|passwd|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer))\s+(?:"[^"]*"|'[^']*'|\S+)/gi;
+
+// 1c. -p VALUE  (MySQL-style short flag).
+const CLI_SHORT_P_RE = /(^|\s)(-p)\s+(?:"[^"]*"|'[^']*'|[^\s]+)/g;
+
+// 1d. Authorization: Bearer <token>  / Authorization: Basic <token>
+const AUTH_HEADER_RE =
+  /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_\-\.=+\/]+)/gi;
+
+// 2. Shell env-style assignment, e.g. MY_PASSWORD=foo or API_TOKEN='x y'.
+const SHELL_ASSIGN_RE =
+  /\b([A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET)[A-Z0-9_]*)=(?:"[^"]*"|'[^']*'|\S+)/g;
+
+// 3. JSON / TOML "key": "value" (case-insensitive).
+const JSON_KV_RE =
+  /("[^"\\]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*"/gi;
+
+// 3b. TOML / dotenv bare keys: password = "value", token='value'.
+const BARE_KV_RE =
+  /\b([A-Za-z0-9_.-]*(?:password|passwd|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[A-Za-z0-9_.-]*\s*[:=]\s*)(?:"[^"]*"|'[^']*'|\S+)/gi;
+
+// 3c. Human prose: "password hunter2", "token abc".
+const SIMPLE_SECRET_WORD_RE =
+  /\b(password|passwd|secret|token)\s+(?:"[^"]*"|'[^']*'|\S+)/gi;
+
+// 4. PEM private-key blocks.
+const PEM_RE =
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g;
+
+// 5. AWS access-key-id
+const AWS_ACCESS_KEY_RE = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
+
+// 6. AWS secret on the same line as a hint (key=value or similar).
+const AWS_SECRET_HINT_RE =
+  /(aws[_-]?secret[_-]?access[_-]?key\s*[:=]?\s*["']?)([A-Za-z0-9/+]{40})(["']?)/gi;
+
+// 7. JWT (three base64url segments).
+const JWT_RE = /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
+
+// 8. GitHub PATs
+const GITHUB_TOKEN_RE = /\bgh[opusr]_[A-Za-z0-9]{20,255}\b/g;
+
+// 9. Slack tokens
+const SLACK_TOKEN_RE = /\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g;
+
+// 10. Google API keys
+const GOOGLE_API_KEY_RE = /\bAIza[0-9A-Za-z_\-]{35}\b/g;
+
+interface Rule {
+  re: RegExp;
+  replace: string | ((substring: string, ...groups: string[]) => string);
+}
+
+const RULES: Rule[] = [
+  { re: CLI_LONG_EQ_RE, replace: (_m, key) => `${key}${REDACTED}` },
+  { re: CLI_LONG_SPACE_RE, replace: (_m, key) => `${key} ${REDACTED}` },
+  { re: CLI_SHORT_P_RE, replace: (_m, lead, flag) => `${lead}${flag} ${REDACTED}` },
+  { re: AUTH_HEADER_RE, replace: (_m, hdr, scheme) => `${hdr}${scheme} ${REDACTED}` },
+  { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}=${REDACTED}` },
+  { re: JSON_KV_RE, replace: (_m, head) => `${head}"${REDACTED}"` },
+  { re: BARE_KV_RE, replace: (_m, head) => `${head}${REDACTED}` },
+  { re: SIMPLE_SECRET_WORD_RE, replace: (_m, word) => `${word} ${REDACTED}` },
+  { re: PEM_RE, replace: REDACTED },
+  { re: AWS_ACCESS_KEY_RE, replace: REDACTED },
+  { re: AWS_SECRET_HINT_RE, replace: (_m, head, _val, tail) => `${head}${REDACTED}${tail}` },
+  { re: JWT_RE, replace: REDACTED },
+  { re: GITHUB_TOKEN_RE, replace: REDACTED },
+  { re: SLACK_TOKEN_RE, replace: REDACTED },
+  { re: GOOGLE_API_KEY_RE, replace: REDACTED },
+];
+
+export function redact(input: string | undefined | null): string {
+  if (!input) return '';
+  let out = input;
+  for (const rule of RULES) {
+    out = out.replace(rule.re as RegExp, rule.replace as any);
+  }
+  return out;
+}
+
+export const REDACTED_PLACEHOLDER = REDACTED;

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -15,7 +15,7 @@
  *   5. AWS access-key-id shapes (AKIA/ASIA + 16 chars).
  *   6. AWS secret-access-key when on the same line as a hint.
  *   7. JWT tokens (three base64url segments).
- *   8. GitHub PATs (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`).
+ *   8. GitHub PATs (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`, `github_pat_`).
  *   9. Slack tokens (`xox[abprs]-...`).
  *  10. Google API keys (`AIza...`, 39 chars).
  */
@@ -70,8 +70,10 @@ const AWS_SECRET_HINT_RE =
 // 7. JWT (three base64url segments).
 const JWT_RE = /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
 
-// 8. GitHub PATs
-const GITHUB_TOKEN_RE = /\bgh[opusr]_[A-Za-z0-9]{20,255}\b/g;
+// 8. GitHub PATs — classic (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`) and
+//    fine-grained (`github_pat_...`, which embeds underscores in its body).
+const GITHUB_TOKEN_RE =
+  /\b(?:gh[opusr]_[A-Za-z0-9]{20,255}|github_pat_[A-Za-z0-9_]{40,255})\b/g;
 
 // 9. Slack tokens
 const SLACK_TOKEN_RE = /\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g;

--- a/src/audit/redactor.ts
+++ b/src/audit/redactor.ts
@@ -98,6 +98,14 @@ const SLACK_TOKEN_RE = /\bxox[abprs]-[A-Za-z0-9\-]{10,}\b/g;
 // 10. Google API keys
 const GOOGLE_API_KEY_RE = /\bAIza[0-9A-Za-z_\-]{35}\b/g;
 
+// 11. URL userinfo credentials, e.g. https://alice:hunter2@example.com/repo.git
+//     or postgres://user:pass@db:5432/app. Redact ONLY the password component,
+//     preserving scheme, username, and host so the audited URL stays
+//     recognizable. The password is any run of non-`@`, non-`/`, non-`:`,
+//     non-whitespace chars between the `:` after the username and the `@`.
+const URL_USERINFO_RE =
+  /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s:/@]+:)([^\s/@]+)(@)/g;
+
 interface Rule {
   re: RegExp;
   replace: string | ((substring: string, ...groups: string[]) => string);
@@ -113,11 +121,18 @@ const RULES: Rule[] = [
   { re: CLI_SHORT_P_QUOTED_ARG_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
   { re: CLI_SHORT_P_ATTACHED_RE, replace: (_m, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}` },
   { re: AUTH_HEADER_RE, replace: (_m, hdr, scheme) => `${hdr}${scheme} ${REDACTED}` },
+  // URL userinfo password: keep scheme://user, drop the password, keep @host.
+  { re: URL_USERINFO_RE, replace: (_m, head, _pw, at) => `${head}${REDACTED}${at}` },
   { re: SHELL_ASSIGN_RE, replace: (_m, key) => `${key}=${REDACTED}` },
   { re: JSON_KV_RE, replace: (_m, head) => `${head}"${REDACTED}"` },
   { re: BARE_KV_RE, replace: (_m, head) => `${head}${REDACTED}` },
   { re: SIMPLE_SECRET_WORD_RE, replace: (_m, word) => `${word} ${REDACTED}` },
+  // Complete PEM blocks first, then any dangling BEGIN with no reachable END
+  // (truncated pasted key / here-doc). Applying the dangling rule in the main
+  // rule set means command/description text — not just stdout/stderr — is
+  // scrubbed of incomplete key material (Codex 3541772951).
   { re: PEM_RE, replace: REDACTED },
+  { re: PEM_OPEN_RE, replace: REDACTED },
   { re: AWS_ACCESS_KEY_RE, replace: REDACTED },
   { re: AWS_SECRET_HINT_RE, replace: (_m, head, _val, tail) => `${head}${REDACTED}${tail}` },
   { re: JWT_RE, replace: REDACTED },
@@ -155,6 +170,33 @@ export function redact(input: string | undefined | null): string {
 export function redactPemBlocks(input: string | undefined | null): string {
   if (!input) return '';
   return input.replace(PEM_RE, REDACTED).replace(PEM_OPEN_RE, REDACTED);
+}
+
+/**
+ * Pre-redact the token shapes that are NOT bounded by the redactor's fixed scan
+ * headroom, over the FULL (un-capped) text, before any byte cap is applied.
+ *
+ * `capThenRedact` bounds the bytes the general redaction rules scan to
+ * `cap + REDACT_SCAN_HEADROOM_BYTES` so a multi-MB stdout doesn't pay full
+ * regex cost. But two secret shapes can legitimately exceed that headroom and
+ * would be sliced mid-token — leaking a prefix — if only matched inside the
+ * bounded window:
+ *   - PEM private-key blocks (BEGIN...END), including a dangling BEGIN whose
+ *     END terminator falls past the window.
+ *   - JWTs, whose signature/claims (cert chains, large payloads) can push the
+ *     third segment past the 4 KiB headroom (Codex 3541772953).
+ * Both are matched here over the whole input first, so their full extent is
+ * replaced with `<redacted>` regardless of where the cap lands. The full scan
+ * is cheap when neither shape is present (fast literal prefix scan); the cost
+ * is paid only when key/token material actually exists — exactly when it must
+ * be redacted.
+ */
+export function preRedactUnboundedTokens(input: string | undefined | null): string {
+  if (!input) return '';
+  return input
+    .replace(PEM_RE, REDACTED)
+    .replace(PEM_OPEN_RE, REDACTED)
+    .replace(JWT_RE, REDACTED);
 }
 
 export const REDACTED_PLACEHOLDER = REDACTED;

--- a/src/audit/rotator.ts
+++ b/src/audit/rotator.ts
@@ -1,0 +1,116 @@
+/**
+ * Audit log rotation.
+ *
+ * Two triggers:
+ *   1. Day boundary — the active file's name is derived from the UTC date,
+ *      so writes naturally land in a fresh file. The rotator additionally
+ *      prunes files older than `retain` days, regardless of size.
+ *   2. Size cap — when the current file exceeds `maxFileBytes`, it is renamed
+ *      with a numeric suffix (`.1`, `.2`, ...) shifted on each rotation,
+ *      retaining at most `retain` historical files.
+ *
+ * The store calls `rotateIfNeeded` before each append; the rotator is the
+ * single owner of file lifecycle. Synchronous fs calls used deliberately:
+ * the audit volume is small (one line per exec) and serialization avoids
+ * concurrent-rename races.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { DEFAULT_MAX_FILE_BYTES, DEFAULT_RETAIN } from './types.js';
+
+export interface RotateOptions {
+  /** Absolute path to the active file (executions-YYYYMMDD.jsonl). */
+  filePath: string;
+  /** Size cap before rotation. */
+  maxFileBytes?: number;
+  /** Number of rotated files to keep (excluding the active file). */
+  retain?: number;
+}
+
+/**
+ * Rotate `filePath` if its current size on disk is >= maxFileBytes.
+ * Returns the rotation count performed (0 or 1).
+ */
+export function rotateIfNeeded(opts: RotateOptions): number {
+  const maxBytes = opts.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+  const retain = opts.retain ?? DEFAULT_RETAIN;
+
+  let size: number;
+  try {
+    size = fs.statSync(opts.filePath).size;
+  } catch {
+    return 0;
+  }
+  if (size < maxBytes) return 0;
+  rotate(opts.filePath, retain);
+  return 1;
+}
+
+/**
+ * Shift `filePath` → `filePath.1`, `.1` → `.2`, ... , drop tail past `retain`.
+ */
+export function rotate(filePath: string, retain: number = DEFAULT_RETAIN): void {
+  // Walk from the tail down to 0 so we don't clobber.
+  // Step 1: remove `filePath.retain` if it exists.
+  const tail = `${filePath}.${retain}`;
+  if (fs.existsSync(tail)) {
+    fs.unlinkSync(tail);
+  }
+  // Step 2: shift .N -> .N+1 for N in [retain-1 .. 1].
+  for (let n = retain - 1; n >= 1; n--) {
+    const src = `${filePath}.${n}`;
+    const dst = `${filePath}.${n + 1}`;
+    if (fs.existsSync(src)) {
+      fs.renameSync(src, dst);
+    }
+  }
+  // Step 3: move active -> .1.
+  if (fs.existsSync(filePath)) {
+    fs.renameSync(filePath, `${filePath}.1`);
+  }
+}
+
+/**
+ * Prune day-rolled files older than `retainDays` from the audit directory.
+ * Returns paths removed.
+ */
+export function pruneOldDays(
+  auditDir: string,
+  retainDays: number = DEFAULT_RETAIN,
+): string[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(auditDir);
+  } catch {
+    return [];
+  }
+  const re = /^executions-(\d{8})\.jsonl(?:\.\d+)?$/;
+  const dates: { date: string; file: string }[] = [];
+  for (const name of entries) {
+    const m = re.exec(name);
+    if (m) dates.push({ date: m[1], file: name });
+  }
+  if (dates.length === 0) return [];
+  dates.sort((a, b) => b.date.localeCompare(a.date)); // newest first
+  // Keep distinct dates up to retainDays; remove anything older.
+  const keepDates = new Set<string>();
+  for (const d of dates) {
+    keepDates.add(d.date);
+    if (keepDates.size >= retainDays) break;
+  }
+  const removed: string[] = [];
+  for (const d of dates) {
+    if (!keepDates.has(d.date)) {
+      const p = path.join(auditDir, d.file);
+      try {
+        fs.unlinkSync(p);
+        removed.push(p);
+      } catch {
+        // best-effort
+      }
+    }
+  }
+  return removed;
+}

--- a/src/audit/rotator.ts
+++ b/src/audit/rotator.ts
@@ -74,11 +74,24 @@ export function rotate(filePath: string, retain: number = DEFAULT_RETAIN): void 
 
 /**
  * Prune day-rolled files older than `retainDays` from the audit directory.
- * Returns paths removed.
+ *
+ * Retention is by AGE, not by count of distinct dates: a file is removed when
+ * its embedded date is strictly older than the cutoff (`asOf` minus
+ * `retainDays - 1` days, so the cutoff window always includes today plus the
+ * previous `retainDays - 1` calendar days). This guarantees data never lives
+ * past the advertised window even when usage has gaps — e.g. with retain=10, an
+ * `executions-20260501.jsonl` file is pruned once "today" is 2026-07-01 even
+ * though only two distinct dates exist on disk. Rotated siblings
+ * (`.jsonl.1`, `.jsonl.2`, ...) share the active file's date and are pruned
+ * with it.
+ *
+ * `asOf` defaults to the current date; callers pass the append date so pruning
+ * is anchored to the write that triggered it. Returns paths removed.
  */
 export function pruneOldDays(
   auditDir: string,
   retainDays: number = DEFAULT_RETAIN,
+  asOf: Date = new Date(),
 ): string[] {
   let entries: string[];
   try {
@@ -87,23 +100,25 @@ export function pruneOldDays(
     return [];
   }
   const re = /^executions-(\d{8})\.jsonl(?:\.\d+)?$/;
-  const dates: { date: string; file: string }[] = [];
+  // Cutoff = asOf - (retainDays - 1) days, as a YYYYMMDD stamp. Files whose
+  // date stamp is lexicographically < cutoff are outside the window. String
+  // comparison is valid because YYYYMMDD is zero-padded and monotonic.
+  const keep = Math.max(1, Math.floor(retainDays));
+  const cutoffDate = new Date(
+    Date.UTC(asOf.getUTCFullYear(), asOf.getUTCMonth(), asOf.getUTCDate()) -
+      (keep - 1) * 24 * 60 * 60 * 1000,
+  );
+  const cy = cutoffDate.getUTCFullYear().toString().padStart(4, '0');
+  const cm = (cutoffDate.getUTCMonth() + 1).toString().padStart(2, '0');
+  const cd = cutoffDate.getUTCDate().toString().padStart(2, '0');
+  const cutoffStamp = `${cy}${cm}${cd}`;
+
+  const removed: string[] = [];
   for (const name of entries) {
     const m = re.exec(name);
-    if (m) dates.push({ date: m[1], file: name });
-  }
-  if (dates.length === 0) return [];
-  dates.sort((a, b) => b.date.localeCompare(a.date)); // newest first
-  // Keep distinct dates up to retainDays; remove anything older.
-  const keepDates = new Set<string>();
-  for (const d of dates) {
-    keepDates.add(d.date);
-    if (keepDates.size >= retainDays) break;
-  }
-  const removed: string[] = [];
-  for (const d of dates) {
-    if (!keepDates.has(d.date)) {
-      const p = path.join(auditDir, d.file);
+    if (!m) continue;
+    if (m[1] < cutoffStamp) {
+      const p = path.join(auditDir, name);
       try {
         fs.unlinkSync(p);
         removed.push(p);

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -79,6 +79,47 @@ export function capUtf8(s: string, maxBytes: number): { text: string; truncated:
   return { text: buf.slice(0, end).toString('utf8'), truncated: true };
 }
 
+/**
+ * Headroom (bytes) scanned by the redactor beyond the final output cap.
+ *
+ * Bounded so a single secret token that *begins* within the retained `cap`
+ * window is still fully present for the redactor to match, even if it
+ * straddles the cap boundary — without paying redaction CPU/memory over an
+ * unbounded (multi-MB) raw stdout/stderr. 4 KiB comfortably covers every
+ * single-token shape the redactor knows (GitHub PAT ≤255, JWT, AWS, Google,
+ * Slack) and a full RSA/ed25519 PEM private-key block.
+ */
+export const REDACT_SCAN_HEADROOM_BYTES = 4096;
+
+/**
+ * Bound, then redact, then cap — in that order.
+ *
+ * The naive `capUtf8(redact(s), cap)` redacts the *entire* raw string before
+ * truncation, so a megabyte of command output pays full regex cost even
+ * though only `cap` bytes survive. Here we first cap the raw text to
+ * `cap + REDACT_SCAN_HEADROOM_BYTES` (the bytes the redactor is allowed to
+ * scan), redact that bounded slice, then cap the redacted result to `cap`.
+ * The headroom guarantees a token whose prefix lands inside the kept window
+ * is matched in full (and thus replaced with `<redacted>`) rather than being
+ * sliced mid-token into a partial-secret leak.
+ *
+ * The reported `truncated` flag is true if bytes were dropped at *either*
+ * stage, preserving the semantics of the previous cap-after-redact path.
+ */
+export function capThenRedact(
+  s: string,
+  cap: number,
+): { text: string; truncated: boolean } {
+  if (cap <= 0) return { text: '', truncated: s.length > 0 };
+  // 1. Bound the bytes the redactor scans.
+  const scan = capUtf8(s, cap + REDACT_SCAN_HEADROOM_BYTES);
+  // 2. Redact within the bounded window.
+  const redacted = redact(scan.text);
+  // 3. Cap the redacted text to the final size.
+  const final = capUtf8(redacted, cap);
+  return { text: final.text, truncated: scan.truncated || final.truncated };
+}
+
 export interface BuildRecordInput {
   profile: string;
   tool: AuditTool;
@@ -116,8 +157,8 @@ export function buildRecord(input: BuildRecordInput): AuditRecord {
   };
 
   if (input.exec) {
-    const so = capUtf8(redact(input.exec.stdout), cap);
-    const se = capUtf8(redact(input.exec.stderr), cap);
+    const so = capThenRedact(input.exec.stdout, cap);
+    const se = capThenRedact(input.exec.stderr, cap);
     const execSection: AuditExecSection = {
       exit_code: input.exec.exitCode,
       duration_ms: input.exec.durationMs,
@@ -146,7 +187,15 @@ export class AuditStore {
     this.auditMaxBytes = cfg.auditMaxBytes ?? DEFAULT_AUDIT_MAX_BYTES;
     this.maxFileBytes = cfg.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
     this.retain = cfg.retain ?? DEFAULT_RETAIN;
-    fs.mkdirSync(this.auditDir, { recursive: true });
+    // Audit logs contain command lines + captured output; keep them
+    // owner-only. mkdir mode is masked by umask, so chmod afterwards to
+    // enforce 0700 on both freshly-created and pre-existing directories.
+    fs.mkdirSync(this.auditDir, { recursive: true, mode: 0o700 });
+    try {
+      fs.chmodSync(this.auditDir, 0o700);
+    } catch {
+      // best-effort: dir may live on a filesystem that ignores chmod
+    }
   }
 
   /** Build + write a record. Returns the written record (after redaction/capping). */
@@ -162,7 +211,19 @@ export class AuditStore {
     });
 
     const line = JSON.stringify(rec) + '\n';
-    fs.appendFileSync(filePath, line, { encoding: 'utf8' });
+    // Owner-only (0600). The mode option only applies when the file is
+    // created, and is masked by umask; chmod on first create enforces it
+    // even under a permissive umask. Existing files keep their mode across
+    // appends (no per-append chmod syscall on the hot path).
+    const existedBefore = fs.existsSync(filePath);
+    fs.appendFileSync(filePath, line, { encoding: 'utf8', mode: 0o600 });
+    if (!existedBefore) {
+      try {
+        fs.chmodSync(filePath, 0o600);
+      } catch {
+        // best-effort
+      }
+    }
 
     const stamp = utcDateStamp(now);
     if (this.lastPruneStamp !== stamp) {

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -105,6 +105,14 @@ export const REDACT_SCAN_HEADROOM_BYTES = 4096;
 export const AUDIT_COMMAND_MIN_CAP_BYTES = 16384;
 
 /**
+ * Hard cap for short audit metadata labels such as `profile` / connectionName.
+ * These fields originate from user-provided config or tool arguments on some
+ * error paths, so cap+redact them before JSONL serialization to avoid a
+ * rejected unknown-name request appending multi-MB records.
+ */
+export const AUDIT_PROFILE_MAX_BYTES = 1024;
+
+/**
  * Bound, then redact, then cap — in that order.
  *
  * The naive `capUtf8(redact(s), cap)` redacts the *entire* raw string before
@@ -199,7 +207,7 @@ export function buildRecord(input: BuildRecordInput): AuditRecord {
   const rec: AuditRecord = {
     ts: now.toISOString(),
     id: newRecordId(now),
-    profile: input.profile,
+    profile: capThenRedact(input.profile, AUDIT_PROFILE_MAX_BYTES).text,
     tool: input.tool,
     command,
     description,

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -29,7 +29,7 @@ import {
   DEFAULT_MAX_FILE_BYTES,
   DEFAULT_RETAIN,
 } from './types.js';
-import { redact } from './redactor.js';
+import { redact, redactPemBlocks } from './redactor.js';
 import { rotateIfNeeded, pruneOldDays } from './rotator.js';
 
 /** Resolve audit directory, expanding `~` and honoring env override. */
@@ -111,12 +111,22 @@ export function capThenRedact(
   cap: number,
 ): { text: string; truncated: boolean } {
   if (cap <= 0) return { text: '', truncated: s.length > 0 };
-  // 1. Bound the bytes the redactor scans.
-  const scan = capUtf8(s, cap + REDACT_SCAN_HEADROOM_BYTES);
+  // 0. Redact PEM private-key blocks over the FULL text first. PEM_RE is
+  //    terminator-anchored, so a key whose `END` marker falls past the bounded
+  //    scan window below would otherwise never match and its raw prefix could
+  //    survive into the capped output. This full-scan is cheap when no key is
+  //    present and is the only rule that must see the un-capped string.
+  const pemSafe = redactPemBlocks(s);
+  // 1. Bound the bytes the remaining redaction rules scan.
+  const scan = capUtf8(pemSafe, cap + REDACT_SCAN_HEADROOM_BYTES);
   // 2. Redact within the bounded window.
   const redacted = redact(scan.text);
   // 3. Cap the redacted text to the final size.
   const final = capUtf8(redacted, cap);
+  // `truncated` is measured on the PEM-safe text: it reports whether real
+  // *content* bytes were dropped by the cap, not the raw pre-redaction length.
+  // A key that was fully replaced with `<redacted>` lost nothing to the cap, so
+  // it is not "truncated"; genuine oversized output past the window still is.
   return { text: final.text, truncated: scan.truncated || final.truncated };
 }
 

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -29,7 +29,7 @@ import {
   DEFAULT_MAX_FILE_BYTES,
   DEFAULT_RETAIN,
 } from './types.js';
-import { redact, redactPemBlocks } from './redactor.js';
+import { redact, preRedactUnboundedTokens } from './redactor.js';
 import { rotateIfNeeded, pruneOldDays } from './rotator.js';
 
 /** Resolve audit directory, expanding `~` and honoring env override. */
@@ -92,6 +92,19 @@ export function capUtf8(s: string, maxBytes: number): { text: string; truncated:
 export const REDACT_SCAN_HEADROOM_BYTES = 4096;
 
 /**
+ * Floor (bytes) for the command/description audit cap.
+ *
+ * The command is capped so a rejected multi-MB payload cannot force expensive
+ * redaction plus a large JSONL append (Codex 3541772945). But the cap must not
+ * be the (possibly tiny) stdout/stderr `auditMaxBytes` — a legitimate command
+ * is short and must survive even when output capture is set to a few bytes. So
+ * the effective command cap is `max(auditMaxBytes, this floor)`: honor a larger
+ * configured output cap, never drop below a bound generous enough to hold any
+ * realistic command line, while still bounding a genuine multi-MB DoS payload.
+ */
+export const AUDIT_COMMAND_MIN_CAP_BYTES = 16384;
+
+/**
  * Bound, then redact, then cap — in that order.
  *
  * The naive `capUtf8(redact(s), cap)` redacts the *entire* raw string before
@@ -111,14 +124,15 @@ export function capThenRedact(
   cap: number,
 ): { text: string; truncated: boolean } {
   if (cap <= 0) return { text: '', truncated: s.length > 0 };
-  // 0. Redact PEM private-key blocks over the FULL text first. PEM_RE is
-  //    terminator-anchored, so a key whose `END` marker falls past the bounded
-  //    scan window below would otherwise never match and its raw prefix could
-  //    survive into the capped output. This full-scan is cheap when no key is
-  //    present and is the only rule that must see the un-capped string.
-  const pemSafe = redactPemBlocks(s);
+  // 0. Pre-redact the UNBOUNDED token shapes over the FULL text first. PEM_RE is
+  //    terminator-anchored and JWTs can carry large claims/cert chains, so a key
+  //    or token whose end falls past the bounded scan window below would
+  //    otherwise never fully match and its raw prefix could survive into the
+  //    capped output. This full-scan is cheap when none are present and is the
+  //    only step that must see the un-capped string (Codex 3541772953).
+  const preRedacted = preRedactUnboundedTokens(s);
   // 1. Bound the bytes the remaining redaction rules scan.
-  const scan = capUtf8(pemSafe, cap + REDACT_SCAN_HEADROOM_BYTES);
+  const scan = capUtf8(preRedacted, cap + REDACT_SCAN_HEADROOM_BYTES);
   // 2. Redact within the bounded window.
   const redacted = redact(scan.text);
   // 3. Cap the redacted text to the final size.
@@ -169,13 +183,26 @@ export function buildRecord(input: BuildRecordInput): AuditRecord {
   const now = input.now ?? new Date();
   const cap = input.auditMaxBytes ?? DEFAULT_AUDIT_MAX_BYTES;
 
+  // Cap the command/description so a rejected multi-MB payload cannot force
+  // expensive redaction plus a large JSONL append, bypassing the size guard
+  // (Codex 3541772945). Use max(cap, floor) so a legitimate short command still
+  // survives when the stdout/stderr auditMaxBytes is set very small, while a
+  // genuine oversized command is still bounded. capThenRedact pre-redacts
+  // unbounded key/token shapes over the full text before truncating. The same
+  // auditCommand pattern feeds the sudo/helper paths.
+  const cmdCap = Math.max(cap, AUDIT_COMMAND_MIN_CAP_BYTES);
+  const command = capThenRedact(input.command, cmdCap).text;
+  const description = input.description
+    ? capThenRedact(input.description, cmdCap).text
+    : undefined;
+
   const rec: AuditRecord = {
     ts: now.toISOString(),
     id: newRecordId(now),
     profile: input.profile,
     tool: input.tool,
-    command: redact(input.command),
-    description: input.description ? redact(input.description) : undefined,
+    command,
+    description,
     approval: {
       mode: input.approval.mode,
       decision: input.approval.decision,

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -253,7 +253,7 @@ export class AuditStore {
     if (this.lastPruneStamp !== stamp) {
       this.lastPruneStamp = stamp;
       try {
-        pruneOldDays(this.auditDir, this.retain);
+        pruneOldDays(this.auditDir, this.retain, now);
       } catch {
         // best-effort
       }

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -120,6 +120,25 @@ export function capThenRedact(
   return { text: final.text, truncated: scan.truncated || final.truncated };
 }
 
+/**
+ * Clamp a numeric config value to a safe integer.
+ *
+ * Returns `fallback` when `v` is undefined/null, non-finite (NaN, Infinity,
+ * -Infinity), or below `minValid`; otherwise floors `v` to an integer. Guards
+ * the store against surprising behavior from bad config — a negative
+ * auditMaxBytes that empties output, a NaN/negative maxFileBytes that rotates
+ * on every append, or retain <= 0 that breaks rotation/prune all collapse to
+ * the documented default instead. `minValid` is the smallest *explicitly
+ * honored* value (0 for auditMaxBytes so "capture nothing" is respected; 1 for
+ * maxFileBytes/retain).
+ */
+export function clampInt(v: number | undefined | null, fallback: number, minValid: number): number {
+  if (v === undefined || v === null || !Number.isFinite(v)) return fallback;
+  const i = Math.floor(v);
+  if (i < minValid) return fallback;
+  return i;
+}
+
 export interface BuildRecordInput {
   profile: string;
   tool: AuditTool;
@@ -184,9 +203,14 @@ export class AuditStore {
 
   constructor(cfg: AuditStoreConfig) {
     this.auditDir = cfg.auditDir;
-    this.auditMaxBytes = cfg.auditMaxBytes ?? DEFAULT_AUDIT_MAX_BYTES;
-    this.maxFileBytes = cfg.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
-    this.retain = cfg.retain ?? DEFAULT_RETAIN;
+    // Clamp config against negative / non-finite (NaN, Infinity) values so a
+    // bad caller cannot produce surprising behavior: negative auditMaxBytes
+    // silently empties output, NaN maxFileBytes rotates on every append, and
+    // retain <= 0 breaks rotation/prune. Fall back to the documented default
+    // for anything non-finite, and floor to a safe minimum otherwise.
+    this.auditMaxBytes = clampInt(cfg.auditMaxBytes, DEFAULT_AUDIT_MAX_BYTES, 0);
+    this.maxFileBytes = clampInt(cfg.maxFileBytes, DEFAULT_MAX_FILE_BYTES, 1);
+    this.retain = clampInt(cfg.retain, DEFAULT_RETAIN, 1);
     // Audit logs contain command lines + captured output; keep them
     // owner-only. mkdir mode is masked by umask, so chmod afterwards to
     // enforce 0700 on both freshly-created and pre-existing directories.

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -1,0 +1,197 @@
+/**
+ * Audit JSONL store.
+ *
+ * Responsibilities:
+ *   - Resolve and ensure the audit directory exists (default ~/.ssh-mcp).
+ *   - Compute the active file path from today's UTC date.
+ *   - Cap stdout/stderr bytes per record at `auditMaxBytes`.
+ *   - Apply the redactor to every text field.
+ *   - Generate a sortable record id.
+ *   - Delegate file rotation to `rotator.ts` before each append.
+ *
+ * Public surface:
+ *   - `AuditStore` class with `appendExec` / `appendDeny` helpers.
+ *   - `buildRecord` for tests / callers that just want a record without I/O.
+ *   - `resolveAuditDir` to expand `~` / honor env overrides.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  AuditRecord,
+  AuditStoreConfig,
+  AuditTool,
+  AuditApprovalSection,
+  AuditExecSection,
+  DEFAULT_AUDIT_MAX_BYTES,
+  DEFAULT_MAX_FILE_BYTES,
+  DEFAULT_RETAIN,
+} from './types.js';
+import { redact } from './redactor.js';
+import { rotateIfNeeded, pruneOldDays } from './rotator.js';
+
+/** Resolve audit directory, expanding `~` and honoring env override. */
+export function resolveAuditDir(override?: string | null): string {
+  const raw =
+    override ??
+    process.env.SSH_MCP_AUDIT_DIR ??
+    path.join(os.homedir(), '.ssh-mcp');
+  if (raw.startsWith('~')) {
+    return path.join(os.homedir(), raw.slice(1));
+  }
+  return path.resolve(raw);
+}
+
+/** UTC YYYYMMDD string. */
+export function utcDateStamp(d: Date = new Date()): string {
+  const y = d.getUTCFullYear().toString().padStart(4, '0');
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = d.getUTCDate().toString().padStart(2, '0');
+  return `${y}${m}${day}`;
+}
+
+export function activeFilePath(auditDir: string, d: Date = new Date()): string {
+  return path.join(auditDir, `executions-${utcDateStamp(d)}.jsonl`);
+}
+
+/** Sortable id: timestamp + random suffix. */
+let _counter = 0;
+export function newRecordId(d: Date = new Date()): string {
+  _counter = (_counter + 1) & 0xffff;
+  const t = d.getTime().toString(36).padStart(9, '0');
+  const r = Math.floor(Math.random() * 0xffffff)
+    .toString(36)
+    .padStart(5, '0');
+  const c = _counter.toString(36).padStart(3, '0');
+  return `${t}-${r}${c}`;
+}
+
+/** Truncate a string to at most `maxBytes` UTF-8 bytes. Returns text + truncated flag. */
+export function capUtf8(s: string, maxBytes: number): { text: string; truncated: boolean } {
+  if (maxBytes <= 0) return { text: '', truncated: s.length > 0 };
+  const buf = Buffer.from(s, 'utf8');
+  if (buf.byteLength <= maxBytes) return { text: s, truncated: false };
+  // Slice to maxBytes, then walk back to avoid splitting a multi-byte char.
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  return { text: buf.slice(0, end).toString('utf8'), truncated: true };
+}
+
+export interface BuildRecordInput {
+  profile: string;
+  tool: AuditTool;
+  command: string;
+  description?: string;
+  approval: AuditApprovalSection;
+  exec?: {
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+    durationMs: number;
+  };
+  now?: Date;
+  auditMaxBytes?: number;
+}
+
+export function buildRecord(input: BuildRecordInput): AuditRecord {
+  const now = input.now ?? new Date();
+  const cap = input.auditMaxBytes ?? DEFAULT_AUDIT_MAX_BYTES;
+
+  const rec: AuditRecord = {
+    ts: now.toISOString(),
+    id: newRecordId(now),
+    profile: input.profile,
+    tool: input.tool,
+    command: redact(input.command),
+    description: input.description ? redact(input.description) : undefined,
+    approval: {
+      mode: input.approval.mode,
+      decision: input.approval.decision,
+      reason: redact(input.approval.reason),
+      decided_at: input.approval.decided_at,
+      decided_by: input.approval.decided_by,
+    },
+  };
+
+  if (input.exec) {
+    const so = capUtf8(redact(input.exec.stdout), cap);
+    const se = capUtf8(redact(input.exec.stderr), cap);
+    const execSection: AuditExecSection = {
+      exit_code: input.exec.exitCode,
+      duration_ms: input.exec.durationMs,
+      stdout_truncated: so.truncated,
+      stderr_truncated: se.truncated,
+      stdout: so.text,
+      stderr: se.text,
+    };
+    rec.exec = execSection;
+  }
+
+  return rec;
+}
+
+export class AuditStore {
+  private readonly auditDir: string;
+  private readonly auditMaxBytes: number;
+  private readonly maxFileBytes: number;
+  private readonly retain: number;
+
+  /** Track which day we last pruned, so we only prune once per day. */
+  private lastPruneStamp: string | null = null;
+
+  constructor(cfg: AuditStoreConfig) {
+    this.auditDir = cfg.auditDir;
+    this.auditMaxBytes = cfg.auditMaxBytes ?? DEFAULT_AUDIT_MAX_BYTES;
+    this.maxFileBytes = cfg.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+    this.retain = cfg.retain ?? DEFAULT_RETAIN;
+    fs.mkdirSync(this.auditDir, { recursive: true });
+  }
+
+  /** Build + write a record. Returns the written record (after redaction/capping). */
+  append(input: BuildRecordInput): AuditRecord {
+    const now = input.now ?? new Date();
+    const rec = buildRecord({ ...input, now, auditMaxBytes: this.auditMaxBytes });
+    const filePath = activeFilePath(this.auditDir, now);
+
+    rotateIfNeeded({
+      filePath,
+      maxFileBytes: this.maxFileBytes,
+      retain: this.retain,
+    });
+
+    const line = JSON.stringify(rec) + '\n';
+    fs.appendFileSync(filePath, line, { encoding: 'utf8' });
+
+    const stamp = utcDateStamp(now);
+    if (this.lastPruneStamp !== stamp) {
+      this.lastPruneStamp = stamp;
+      try {
+        pruneOldDays(this.auditDir, this.retain);
+      } catch {
+        // best-effort
+      }
+    }
+    return rec;
+  }
+
+  /** Path to the active file (today's UTC date). For tests + diagnostics. */
+  currentFilePath(d: Date = new Date()): string {
+    return activeFilePath(this.auditDir, d);
+  }
+}
+
+/**
+ * Build a yolo approval section — convenient placeholder for callers that
+ * haven't wired the approval engine yet (this card lands before approval-engine).
+ */
+export function yoloApproval(now: Date = new Date()): AuditApprovalSection {
+  return {
+    mode: 'yolo',
+    decision: 'allow',
+    reason: 'approval engine not yet wired (yolo placeholder)',
+    decided_at: now.toISOString(),
+    decided_by: 'yolo',
+  };
+}

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Audit log record shapes.
+ *
+ * Each invocation of the `exec` or `sudo-exec` MCP tool produces exactly one
+ * JSONL line in the configured audit directory (default `~/.ssh-mcp`).
+ *
+ * Records are written AFTER execution finishes (success, failure, or denied
+ * by the approval engine). Secrets are scrubbed by the redactor before the
+ * record is serialized; stdout/stderr are capped to `auditMaxBytes` with a
+ * `truncated` flag.
+ */
+
+export type AuditTool = 'exec' | 'sudo-exec';
+
+export type ApprovalMode = 'yolo' | 'smart' | 'manual';
+
+export type ApprovalDecisionKind = 'allow' | 'deny';
+
+export interface AuditApprovalSection {
+  /** Approval engine mode in effect when the decision was made. */
+  mode: ApprovalMode;
+  /** Final decision. `deny` means the transport never ran the command. */
+  decision: ApprovalDecisionKind;
+  /** Human-readable rationale (LLM reason, manual operator note, or "yolo"). */
+  reason: string;
+  /** ISO-8601 timestamp at which the decision was made. */
+  decided_at: string;
+  /** Source attribution: `smart-llm`, `webui:<user>`, `yolo`, etc. */
+  decided_by: string;
+}
+
+export interface AuditExecSection {
+  exit_code: number | null;
+  duration_ms: number;
+  stdout_truncated: boolean;
+  stderr_truncated: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+export interface AuditRecord {
+  /** ISO-8601 timestamp when the record was finalized (UTC). */
+  ts: string;
+  /** Unique record id (ULID-ish; lexicographically sortable). */
+  id: string;
+  /** Profile / connection name (`default`, `prod-bastion`, ...). */
+  profile: string;
+  /** Tool that invoked the audit. */
+  tool: AuditTool;
+  /** Sanitized + redacted command string. */
+  command: string;
+  /** Verbatim description from the MCP call, redacted. */
+  description?: string;
+  /** Approval engine decision. Always present once approval engine lands. */
+  approval: AuditApprovalSection;
+  /** Execution detail. Omitted when `approval.decision === 'deny'`. */
+  exec?: AuditExecSection;
+}
+
+export interface AuditStoreConfig {
+  /** Directory where executions-YYYYMMDD.jsonl files live. */
+  auditDir: string;
+  /** Per-record cap on stdout/stderr bytes (UTF-8). */
+  auditMaxBytes: number;
+  /** File size threshold (bytes) that triggers a size-based rotation. */
+  maxFileBytes?: number;
+  /** Number of rotated files to keep (excluding the current file). */
+  retain?: number;
+}
+
+export const DEFAULT_AUDIT_MAX_BYTES = 10_000;
+export const DEFAULT_MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+export const DEFAULT_RETAIN = 10;

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,17 @@ const AUDIT_MAX_BYTES = (() => {
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 10_000;
 })();
-const auditStore = new AuditStore({ auditDir: AUDIT_DIR, auditMaxBytes: AUDIT_MAX_BYTES });
+// Audit store is constructed lazily (see getAuditStore) so that merely
+// importing this module — e.g. under SSH_MCP_DISABLE_MAIN=1 for library use
+// or unit tests — never performs audit-directory filesystem I/O. The store
+// is materialized on first actual audit write (CLI/tool execution).
+let _auditStore: AuditStore | null = null;
+function getAuditStore(): AuditStore {
+  if (_auditStore === null) {
+    _auditStore = new AuditStore({ auditDir: AUDIT_DIR, auditMaxBytes: AUDIT_MAX_BYTES });
+  }
+  return _auditStore;
+}
 const MAX_CHARS_RAW = argvConfig.maxChars;
 const MAX_CHARS = (() => {
   if (typeof MAX_CHARS_RAW === 'string') {
@@ -365,7 +375,7 @@ function auditExecution(params: {
 }): void {
   const now = new Date();
   const durationMs = Math.max(0, Date.now() - params.startedAt);
-  const store = params.store ?? auditStore;
+  const store = params.store ?? getAuditStore();
   try {
     store.append({
       profile: params.profile,

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,10 @@ async function getOrCreateTransport(): Promise<ISshTransport> {
  * Map ExecResult to MCP tool response. Preserves upstream semantics:
  *   - auth/host_key/connect/transport categories → reject with descriptive error
  *   - timeout → reject with timeout error
- *   - non-zero exit with stderr → reject (wraps as "Error (code N):\n<stderr>")
+ *   - non-zero exit → reject (wraps as "Error (code N):\n<stderr>"), even when
+ *     stderr is empty (e.g. `false`, `test -f missing`): the synthetic detail
+ *     "Command exited with status N" is used so a failed command never looks
+ *     like a success just because it printed nothing to stderr.
  *   - exit 0 → success, even if stderr is non-empty
  *
  * Exit 0 is treated as success regardless of stderr: the OpenSSH transport
@@ -254,8 +257,9 @@ export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'transport') {
     throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
   }
-  if (result.stderr && result.exitCode !== 0) {
-    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
+  if (result.exitCode !== null && result.exitCode !== 0) {
+    const detail = result.stderr || `Command exited with status ${result.exitCode}`;
+    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${detail}`);
   }
   return {
     content: [{

--- a/src/index.ts
+++ b/src/index.ts
@@ -375,8 +375,11 @@ function auditExecution(params: {
 }): void {
   const now = new Date();
   const durationMs = Math.max(0, Date.now() - params.startedAt);
-  const store = params.store ?? getAuditStore();
   try {
+    // Resolve the store inside the try: lazily constructing it can throw when
+    // the audit directory is unwritable, and audit logging is best-effort —
+    // a store-construction failure must not surface to the caller either.
+    const store = params.store ?? getAuditStore();
     store.append({
       profile: params.profile,
       tool: params.tool,
@@ -419,23 +422,45 @@ export async function executeAuditedTransportCommand(input: {
     ? `${sanitizedCommand} # ${input.description.replace(/#/g, '\\#')}`
     : sanitizedCommand;
   const startedAt = Date.now();
-  const result = input.tool === 'sudo-exec'
-    ? await input.transport.execElevated(commandWithDescription, {
-        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT,
-        mode: 'sudo',
-        password: input.sudoPassword,
-      })
-    : await input.transport.exec(commandWithDescription, { timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT });
-  auditExecution({
-    tool: input.tool,
-    profile: input.profile ?? 'stub',
-    command: commandWithDescription,
-    description: input.description,
-    startedAt,
-    result,
-    store: input.store,
-  });
-  return resultToMcpContent(result);
+  const profile = input.profile ?? 'default';
+  let audited = false;
+  try {
+    const result = input.tool === 'sudo-exec'
+      ? await input.transport.execElevated(commandWithDescription, {
+          timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT,
+          mode: 'sudo',
+          password: input.sudoPassword,
+        })
+      : await input.transport.exec(commandWithDescription, { timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT });
+    auditExecution({
+      tool: input.tool,
+      profile,
+      command: commandWithDescription,
+      description: input.description,
+      startedAt,
+      result,
+      store: input.store,
+    });
+    audited = true;
+    return resultToMcpContent(result);
+  } catch (err) {
+    // Transport rejection (spawn failure, unexpected exception) still gets an
+    // audit record — the contract is "audit success AND failure", matching the
+    // exec/sudo-exec MCP handlers. `audited` guards the resultToMcpContent
+    // throw path (result already audited above) from double-writing.
+    if (!audited) {
+      auditExecution({
+        tool: input.tool,
+        profile,
+        command: commandWithDescription,
+        description: input.description,
+        startedAt,
+        error: err,
+        store: input.store,
+      });
+    }
+    throw err;
+  }
 }
 
 export function resultToMcpContent(result: ExecResult) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,14 +78,16 @@ function validateConfig(config: Record<string, string | null>) {
   if (!config.user) errors.push('Missing required --user');
   if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
 
-  const transport = config.transport ?? 'ssh2';
+  const transportExplicit = config.transport;
   const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+  // --kerberos alone implies --transport=openssh
+  const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
 
   if (transport !== 'ssh2' && transport !== 'openssh') {
     errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
   }
-  if (kerberos && transport === 'ssh2') {
-    errors.push('--kerberos requires --transport=openssh (or pass --kerberos alone, which implies openssh)');
+  if (kerberos && transportExplicit === 'ssh2') {
+    errors.push('--kerberos requires --transport=openssh (remove --transport=ssh2 or pass --kerberos alone)');
   }
   if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
     errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,11 @@ async function bootstrapRegistry(): Promise<void> {
 }
 
 function resolvedProfileName(connectionName?: string): string {
-  return connectionName ?? registry.getDefaultName() ?? 'default';
+  // Delegate to the registry's non-throwing resolver so an ambiguous
+  // multi-host call (name omitted, >1 server, no explicit default) is recorded
+  // as '(unresolved)' instead of being misattributed to the first server on the
+  // failure-audit path.
+  return registry.resolveProfileName(connectionName);
 }
 
 function auditExecution(params: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,13 @@ export function parseServerConfigJson(raw: string): ServerConfig {
   if (typeof obj.name !== 'string' || obj.name.length === 0) {
     throw new Error('--ssh JSON requires a non-empty string "name"');
   }
-  if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
+  if (typeof obj.host !== 'string' || obj.host.length === 0) {
+    throw new Error(`--ssh "${obj.name}" missing required "host" (expected a non-empty string)`);
+  }
   const user = obj.user ?? obj.username;
-  if (!user) throw new Error(`--ssh "${obj.name}" missing required "user" (or "username")`);
+  if (typeof user !== 'string' || user.length === 0) {
+    throw new Error(`--ssh "${obj.name}" missing required "user" (or "username") (expected a non-empty string)`);
+  }
   const auth: AuthMode | undefined = obj.auth;
   if (!auth || !['kerberos', 'key', 'password'].includes(auth)) {
     throw new Error(`--ssh "${obj.name}" requires "auth": "kerberos" | "key" | "password"`);
@@ -134,6 +138,14 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       // a credential-less key config (Codex 3541767246).
       if (obj.key !== undefined) {
         throw new Error(`--ssh "${obj.name}" auth "key" uses "keyPath" (or "privateKey" for ssh2), not "key"`);
+      }
+      if (obj.keyPath !== undefined &&
+          (typeof obj.keyPath !== 'string' || obj.keyPath.length === 0)) {
+        throw new Error(`--ssh "${obj.name}" "keyPath" must be a non-empty string`);
+      }
+      if (obj.privateKey !== undefined &&
+          (typeof obj.privateKey !== 'string' || obj.privateKey.length === 0)) {
+        throw new Error(`--ssh "${obj.name}" "privateKey" must be a non-empty string`);
       }
       // OpenSshTransport.buildArgs only passes cfg.keyPath via `-i`; an inline
       // privateKey would be silently ignored and ssh would fall back to

--- a/src/index.ts
+++ b/src/index.ts
@@ -447,14 +447,19 @@ export async function executeAuditedTransportCommand(input: {
   sudoPassword?: string;
   store: AuditStore;
 }) {
-  const sanitizedCommand = sanitizeCommand(input.command);
-  const commandWithDescription = input.description
-    ? `${sanitizedCommand} # ${input.description.replace(/#/g, '\\#')}`
-    : sanitizedCommand;
   const startedAt = Date.now();
   const profile = input.profile ?? 'default';
   let audited = false;
+  // Record the raw attempted command if sanitization rejects it below. A
+  // command rejected by validation (empty / over --maxChars) still leaves an
+  // audit record — the contract covers failures, and sanitizeCommand throws.
+  let auditCommand = String(input.command ?? '');
   try {
+    const sanitizedCommand = sanitizeCommand(input.command);
+    const commandWithDescription = input.description
+      ? `${sanitizedCommand} # ${input.description.replace(/#/g, '\\#')}`
+      : sanitizedCommand;
+    auditCommand = commandWithDescription;
     const result = input.tool === 'sudo-exec'
       ? await input.transport.execElevated(commandWithDescription, {
           timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT,
@@ -474,15 +479,16 @@ export async function executeAuditedTransportCommand(input: {
     audited = true;
     return resultToMcpContent(result);
   } catch (err) {
-    // Transport rejection (spawn failure, unexpected exception) still gets an
-    // audit record — the contract is "audit success AND failure", matching the
+    // Transport rejection (spawn failure, unexpected exception) OR a
+    // sanitization rejection (empty/too-long command) still gets an audit
+    // record — the contract is "audit success AND failure", matching the
     // exec/sudo-exec MCP handlers. `audited` guards the resultToMcpContent
     // throw path (result already audited above) from double-writing.
     if (!audited) {
       auditExecution({
         tool: input.tool,
         profile,
-        command: commandWithDescription,
+        command: auditCommand,
         description: input.description,
         startedAt,
         error: err,
@@ -585,15 +591,20 @@ server.tool(
     connectionName: connectionNameSchema,
   },
   async ({ command, description, connectionName }) => {
-    const sanitizedCommand = sanitizeCommand(command);
     const profile = resolvedProfileName(connectionName);
     const startedAt = Date.now();
     let audited = false;
+    // Record the raw attempted command if sanitization rejects it below. A
+    // command rejected by validation (empty / over --maxChars) still leaves an
+    // audit record — the contract covers failures, and sanitizeCommand throws.
+    let auditCommand = String(command ?? '');
     try {
+      const sanitizedCommand = sanitizeCommand(command);
       const t = await registry.get(connectionName);
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
+      auditCommand = commandWithDescription;
       const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
       auditExecution({
         tool: 'exec',
@@ -606,7 +617,7 @@ server.tool(
       audited = true;
       return resultToMcpContent(result);
     } catch (err: any) {
-      if (!audited) auditExecution({ tool: 'exec', profile, command: sanitizedCommand, description, startedAt, error: err });
+      if (!audited) auditExecution({ tool: 'exec', profile, command: auditCommand, description, startedAt, error: err });
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
     }
@@ -623,15 +634,21 @@ if (!DISABLE_SUDO) {
       connectionName: connectionNameSchema,
     },
     async ({ command, description, connectionName }) => {
-      const sanitizedCommand = sanitizeCommand(command);
       const profile = resolvedProfileName(connectionName);
       const startedAt = Date.now();
       let audited = false;
+      // Record the raw attempted command if sanitization rejects it below. A
+      // command rejected by validation (empty / over --maxChars) still leaves
+      // an audit record — the contract covers failures, and sanitizeCommand
+      // throws.
+      let auditCommand = String(command ?? '');
       try {
+        const sanitizedCommand = sanitizeCommand(command);
         const t = await registry.get(connectionName);
         const commandWithDescription = description
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
+        auditCommand = commandWithDescription;
         // Legacy single-host mode may still pass --sudoPassword on CLI; in
         // multi-host mode each ServerConfig carries its own sudoPassword.
         const legacySudo = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined && !isMultiHost)
@@ -653,7 +670,7 @@ if (!DISABLE_SUDO) {
         audited = true;
         return resultToMcpContent(result);
       } catch (err: any) {
-        if (!audited) auditExecution({ tool: 'sudo-exec', profile, command: sanitizedCommand, description, startedAt, error: err });
+        if (!audited) auditExecution({ tool: 'sudo-exec', profile, command: auditCommand, description, startedAt, error: err });
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,27 @@
 #!/usr/bin/env node
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
+import { ISshTransport, TransportConfig, ExecResult } from './transports/types.js';
+import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
+import { createTransport } from './transports/factory.js';
+import {
+  sanitizeCommand as sanitizeCommandImpl,
+  sanitizePassword,
+  escapeCommandForShell,
+} from './utils/shell.js';
+
+// Re-exports for backward compatibility with existing tests (smoke.ssh.test.ts,
+// persistent-connection.test.ts, etc.).
+export { SSHConnectionManager, escapeCommandForShell };
+export type { SSHConfig };
+
 // Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
+// Kerberos SSO:   node build/index.js --host=host --user=user@REALM --kerberos
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
@@ -14,20 +29,20 @@ function parseArgv() {
     if (arg.startsWith('--')) {
       const equalIndex = arg.indexOf('=');
       if (equalIndex === -1) {
-        // Flag without value
         config[arg.slice(2)] = null;
       } else {
-        // Key=value pair
         config[arg.slice(2, equalIndex)] = arg.slice(equalIndex + 1);
       }
     }
   }
   return config;
 }
+
 const isTestMode = process.env.SSH_MCP_TEST === '1';
 const isCliEnabled = process.env.SSH_MCP_DISABLE_MAIN !== '1';
 const argvConfig = (isCliEnabled || isTestMode) ? parseArgv() : {} as Record<string, string>;
 
+// Connection config (legacy flags)
 const HOST = argvConfig.host;
 const PORT = argvConfig.port ? parseInt(argvConfig.port) : 22;
 const USER = argvConfig.user;
@@ -36,13 +51,7 @@ const SUPASSWORD = argvConfig.suPassword;
 const SUDOPASSWORD = argvConfig.sudoPassword;
 const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
-const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
-// Max characters configuration:
-// - Default: 1000 characters
-// - When set via --maxChars:
-//   * a positive integer enforces that limit
-//   * 0 or a negative value disables the limit (no max)
-//   * the string "none" (case-insensitive) disables the limit (no max)
+const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000;
 const MAX_CHARS_RAW = argvConfig.maxChars;
 const MAX_CHARS = (() => {
   if (typeof MAX_CHARS_RAW === 'string') {
@@ -56,11 +65,38 @@ const MAX_CHARS = (() => {
   return 1000;
 })();
 
+// Transport config (new flags)
+const TRANSPORT_FLAG = argvConfig.transport;
+const KERBEROS_FLAG = argvConfig.kerberos !== undefined && argvConfig.kerberos !== 'false';
+const GSSAPI_DELEGATE = argvConfig.gssapiDelegateCredentials;
+const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
+const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
+
 function validateConfig(config: Record<string, string | null>) {
-  const errors = [];
+  const errors: string[] = [];
   if (!config.host) errors.push('Missing required --host');
   if (!config.user) errors.push('Missing required --user');
   if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
+
+  const transport = config.transport ?? 'ssh2';
+  const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+
+  if (transport !== 'ssh2' && transport !== 'openssh') {
+    errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
+  }
+  if (kerberos && transport === 'ssh2') {
+    errors.push('--kerberos requires --transport=openssh (or pass --kerberos alone, which implies openssh)');
+  }
+  if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
+    errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
+  }
+  if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
+    errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
+  }
+  if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
+    errors.push('--gssapiDelegateCredentials must be yes or no');
+  }
+
   if (errors.length > 0) {
     throw new Error('Configuration error:\n' + errors.join('\n'));
   }
@@ -70,277 +106,101 @@ if (isCliEnabled) {
   validateConfig(argvConfig);
 }
 
-// Command sanitization and validation
 export function sanitizeCommand(command: string): string {
-  if (typeof command !== 'string') {
-    throw new McpError(ErrorCode.InvalidParams, 'Command must be a string');
-  }
-
-  const trimmedCommand = command.trim();
-  if (!trimmedCommand) {
-    throw new McpError(ErrorCode.InvalidParams, 'Command cannot be empty');
-  }
-
-  // Length check
-  if (Number.isFinite(MAX_CHARS) && trimmedCommand.length > (MAX_CHARS as number)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      `Command is too long (max ${MAX_CHARS} characters)`
-    );
-  }
-
-  return trimmedCommand;
+  return sanitizeCommandImpl(command, MAX_CHARS as number);
 }
 
-function sanitizePassword(password: string | undefined): string | undefined {
-  if (typeof password !== 'string') return undefined;
-  // minimal check, do not log or modify content
-  if (password.length === 0) return undefined;
-  return password;
+function resolveTransport(): 'ssh2' | 'openssh' {
+  if (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) return 'openssh';
+  return 'ssh2';
 }
 
-// Escape command for use in shell contexts (like pkill)
-export function escapeCommandForShell(command: string): string {
-  // Replace single quotes with escaped single quotes
-  return command.replace(/'/g, "'\"'\"'");
+function resolveAuthMode(): 'kerberos' | 'key' | 'password' | undefined {
+  if (KERBEROS_FLAG) return 'kerberos';
+  if (KEY) return 'key';
+  if (PASSWORD) return 'password';
+  return undefined;
 }
 
-// SSH Connection Manager to maintain persistent connection
-export interface SSHConfig {
-  host: string;
-  port: number;
-  username: string;
-  password?: string;
-  privateKey?: string;
-  suPassword?: string;
-  sudoPassword?: string;  // Password for sudo commands specifically (if different from suPassword)
+async function buildTransportConfig(): Promise<TransportConfig> {
+  if (!HOST || !USER) {
+    throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+  }
+
+  const cfg: TransportConfig = {
+    host: HOST,
+    port: PORT,
+    username: USER,
+    transport: resolveTransport(),
+    authMode: resolveAuthMode(),
+  };
+
+  if (PASSWORD) cfg.password = PASSWORD;
+  if (KEY) {
+    cfg.keyPath = KEY;
+    // ssh2 transport needs the key contents, not the path
+    if (cfg.transport === 'ssh2') {
+      const fs = await import('fs/promises');
+      cfg.privateKey = await fs.readFile(KEY, 'utf8');
+    }
+  }
+  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
+  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
+  if (KERBEROS_FLAG) cfg.kerberos = true;
+  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
+  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
+  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+
+  return cfg;
 }
 
-export class SSHConnectionManager {
-  private conn: Client | null = null;
-  private sshConfig: SSHConfig;
-  private isConnecting = false;
-  private connectionPromise: Promise<void> | null = null;
-  private suShell: any = null;  // Store the elevated shell session
-  private suPromise: Promise<void> | null = null;
-  private isElevated = false;  // Track if we're in su mode
+let activeTransport: ISshTransport | null = null;
 
-  constructor(config: SSHConfig) {
-    this.sshConfig = config;
-  }
-
-  async connect(): Promise<void> {
-    if (this.conn && this.isConnected()) {
-      return; // Already connected
-    }
-
-    if (this.isConnecting && this.connectionPromise) {
-      return this.connectionPromise; // Wait for ongoing connection
-    }
-
-    this.isConnecting = true;
-    this.connectionPromise = new Promise((resolve, reject) => {
-      this.conn = new Client();
-
-      const timeoutId = setTimeout(() => {
-        this.conn?.end();
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-        reject(new McpError(ErrorCode.InternalError, 'SSH connection timeout'));
-      }, 30000); // 30 seconds connection timeout
-
-      this.conn.on('ready', async () => {
-        clearTimeout(timeoutId);
-        this.isConnecting = false;
-
-        // In test mode, don't wait for su elevation during connection setup, as it
-        // may cause JSON-RPC server initialization to hang. Instead, elevation will
-        // be triggered on-demand when a command is executed.
-        // In production, elevation during connection is desirable for robustness.
-        if (this.sshConfig.suPassword && !process.env.SSH_MCP_TEST) {
-          try {
-            await this.ensureElevated();
-          } catch (err) {
-            // Do not reject the connection; just log the error. Subsequent commands
-            // will either use the su shell if available or fall back to normal execution.
-          }
-        }
-
-        resolve();
-      });
-
-      this.conn.on('error', (err: Error) => {
-        clearTimeout(timeoutId);
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-        reject(new McpError(ErrorCode.InternalError, `SSH connection error: ${err.message}`));
-      });
-
-      this.conn.on('end', () => {
-        console.error('SSH connection ended');
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-      });
-
-      this.conn.on('close', () => {
-        console.error('SSH connection closed');
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-      });
-
-      this.conn.connect(this.sshConfig);
-    });
-
-    return this.connectionPromise;
-  }
-
-  isConnected(): boolean {
-    return this.conn !== null && (this.conn as any)._sock && !(this.conn as any)._sock.destroyed;
-  }
-
-  getSudoPassword(): string | undefined {
-    return this.sshConfig.sudoPassword;
-  }
-
-  getSuPassword(): string | undefined {
-    return this.sshConfig.suPassword;
-  }
-
-  async setSuPassword(pwd?: string): Promise<void> {
-    this.sshConfig.suPassword = pwd;
-    if (pwd) {
-      try {
-        await this.ensureElevated();
-      } catch (err) {
-        console.error('setSuPassword: failed to elevate to su shell:', err);
-      }
-    } else {
-      // If clearing suPassword, drop any existing suShell
-      if (this.suShell) {
-        try { this.suShell.end(); } catch (e) { /* ignore */ }
-        this.suShell = null;
-        this.isElevated = false;
-      }
-    }
-  }
-
-  private async ensureElevated(): Promise<void> {
-    if (this.isElevated && this.suShell) return;
-    if (!this.sshConfig.suPassword) return;
-
-    if (this.suPromise) return this.suPromise;
-
-    this.suPromise = new Promise((resolve, reject) => {
-      const conn = this.getConnection();
-
-      // Add a safety timeout so elevation doesn't hang forever
-      const timeoutId = setTimeout(() => {
-        this.suPromise = null;
-        reject(new McpError(ErrorCode.InternalError, 'su elevation timed out'));
-      }, 10000);  // 10 second timeout for elevation
-
-      conn.shell({ term: 'xterm', cols: 80, rows: 24 }, (err: Error | undefined, stream: ClientChannel) => {
-        if (err) {
-          clearTimeout(timeoutId);
-          this.suPromise = null;
-          reject(new McpError(ErrorCode.InternalError, `Failed to start interactive shell for su: ${err.message}`));
-          return;
-        }
-
-        let buffer = '';
-        let passwordSent = false;
-        const cleanup = () => {
-          try { stream.removeAllListeners('data'); } catch (e) { /* ignore */ }
-        };
-
-        const onData = (data: Buffer) => {
-          const text = data.toString();
-          buffer += text;
-
-          // If we haven't sent the password yet, look for the password prompt
-          if (!passwordSent && /password[: ]/i.test(buffer)) {
-            passwordSent = true;
-            stream.write(this.sshConfig.suPassword + '\n');
-            // Don't return; keep looking for root prompt
-          }
-
-          // After password is sent, look for any root indicator
-          // Look for '#' which indicates root prompt (may be followed by spaces, escape codes, etc)
-          if (passwordSent) {
-            if (/#/.test(buffer)) {
-              clearTimeout(timeoutId);
-              cleanup();
-              this.suShell = stream;
-              this.isElevated = true;
-              this.suPromise = null;
-              resolve();
-              return;
-            }
-          }
-
-          // Detect authentication failure messages
-          if (/authentication failure|incorrect password|su: .*failed|su: failure/i.test(buffer)) {
-            clearTimeout(timeoutId);
-            cleanup();
-            this.suPromise = null;
-            reject(new McpError(ErrorCode.InternalError, `su authentication failed: ${buffer}`));
-            return;
-          }
-        };
-
-        stream.on('data', onData);
-
-        stream.on('close', () => {
-          clearTimeout(timeoutId);
-          if (!this.isElevated) {
-            this.suPromise = null;
-            reject(new McpError(ErrorCode.InternalError, 'su shell closed before elevation completed'));
-          }
-        });
-
-        // Kick off the su command
-        stream.write('su -\n');
-      });
-    });
-
-    return this.suPromise;
-  }
-
-  async ensureConnected(): Promise<void> {
-    if (!this.isConnected()) {
-      await this.connect();
-    }
-  }
-
-  getConnection(): Client {
-    if (!this.conn) {
-      throw new McpError(ErrorCode.InternalError, 'SSH connection not established');
-    }
-    return this.conn;
-  }
-
-  close(): void {
-    if (this.conn) {
-      if (this.suShell) {
-        try { this.suShell.end(); } catch (e) { /* ignore */ }
-        this.suShell = null;
-        this.isElevated = false;
-      }
-      this.conn.end();
-      this.conn = null;
-    }
-  }
+async function getOrCreateTransport(): Promise<ISshTransport> {
+  if (activeTransport) return activeTransport;
+  const cfg = await buildTransportConfig();
+  activeTransport = createTransport(cfg);
+  await activeTransport.init();
+  return activeTransport;
 }
 
-let connectionManager: SSHConnectionManager | null = null;
+/**
+ * Map ExecResult to MCP tool response. Preserves upstream semantics:
+ *   - stderr present → reject with McpError (wraps as "Error (code N):\n<stderr>")
+ *   - auth/host_key/connect/transport categories → reject with descriptive error
+ *   - timeout → reject with timeout error
+ *   - success → return {content: [{type:'text', text: stdout}]}
+ */
+function resultToMcpContent(result: ExecResult) {
+  if (result.category === 'timeout') {
+    throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
+  }
+  if (result.category === 'auth') {
+    throw new McpError(ErrorCode.InternalError, `SSH authentication error: ${result.stderr}`);
+  }
+  if (result.category === 'host_key') {
+    throw new McpError(ErrorCode.InternalError, `SSH host key error: ${result.stderr}`);
+  }
+  if (result.category === 'connect') {
+    throw new McpError(ErrorCode.InternalError, `SSH connection error: ${result.stderr}`);
+  }
+  if (result.category === 'transport') {
+    throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
+  }
+  if (result.stderr) {
+    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
+  }
+  return {
+    content: [{
+      type: 'text' as const,
+      text: result.stdout,
+    }],
+  };
+}
 
 const server = new McpServer({
   name: 'SSH MCP Server',
-  version: '1.5.0',
+  version: '2.0.0',
   capabilities: {
     resources: {},
     tools: {},
@@ -348,146 +208,52 @@ const server = new McpServer({
 });
 
 server.tool(
-  "exec",
-  "Execute a shell command on the remote SSH server and return the output.",
+  'exec',
+  'Execute a shell command on the remote SSH server and return the output.',
   {
-    command: z.string().describe("Shell command to execute on the remote SSH server"),
-    description: z.string().optional().describe("Optional description of what this command will do"),
+    command: z.string().describe('Shell command to execute on the remote SSH server'),
+    description: z.string().optional().describe('Optional description of what this command will do'),
   },
   async ({ command, description }) => {
-    // Sanitize command input
     const sanitizedCommand = sanitizeCommand(command);
-
     try {
-      // Initialize connection manager if not already done
-      if (!connectionManager) {
-        if (!HOST || !USER) {
-          throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-        }
-        const sshConfig: SSHConfig = {
-          host: HOST,
-          port: PORT,
-          username: USER,
-        };
-
-        if (PASSWORD) {
-          sshConfig.password = PASSWORD;
-        } else if (KEY) {
-          const fs = await import('fs/promises');
-          sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-        }
-
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-        }
-        connectionManager = new SSHConnectionManager(sshConfig);
-      }
-
-      // Ensure connection is active (reconnect if needed)
-      await connectionManager.ensureConnected();
-
-      // If a suPassword was provided, explicitly wait for elevation before executing.
-      // This is critical: ensureElevated is idempotent and will return immediately if
-      // already elevated, so this ensures we have a su shell before we try to use it.
-      if ((connectionManager as any).getSuPassword && (connectionManager as any).getSuPassword()) {
-        try {
-          const elevationPromise = (connectionManager as any).ensureElevated();
-          // Add a short timeout for elevation to complete
-          await Promise.race([
-            elevationPromise,
-            new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000))
-          ]);
-        } catch (err) {
-          // Log but don't fail; fall back to non-elevated execution if elevation times out
-        }
-      }
-
-      // Append description as comment if provided
+      const t = await getOrCreateTransport();
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
-
-      const result = await execSshCommandWithConnection(connectionManager, commandWithDescription);
-      return result;
+      const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
+      return resultToMcpContent(result);
     } catch (err: any) {
-      // Wrap unexpected errors
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
     }
   }
 );
 
-// Expose sudo-exec tool unless explicitly disabled
 if (!DISABLE_SUDO) {
   server.tool(
-    "sudo-exec",
-    "Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.",
+    'sudo-exec',
+    'Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.',
     {
-      command: z.string().describe("Shell command to execute with sudo on the remote SSH server"),
-      description: z.string().optional().describe("Optional description of what this command will do"),
+      command: z.string().describe('Shell command to execute with sudo on the remote SSH server'),
+      description: z.string().optional().describe('Optional description of what this command will do'),
     },
     async ({ command, description }) => {
       const sanitizedCommand = sanitizeCommand(command);
-
       try {
-        if (!connectionManager) {
-          if (!HOST || !USER) {
-            throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-          }
-
-          const sshConfig: SSHConfig = {
-            host: HOST,
-            port: PORT || 22,
-            username: USER,
-          };
-          if (PASSWORD) {
-            sshConfig.password = PASSWORD;
-          } else if (KEY) {
-            const fs = await import('fs/promises');
-            sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-          }
-          if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-            sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-          }
-          if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-            sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
-          }
-          connectionManager = new SSHConnectionManager(sshConfig);
-        }
-
-        await connectionManager.ensureConnected();
-
-        // If suPassword or sudoPassword were provided on this call but the
-        // existing connection manager was created earlier without them,
-        // update the manager's values so the subsequent sudo-exec call uses
-        // the latest passwords.
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          await connectionManager.setSuPassword(sanitizePassword(SUPASSWORD));
-        }
-        if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-          // update sudoPassword on the manager instance
-          (connectionManager as any).sshConfig = { ...(connectionManager as any).sshConfig, sudoPassword: sanitizePassword(SUDOPASSWORD) };
-        }
-
-        let wrapped: string;
-        const sudoPassword = connectionManager.getSudoPassword();
-
-        // Append description as comment if provided
+        const t = await getOrCreateTransport();
         const commandWithDescription = description
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
-
-        if (!sudoPassword) {
-          // No password provided, use -n to fail if sudo requires a password
-          wrapped = `sudo -n sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
-        } else {
-          // Password provided — pipe it into sudo using printf. This avoids complex
-          // PTY/stdin handling on the SSH channel and is simpler and more reliable.
-          const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
-          wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
-        }
-
-        return await execSshCommandWithConnection(connectionManager, wrapped);
+        const sudoPwd = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined)
+          ? sanitizePassword(SUDOPASSWORD)
+          : undefined;
+        const result = await t.execElevated(commandWithDescription, {
+          timeoutMs: DEFAULT_TIMEOUT,
+          mode: 'sudo',
+          password: sudoPwd,
+        });
+        return resultToMcpContent(result);
       } catch (err: any) {
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
@@ -496,16 +262,24 @@ if (!DISABLE_SUDO) {
   );
 }
 
-// New function that uses persistent connection
-export async function execSshCommandWithConnection(manager: SSHConnectionManager, command: string, stdin?: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+// ===========================================================================
+// Legacy exports: preserved so existing tests (which import SSHConnectionManager,
+// execSshCommandWithConnection, execSshCommand) keep working without modification.
+// These call through to Ssh2Transport-equivalent logic or directly to ssh2.
+// ===========================================================================
+
+export async function execSshCommandWithConnection(
+  manager: SSHConnectionManager,
+  command: string,
+  stdin?: string
+): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: 'text'; text: string; } | { [x: string]: unknown; type: 'image'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'audio'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'resource'; resource: any; })[] }> {
   return new Promise((resolve, reject) => {
     let timeoutId: NodeJS.Timeout;
     let isResolved = false;
 
     const conn = manager.getConnection();
-    const shell = (manager as any).suShell;  // Use su shell if available
+    const shell = (manager as any).getSuShell ? (manager as any).getSuShell() : (manager as any).suShell;
 
-    // Set up timeout
     timeoutId = setTimeout(() => {
       if (!isResolved) {
         isResolved = true;
@@ -513,44 +287,29 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
       }
     }, DEFAULT_TIMEOUT);
 
-    // If we have an active su shell, use it directly (commands run as root in session)
     if (shell) {
       let buffer = '';
-
       const dataHandler = (data: Buffer) => {
         const text = data.toString();
         buffer += text;
-
-        // Wait for root prompt (#) to know command is complete
-        // Match # which indicates root prompt (may be followed by spaces, escape codes, etc)
         if (/#/.test(buffer)) {
           if (!isResolved) {
             isResolved = true;
             clearTimeout(timeoutId);
-
-            // Extract output: remove the command echo and final prompt
             const lines = buffer.split('\n');
-            // First line is often the echoed command; last line is the prompt
-            let output = lines.slice(1, -1).join('\n');
-
+            const output = lines.slice(1, -1).join('\n');
             resolve({
-              content: [{
-                type: 'text',
-                text: output + (output ? '\n' : ''),
-              }],
+              content: [{ type: 'text', text: output + (output ? '\n' : '') }],
             });
           }
           shell.removeListener('data', dataHandler);
         }
       };
-
       shell.on('data', dataHandler);
-      // Send command immediately; shell is ready after elevation
       shell.write(command + '\n');
       return;
     }
 
-    // No persistent su shell; use normal exec with optional password piping
     conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
       if (err) {
         if (!isResolved) {
@@ -564,37 +323,21 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
       let stdout = '';
       let stderr = '';
 
-      // If stdin provided (e.g., sudo password), write it
       if (stdin && stdin.length > 0) {
-        try {
-          stream.write(stdin);
-        } catch (e) {
-          console.error('Error writing to stdin:', e);
-        }
+        try { stream.write(stdin); } catch (e) { console.error('Error writing to stdin:', e); }
       }
       try { stream.end(); } catch (e) { /* ignore */ }
 
-      stream.on('data', (data: Buffer) => {
-        stdout += data.toString();
-      });
-
-      stream.stderr.on('data', (data: Buffer) => {
-        stderr += data.toString();
-      });
-
-      stream.on('close', (code: number, signal: string) => {
+      stream.on('data', (data: Buffer) => { stdout += data.toString(); });
+      stream.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+      stream.on('close', (code: number, _signal: string) => {
         if (!isResolved) {
           isResolved = true;
           clearTimeout(timeoutId);
           if (stderr) {
             reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
           } else {
-            resolve({
-              content: [{
-                type: 'text',
-                text: stdout,
-              }],
-            });
+            resolve({ content: [{ type: 'text', text: stdout }] });
           }
         }
       });
@@ -602,24 +345,21 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
   });
 }
 
-// Keep the old function for backward compatibility (used in tests)
-export async function execSshCommand(sshConfig: any, command: string, stdin?: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+export async function execSshCommand(
+  sshConfig: any,
+  command: string,
+  stdin?: string
+): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: 'text'; text: string; } | { [x: string]: unknown; type: 'image'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'audio'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'resource'; resource: any; })[] }> {
   return new Promise((resolve, reject) => {
     const conn = new Client();
     let timeoutId: NodeJS.Timeout;
     let isResolved = false;
 
-    // Set up timeout
     timeoutId = setTimeout(() => {
       if (!isResolved) {
         isResolved = true;
-        // Try to abort the running command before closing connection
-        const abortTimeout = setTimeout(() => {
-          // If abort command itself times out, force close connection
-          conn.end();
-        }, 5000); // 5 second timeout for abort command
-
-        conn.exec('timeout 3s pkill -f \'' + escapeCommandForShell(command) + '\' 2>/dev/null || true', (err: Error | undefined, abortStream: ClientChannel | undefined) => {
+        const abortTimeout = setTimeout(() => { conn.end(); }, 5000);
+        conn.exec(`timeout 3s pkill -f '${escapeCommandForShell(command)}' 2>/dev/null || true`, (err: Error | undefined, abortStream: ClientChannel | undefined) => {
           if (abortStream) {
             abortStream.on('close', () => {
               clearTimeout(abortTimeout);
@@ -645,18 +385,13 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
           conn.end();
           return;
         }
-        // If stdin provided, write it to the stream and end stdin
         if (stdin && stdin.length > 0) {
-          try {
-            stream.write(stdin);
-          } catch (e) {
-            // ignore
-          }
+          try { stream.write(stdin); } catch (e) { /* ignore */ }
         }
         try { stream.end(); } catch (e) { /* ignore */ }
         let stdout = '';
         let stderr = '';
-        stream.on('close', (code: number, signal: string) => {
+        stream.on('close', (code: number, _signal: string) => {
           if (!isResolved) {
             isResolved = true;
             clearTimeout(timeoutId);
@@ -664,21 +399,12 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
             if (stderr) {
               reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
             } else {
-              resolve({
-                content: [{
-                  type: 'text',
-                  text: stdout,
-                }],
-              });
+              resolve({ content: [{ type: 'text', text: stdout }] });
             }
           }
         });
-        stream.on('data', (data: Buffer) => {
-          stdout += data.toString();
-        });
-        stream.stderr.on('data', (data: Buffer) => {
-          stderr += data.toString();
-        });
+        stream.on('data', (data: Buffer) => { stdout += data.toString(); });
+        stream.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
       });
     });
     conn.on('error', (err: Error) => {
@@ -692,17 +418,20 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
   });
 }
 
+// ===========================================================================
+// Server lifecycle
+// ===========================================================================
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("SSH MCP Server running on stdio");
+  console.error('SSH MCP Server running on stdio');
 
-  // Handle graceful shutdown
   const cleanup = () => {
-    console.error("Shutting down SSH MCP Server...");
-    if (connectionManager) {
-      connectionManager.close();
-      connectionManager = null;
+    console.error('Shutting down SSH MCP Server...');
+    if (activeTransport) {
+      void activeTransport.close();
+      activeTransport = null;
     }
     process.exit(0);
   };
@@ -710,26 +439,23 @@ async function main() {
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
   process.on('exit', () => {
-    if (connectionManager) {
-      connectionManager.close();
+    if (activeTransport) {
+      void activeTransport.close();
     }
   });
 }
 
-// Initialize server in test mode for automated tests
 if (isTestMode) {
   const transport = new StdioServerTransport();
   server.connect(transport).catch(error => {
-    console.error("Fatal error connecting server:", error);
+    console.error('Fatal error connecting server:', error);
     process.exit(1);
   });
-}
-// Start server in CLI mode
-else if (isCliEnabled) {
+} else if (isCliEnabled) {
   main().catch((error) => {
-    console.error("Fatal error in main():", error);
-    if (connectionManager) {
-      connectionManager.close();
+    console.error('Fatal error in main():', error);
+    if (activeTransport) {
+      void activeTransport.close();
     }
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,11 +92,20 @@ function validateConfig(config: Record<string, string | null>) {
   if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
     errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
   }
-  if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
+  // OpenSSH options that require an explicit value. A value-less flag (e.g.
+  // `--strictHostKeyChecking` with no `=value`) is recorded as `null` by
+  // parseArgv; guarding on truthiness would silently skip validation and let
+  // buildTransportConfig drop the option, falling back to the default and (for
+  // strictHostKeyChecking) weakening the requested host-key policy. Detect the
+  // flag by property presence so a missing value is rejected with a clear error.
+  if ('strictHostKeyChecking' in config && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
     errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
   }
-  if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
+  if ('gssapiDelegateCredentials' in config && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
     errors.push('--gssapiDelegateCredentials must be yes or no');
+  }
+  if ('knownHostsFile' in config && !config.knownHostsFile) {
+    errors.push('--knownHostsFile requires a file path');
   }
 
   if (errors.length > 0) {
@@ -297,7 +306,14 @@ function stripBenignSshWarnings(stderr: string): string {
 }
 export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
-    throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
+    // Always surface that the command timed out, even when the process wrote to
+    // stderr before the deadline. A build/tool that prints progress or
+    // diagnostics to stderr and then hangs would otherwise be reported as an
+    // ordinary error, hiding the timeout. Keep any captured stderr as trailing
+    // context so its diagnostics are not lost.
+    const timeoutMsg = `Command execution timed out after ${DEFAULT_TIMEOUT}ms`;
+    const detail = result.stderr ? `${timeoutMsg}\n${result.stderr}` : timeoutMsg;
+    throw new McpError(ErrorCode.InternalError, detail);
   }
   if (result.category === 'auth') {
     throw new McpError(ErrorCode.InternalError, `SSH authentication error: ${result.stderr}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,46 +112,90 @@ export function sanitizeCommand(command: string): string {
   return sanitizeCommandImpl(command, MAX_CHARS as number);
 }
 
-function resolveTransport(): 'ssh2' | 'openssh' {
-  if (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) return 'openssh';
+function resolveTransport(opts: { transportFlag?: string | null; kerberos?: boolean }): 'ssh2' | 'openssh' {
+  if (opts.transportFlag === 'openssh' || opts.kerberos) return 'openssh';
   return 'ssh2';
 }
 
-function resolveAuthMode(): 'kerberos' | 'key' | 'password' | undefined {
-  if (KERBEROS_FLAG) return 'kerberos';
-  if (KEY) return 'key';
-  if (PASSWORD) return 'password';
+/**
+ * Resolve the effective auth mode from the provided credential flags.
+ *
+ * Precedence: kerberos > password > key. Password is ranked above key to
+ * preserve the legacy ssh2 behaviour (base `main`): when both a password and a
+ * key path are supplied, the password wins and the key file is never read. This
+ * avoids an ENOENT crash for password configs that still carry a stale/sample
+ * `--key=path/to/key`.
+ */
+export function resolveAuthMode(opts: {
+  kerberos?: boolean;
+  key?: string | null;
+  password?: string | null;
+}): 'kerberos' | 'key' | 'password' | undefined {
+  if (opts.kerberos) return 'kerberos';
+  if (opts.password) return 'password';
+  if (opts.key) return 'key';
   return undefined;
 }
 
-async function buildTransportConfig(): Promise<TransportConfig> {
-  if (!HOST || !USER) {
+/**
+ * Inputs for {@link buildTransportConfig}. Mirrors the legacy CLI flags but is
+ * passed explicitly so the resolution logic is pure and unit-testable.
+ */
+export interface BuildTransportConfigInputs {
+  host?: string | null;
+  port: number;
+  username?: string | null;
+  password?: string | null;
+  key?: string | null;
+  suPassword?: string | null;
+  sudoPassword?: string | null;
+  kerberos?: boolean;
+  transportFlag?: string | null;
+  gssapiDelegateCredentials?: string | null;
+  knownHostsFile?: string | null;
+  strictHostKeyChecking?: string | null;
+}
+
+export async function buildTransportConfig(inputs: BuildTransportConfigInputs): Promise<TransportConfig> {
+  const { host, username } = inputs;
+  if (!host || !username) {
     throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
   }
 
+  const transport = resolveTransport({ transportFlag: inputs.transportFlag, kerberos: inputs.kerberos });
+  const authMode = resolveAuthMode({
+    kerberos: inputs.kerberos,
+    password: inputs.password,
+    key: inputs.key,
+  });
+
   const cfg: TransportConfig = {
-    host: HOST,
-    port: PORT,
-    username: USER,
-    transport: resolveTransport(),
-    authMode: resolveAuthMode(),
+    host,
+    port: inputs.port,
+    username,
+    transport,
+    authMode,
   };
 
-  if (PASSWORD) cfg.password = PASSWORD;
-  if (KEY) {
-    cfg.keyPath = KEY;
-    // ssh2 transport needs the key contents, not the path
-    if (cfg.transport === 'ssh2') {
+  if (inputs.password) cfg.password = inputs.password;
+  if (inputs.key) {
+    cfg.keyPath = inputs.key;
+    // ssh2 transport needs the key contents, not the path — but only when the
+    // key is the resolved auth mode. A password config that also carries a
+    // stale/sample --key must NOT read the (possibly nonexistent) key file,
+    // which would otherwise throw ENOENT before connecting (regression vs base
+    // main, where password took precedence and the key was never read).
+    if (transport === 'ssh2' && authMode === 'key') {
       const fs = await import('fs/promises');
-      cfg.privateKey = await fs.readFile(KEY, 'utf8');
+      cfg.privateKey = await fs.readFile(inputs.key, 'utf8');
     }
   }
-  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
-  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
-  if (KERBEROS_FLAG) cfg.kerberos = true;
-  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
-  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
-  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+  if (inputs.suPassword !== null && inputs.suPassword !== undefined) cfg.suPassword = sanitizePassword(inputs.suPassword);
+  if (inputs.sudoPassword !== null && inputs.sudoPassword !== undefined) cfg.sudoPassword = sanitizePassword(inputs.sudoPassword);
+  if (inputs.kerberos) cfg.kerberos = true;
+  if (inputs.gssapiDelegateCredentials) cfg.gssapiDelegateCredentials = inputs.gssapiDelegateCredentials as 'yes' | 'no';
+  if (inputs.knownHostsFile) cfg.knownHostsFile = inputs.knownHostsFile;
+  if (inputs.strictHostKeyChecking) cfg.strictHostKeyChecking = inputs.strictHostKeyChecking as 'yes' | 'no' | 'accept-new';
 
   return cfg;
 }
@@ -160,7 +204,20 @@ let activeTransport: ISshTransport | null = null;
 
 async function getOrCreateTransport(): Promise<ISshTransport> {
   if (activeTransport) return activeTransport;
-  const cfg = await buildTransportConfig();
+  const cfg = await buildTransportConfig({
+    host: HOST,
+    port: PORT,
+    username: USER,
+    password: PASSWORD,
+    key: KEY,
+    suPassword: SUPASSWORD,
+    sudoPassword: SUDOPASSWORD,
+    kerberos: KERBEROS_FLAG,
+    transportFlag: TRANSPORT_FLAG,
+    gssapiDelegateCredentials: GSSAPI_DELEGATE,
+    knownHostsFile: KNOWN_HOSTS_FILE,
+    strictHostKeyChecking: STRICT_HOST_KEY,
+  });
   activeTransport = createTransport(cfg);
   await activeTransport.init();
   return activeTransport;
@@ -168,12 +225,20 @@ async function getOrCreateTransport(): Promise<ISshTransport> {
 
 /**
  * Map ExecResult to MCP tool response. Preserves upstream semantics:
- *   - stderr present → reject with McpError (wraps as "Error (code N):\n<stderr>")
  *   - auth/host_key/connect/transport categories → reject with descriptive error
  *   - timeout → reject with timeout error
- *   - success → return {content: [{type:'text', text: stdout}]}
+ *   - non-zero exit with stderr → reject (wraps as "Error (code N):\n<stderr>")
+ *   - exit 0 → success, even if stderr is non-empty
+ *
+ * Exit 0 is treated as success regardless of stderr: the OpenSSH transport
+ * surfaces benign diagnostics on stderr (e.g. with the default
+ * StrictHostKeyChecking=accept-new, the first connection to a host prints
+ * "Warning: Permanently added '<host>' ... to the list of known hosts." while
+ * exiting 0). Throwing on any stderr would turn every first-connect into an
+ * error. stderr is only an error indicator when the command actually failed
+ * (non-zero exit) and no more specific category applies.
  */
-function resultToMcpContent(result: ExecResult) {
+export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
   }
@@ -189,7 +254,7 @@ function resultToMcpContent(result: ExecResult) {
   if (result.category === 'transport') {
     throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
   }
-  if (result.stderr) {
+  if (result.stderr && result.exitCode !== 0) {
     throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
   }
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,16 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       break;
     case 'password':
       cfg.transport = resolveJsonTransport(obj);
-      if (obj.password) cfg.password = obj.password;
+      // Require actual password material. An empty/missing password still
+      // registers the server as password-authenticated but fails on first use:
+      // OpenSshTransport.init() throws "authMode=password requires --password",
+      // and the default ssh2 path attempts to connect without the credential the
+      // selected auth mode promises. Fail at parse time like the key-auth branch
+      // already does for missing key material (Codex 3549295040).
+      if (typeof obj.password !== 'string' || obj.password.length === 0) {
+        throw new Error(`--ssh "${obj.name}" auth "password" requires a non-empty "password"`);
+      }
+      cfg.password = obj.password;
       break;
   }
 
@@ -435,9 +444,20 @@ export async function buildTransportConfig(
 
 const registry = new TransportRegistry(prepareKeyContents);
 
-async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
+export async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
   // ssh2 transport reads key contents in memory; openssh uses -i path.
-  if (cfg.transport === 'ssh2' && cfg.keyPath && !cfg.privateKey) {
+  // Gate on authMode === 'key': buildTransportConfig() still records keyPath
+  // even when password auth takes precedence over a stale/sample --key, so a
+  // config such as `--password=... --key=/stale` must NOT read the (possibly
+  // nonexistent) key file here — otherwise the first tool call fails with
+  // ENOENT instead of using the password (Codex 3549295046). Mirrors the eager
+  // read's `authMode === 'key'` guard in buildTransportConfig().
+  if (
+    cfg.authMode === 'key' &&
+    cfg.transport === 'ssh2' &&
+    cfg.keyPath &&
+    !cfg.privateKey
+  ) {
     const fs = await import('fs/promises');
     cfg.privateKey = await fs.readFile(cfg.keyPath, 'utf8');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,27 +200,64 @@ export async function buildTransportConfig(inputs: BuildTransportConfigInputs): 
   return cfg;
 }
 
-let activeTransport: ISshTransport | null = null;
+export interface TransportInitCache {
+  activeTransport: ISshTransport | null;
+  initPromise: Promise<ISshTransport> | null;
+}
+
+const activeTransportCache: TransportInitCache = {
+  activeTransport: null,
+  initPromise: null,
+};
+
+/**
+ * Return the active transport, or share one in-flight initialization.
+ *
+ * The transport must not be published before init() completes: OpenSSH password
+ * auth prepares SSH_ASKPASS asynchronously, and a concurrent tool call that sees
+ * a half-initialized transport can enter runSsh before the helper/env is ready.
+ */
+export function getOrCreateInitializedTransport(
+  cache: TransportInitCache,
+  createInitializedTransport: () => Promise<ISshTransport>,
+): Promise<ISshTransport> {
+  if (cache.activeTransport) return Promise.resolve(cache.activeTransport);
+  if (cache.initPromise) return cache.initPromise;
+
+  const initPromise = createInitializedTransport()
+    .then((transport) => {
+      cache.activeTransport = transport;
+      if (cache.initPromise === initPromise) cache.initPromise = null;
+      return transport;
+    })
+    .catch((err) => {
+      if (cache.initPromise === initPromise) cache.initPromise = null;
+      throw err;
+    });
+  cache.initPromise = initPromise;
+  return initPromise;
+}
 
 async function getOrCreateTransport(): Promise<ISshTransport> {
-  if (activeTransport) return activeTransport;
-  const cfg = await buildTransportConfig({
-    host: HOST,
-    port: PORT,
-    username: USER,
-    password: PASSWORD,
-    key: KEY,
-    suPassword: SUPASSWORD,
-    sudoPassword: SUDOPASSWORD,
-    kerberos: KERBEROS_FLAG,
-    transportFlag: TRANSPORT_FLAG,
-    gssapiDelegateCredentials: GSSAPI_DELEGATE,
-    knownHostsFile: KNOWN_HOSTS_FILE,
-    strictHostKeyChecking: STRICT_HOST_KEY,
+  return getOrCreateInitializedTransport(activeTransportCache, async () => {
+    const cfg = await buildTransportConfig({
+      host: HOST,
+      port: PORT,
+      username: USER,
+      password: PASSWORD,
+      key: KEY,
+      suPassword: SUPASSWORD,
+      sudoPassword: SUDOPASSWORD,
+      kerberos: KERBEROS_FLAG,
+      transportFlag: TRANSPORT_FLAG,
+      gssapiDelegateCredentials: GSSAPI_DELEGATE,
+      knownHostsFile: KNOWN_HOSTS_FILE,
+      strictHostKeyChecking: STRICT_HOST_KEY,
+    });
+    const transport = createTransport(cfg);
+    await transport.init();
+    return transport;
   });
-  activeTransport = createTransport(cfg);
-  await activeTransport.init();
-  return activeTransport;
 }
 
 /**
@@ -500,9 +537,10 @@ async function main() {
 
   const cleanup = () => {
     console.error('Shutting down SSH MCP Server...');
-    if (activeTransport) {
-      void activeTransport.close();
-      activeTransport = null;
+    if (activeTransportCache.activeTransport) {
+      void activeTransportCache.activeTransport.close();
+      activeTransportCache.activeTransport = null;
+      activeTransportCache.initPromise = null;
     }
     process.exit(0);
   };
@@ -510,8 +548,8 @@ async function main() {
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
   process.on('exit', () => {
-    if (activeTransport) {
-      void activeTransport.close();
+    if (activeTransportCache.activeTransport) {
+      void activeTransportCache.activeTransport.close();
     }
   });
 }
@@ -525,8 +563,8 @@ if (isTestMode) {
 } else if (isCliEnabled) {
   main().catch((error) => {
     console.error('Fatal error in main():', error);
-    if (activeTransport) {
-      void activeTransport.close();
+    if (activeTransportCache.activeTransport) {
+      void activeTransportCache.activeTransport.close();
     }
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
   sanitizePassword,
   escapeCommandForShell,
 } from './utils/shell.js';
+import { AuditStore, resolveAuditDir, yoloApproval } from './audit/store.js';
+import { AuditTool } from './audit/types.js';
 
 // Re-exports for backward compatibility with existing tests.
 export { SSHConnectionManager, escapeCommandForShell };
@@ -115,6 +117,17 @@ const SUDOPASSWORD = argvConfig.sudoPassword;
 const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
 const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000;
+// TODO(toml-config): read [server].audit_dir / [server].audit_max_bytes from
+// the resolved TOML config once the toml-config card lands. For now, keep the
+// documented default and support env overrides for tests/operators.
+const AUDIT_DIR = resolveAuditDir(process.env.SSH_MCP_AUDIT_DIR);
+const AUDIT_MAX_BYTES = (() => {
+  const raw = process.env.SSH_MCP_AUDIT_MAX_BYTES;
+  if (!raw) return 10_000;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 10_000;
+})();
+const auditStore = new AuditStore({ auditDir: AUDIT_DIR, auditMaxBytes: AUDIT_MAX_BYTES });
 const MAX_CHARS_RAW = argvConfig.maxChars;
 const MAX_CHARS = (() => {
   if (typeof MAX_CHARS_RAW === 'string') {
@@ -238,6 +251,85 @@ async function bootstrapRegistry(): Promise<void> {
   }
 }
 
+function resolvedProfileName(connectionName?: string): string {
+  return connectionName ?? registry.getDefaultName() ?? 'default';
+}
+
+function auditExecution(params: {
+  tool: AuditTool;
+  profile: string;
+  command: string;
+  description?: string;
+  startedAt: number;
+  result?: ExecResult;
+  error?: unknown;
+  store?: AuditStore;
+}): void {
+  const now = new Date();
+  const durationMs = Math.max(0, Date.now() - params.startedAt);
+  const store = params.store ?? auditStore;
+  try {
+    store.append({
+      profile: params.profile,
+      tool: params.tool,
+      command: params.command,
+      description: params.description,
+      approval: yoloApproval(now),
+      exec: params.result
+        ? {
+            stdout: params.result.stdout ?? '',
+            stderr: params.result.stderr ?? '',
+            exitCode: params.result.exitCode ?? null,
+            durationMs,
+          }
+        : {
+            stdout: '',
+            stderr: params.error instanceof Error ? params.error.message : String(params.error ?? 'unknown error'),
+            exitCode: null,
+            durationMs,
+          },
+      now,
+    });
+  } catch (auditErr: any) {
+    // Audit failure must be visible but should not hide the real SSH result.
+    console.error(`audit log append failed: ${auditErr?.message || auditErr}`);
+  }
+}
+
+export async function executeAuditedTransportCommand(input: {
+  transport: Pick<ISshTransport, 'exec' | 'execElevated'>;
+  tool: AuditTool;
+  command: string;
+  description?: string;
+  profile?: string;
+  timeoutMs?: number;
+  sudoPassword?: string;
+  store: AuditStore;
+}) {
+  const sanitizedCommand = sanitizeCommand(input.command);
+  const commandWithDescription = input.description
+    ? `${sanitizedCommand} # ${input.description.replace(/#/g, '\\#')}`
+    : sanitizedCommand;
+  const startedAt = Date.now();
+  const result = input.tool === 'sudo-exec'
+    ? await input.transport.execElevated(commandWithDescription, {
+        timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT,
+        mode: 'sudo',
+        password: input.sudoPassword,
+      })
+    : await input.transport.exec(commandWithDescription, { timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT });
+  auditExecution({
+    tool: input.tool,
+    profile: input.profile ?? 'stub',
+    command: commandWithDescription,
+    description: input.description,
+    startedAt,
+    result,
+    store: input.store,
+  });
+  return resultToMcpContent(result);
+}
+
 export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
@@ -294,14 +386,27 @@ server.tool(
   },
   async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
+    const profile = resolvedProfileName(connectionName);
+    const startedAt = Date.now();
+    let audited = false;
     try {
       const t = await registry.get(connectionName);
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
       const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
+      auditExecution({
+        tool: 'exec',
+        profile,
+        command: commandWithDescription,
+        description,
+        startedAt,
+        result,
+      });
+      audited = true;
       return resultToMcpContent(result);
     } catch (err: any) {
+      if (!audited) auditExecution({ tool: 'exec', profile, command: sanitizedCommand, description, startedAt, error: err });
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
     }
@@ -319,6 +424,9 @@ if (!DISABLE_SUDO) {
     },
     async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
+      const profile = resolvedProfileName(connectionName);
+      const startedAt = Date.now();
+      let audited = false;
       try {
         const t = await registry.get(connectionName);
         const commandWithDescription = description
@@ -334,8 +442,18 @@ if (!DISABLE_SUDO) {
           mode: 'sudo',
           password: legacySudo,
         });
+        auditExecution({
+          tool: 'sudo-exec',
+          profile,
+          command: commandWithDescription,
+          description,
+          startedAt,
+          result,
+        });
+        audited = true;
         return resultToMcpContent(result);
       } catch (err: any) {
+        if (!audited) auditExecution({ tool: 'sudo-exec', profile, command: sanitizedCommand, description, startedAt, error: err });
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function collectSshJsonArgs(): string[] {
     .map(a => a.slice('--ssh='.length));
 }
 
-function parseServerConfigJson(raw: string): ServerConfig {
+export function parseServerConfigJson(raw: string): ServerConfig {
   let obj: any;
   try {
     obj = JSON.parse(raw);
@@ -95,6 +95,16 @@ function parseServerConfigJson(raw: string): ServerConfig {
 
   if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
   if (obj.suPassword) cfg.suPassword = obj.suPassword;
+  // knownHostsFile / strictHostKeyChecking are openssh-transport-only. The ssh2
+  // transport ignores both, so accepting them on an ssh2 config would silently
+  // drop the requested host-key enforcement — a security downgrade. Mirror the
+  // legacy single-host rule ("--knownHostsFile and --strictHostKeyChecking
+  // require --transport=openssh") and reject the combination here.
+  if ((obj.knownHostsFile || obj.strictHostKeyChecking) && cfg.transport !== 'openssh') {
+    throw new Error(
+      `--ssh "${obj.name}" knownHostsFile/strictHostKeyChecking require "transport": "openssh" (got ${cfg.transport})`
+    );
+  }
   if (obj.knownHostsFile) cfg.knownHostsFile = obj.knownHostsFile;
   if (obj.strictHostKeyChecking) cfg.strictHostKeyChecking = obj.strictHostKeyChecking;
   return cfg;
@@ -138,8 +148,13 @@ function validateConfig(config: Record<string, string | null>, multiHost: boolea
   const errors: string[] = [];
 
   if (multiHost) {
-    // Multi-host mode: legacy single-host flags are disallowed to avoid ambiguity
-    const legacyFlags = ['host', 'user', 'password', 'key', 'kerberos', 'transport',
+    // Multi-host mode: legacy single-host flags are disallowed to avoid ambiguity.
+    // bootstrapRegistry reads connection details ONLY from each --ssh JSON in
+    // this mode, so any legacy flag would be silently ignored — including
+    // --port (wrong port), --sudoPassword and --suPassword (elevation would run
+    // without the password). Reject the whole set rather than drop them quietly.
+    const legacyFlags = ['host', 'user', 'port', 'password', 'key', 'kerberos', 'transport',
+                         'sudoPassword', 'suPassword',
                          'strictHostKeyChecking', 'knownHostsFile', 'gssapiDelegateCredentials'];
     const set = legacyFlags.filter(f => config[f] !== undefined);
     if (set.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ async function bootstrapRegistry(): Promise<void> {
   }
 }
 
-function resultToMcpContent(result: ExecResult) {
+export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
   }
@@ -254,13 +254,23 @@ function resultToMcpContent(result: ExecResult) {
   if (result.category === 'transport') {
     throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
   }
-  if (result.stderr) {
-    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
+  // Only treat stderr as a hard failure when the command actually failed (non-zero exit).
+  // Many tools (sudo with -S, curl, git, apt) write progress/info to stderr on success.
+  const exitCode = result.exitCode ?? 0;
+  if (exitCode !== 0 && result.stderr) {
+    throw new McpError(ErrorCode.InternalError, `Error (code ${exitCode}):\n${result.stderr}`);
   }
+  // Success path: include stderr alongside stdout when it has substantive content.
+  const trimmedStderr = result.stderr.trim();
+  const text = trimmedStderr
+    ? (result.stdout
+        ? `${result.stdout.replace(/\n+$/, '')}\n[stderr]\n${result.stderr}`
+        : result.stderr)
+    : result.stdout;
   return {
     content: [{
       type: 'text' as const,
-      text: result.stdout,
+      text,
     }],
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,26 @@ import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-import { ISshTransport, TransportConfig, ExecResult } from './transports/types.js';
+import { ISshTransport, TransportConfig, ServerConfig, ExecResult, AuthMode } from './transports/types.js';
 import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
 import { createTransport } from './transports/factory.js';
+import { TransportRegistry } from './transports/registry.js';
 import {
   sanitizeCommand as sanitizeCommandImpl,
   sanitizePassword,
   escapeCommandForShell,
 } from './utils/shell.js';
 
-// Re-exports for backward compatibility with existing tests (smoke.ssh.test.ts,
-// persistent-connection.test.ts, etc.).
+// Re-exports for backward compatibility with existing tests.
 export { SSHConnectionManager, escapeCommandForShell };
 export type { SSHConfig };
 
-// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
-// Kerberos SSO:   node build/index.js --host=host --user=user@REALM --kerberos
+// =============================================================================
+// CLI parsing — two modes:
+//   (A) Multi-host: repeated --ssh=<JSON> (each JSON must include "name")
+//   (B) Legacy single-host: --host --user [--kerberos | --key | --password] ...
+// =============================================================================
+
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
@@ -31,18 +35,77 @@ function parseArgv() {
       if (equalIndex === -1) {
         config[arg.slice(2)] = null;
       } else {
-        config[arg.slice(2, equalIndex)] = arg.slice(equalIndex + 1);
+        const key = arg.slice(2, equalIndex);
+        // --ssh is handled separately below (repeatable); skip here so we
+        // don't clobber with only the last value.
+        if (key === 'ssh') continue;
+        config[key] = arg.slice(equalIndex + 1);
       }
     }
   }
   return config;
 }
 
+function collectSshJsonArgs(): string[] {
+  return process.argv.slice(2)
+    .filter(a => a.startsWith('--ssh='))
+    .map(a => a.slice('--ssh='.length));
+}
+
+function parseServerConfigJson(raw: string): ServerConfig {
+  let obj: any;
+  try {
+    obj = JSON.parse(raw);
+  } catch (e: any) {
+    throw new Error(`--ssh JSON parse error: ${e?.message || e}\nRaw: ${raw}`);
+  }
+  if (!obj.name) throw new Error('--ssh JSON missing required "name"');
+  if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
+  const user = obj.user ?? obj.username;
+  if (!user) throw new Error(`--ssh "${obj.name}" missing required "user" (or "username")`);
+  const auth: AuthMode | undefined = obj.auth;
+  if (!auth || !['kerberos', 'key', 'password'].includes(auth)) {
+    throw new Error(`--ssh "${obj.name}" requires "auth": "kerberos" | "key" | "password"`);
+  }
+
+  const cfg: ServerConfig = {
+    name: obj.name,
+    host: obj.host,
+    port: obj.port ?? 22,
+    username: user,
+    authMode: auth,
+  };
+
+  switch (auth) {
+    case 'kerberos':
+      cfg.kerberos = true;
+      cfg.transport = 'openssh';
+      if (obj.gssapiDelegateCredentials) cfg.gssapiDelegateCredentials = obj.gssapiDelegateCredentials;
+      break;
+    case 'key':
+      cfg.transport = obj.transport ?? 'ssh2';
+      if (obj.keyPath) cfg.keyPath = obj.keyPath;
+      if (obj.privateKey) cfg.privateKey = obj.privateKey;
+      break;
+    case 'password':
+      cfg.transport = obj.transport ?? 'ssh2';
+      if (obj.password) cfg.password = obj.password;
+      break;
+  }
+
+  if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
+  if (obj.suPassword) cfg.suPassword = obj.suPassword;
+  if (obj.knownHostsFile) cfg.knownHostsFile = obj.knownHostsFile;
+  if (obj.strictHostKeyChecking) cfg.strictHostKeyChecking = obj.strictHostKeyChecking;
+  return cfg;
+}
+
 const isTestMode = process.env.SSH_MCP_TEST === '1';
 const isCliEnabled = process.env.SSH_MCP_DISABLE_MAIN !== '1';
 const argvConfig = (isCliEnabled || isTestMode) ? parseArgv() : {} as Record<string, string>;
+const sshJsonArgs = (isCliEnabled || isTestMode) ? collectSshJsonArgs() : [];
 
-// Connection config (legacy flags)
+// Legacy (single-host) flags
 const HOST = argvConfig.host;
 const PORT = argvConfig.port ? parseInt(argvConfig.port) : 22;
 const USER = argvConfig.user;
@@ -65,38 +128,48 @@ const MAX_CHARS = (() => {
   return 1000;
 })();
 
-// Transport config (new flags)
 const TRANSPORT_FLAG = argvConfig.transport;
 const KERBEROS_FLAG = argvConfig.kerberos !== undefined && argvConfig.kerberos !== 'false';
 const GSSAPI_DELEGATE = argvConfig.gssapiDelegateCredentials;
 const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
 const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
 
-function validateConfig(config: Record<string, string | null>) {
+function validateConfig(config: Record<string, string | null>, multiHost: boolean) {
   const errors: string[] = [];
-  if (!config.host) errors.push('Missing required --host');
-  if (!config.user) errors.push('Missing required --user');
-  if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
 
-  const transportExplicit = config.transport;
-  const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
-  // --kerberos alone implies --transport=openssh
-  const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
+  if (multiHost) {
+    // Multi-host mode: legacy single-host flags are disallowed to avoid ambiguity
+    const legacyFlags = ['host', 'user', 'password', 'key', 'kerberos', 'transport',
+                         'strictHostKeyChecking', 'knownHostsFile', 'gssapiDelegateCredentials'];
+    const set = legacyFlags.filter(f => config[f] !== undefined);
+    if (set.length > 0) {
+      errors.push(`Multi-host (--ssh) mode cannot be mixed with legacy single-host flags: ${set.map(s => '--' + s).join(', ')}`);
+    }
+  } else {
+    // Legacy single-host validation
+    if (!config.host) errors.push('Missing required --host (or use --ssh=<JSON> for multi-host mode)');
+    if (!config.user) errors.push('Missing required --user');
+    if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
 
-  if (transport !== 'ssh2' && transport !== 'openssh') {
-    errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
-  }
-  if (kerberos && transportExplicit === 'ssh2') {
-    errors.push('--kerberos requires --transport=openssh (remove --transport=ssh2 or pass --kerberos alone)');
-  }
-  if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
-    errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
-  }
-  if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
-    errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
-  }
-  if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
-    errors.push('--gssapiDelegateCredentials must be yes or no');
+    const transportExplicit = config.transport;
+    const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+    const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
+
+    if (transport !== 'ssh2' && transport !== 'openssh') {
+      errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
+    }
+    if (kerberos && transportExplicit === 'ssh2') {
+      errors.push('--kerberos requires --transport=openssh (remove --transport=ssh2 or pass --kerberos alone)');
+    }
+    if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
+      errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
+    }
+    if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
+      errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
+    }
+    if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
+      errors.push('--gssapiDelegateCredentials must be yes or no');
+    }
   }
 
   if (errors.length > 0) {
@@ -104,75 +177,67 @@ function validateConfig(config: Record<string, string | null>) {
   }
 }
 
+const isMultiHost = sshJsonArgs.length > 0;
+
 if (isCliEnabled) {
-  validateConfig(argvConfig);
+  validateConfig(argvConfig, isMultiHost);
 }
 
 export function sanitizeCommand(command: string): string {
   return sanitizeCommandImpl(command, MAX_CHARS as number);
 }
 
-function resolveTransport(): 'ssh2' | 'openssh' {
-  if (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) return 'openssh';
-  return 'ssh2';
-}
+// =============================================================================
+// Transport registry — lazy init, single entry for legacy single-host mode.
+// =============================================================================
 
-function resolveAuthMode(): 'kerberos' | 'key' | 'password' | undefined {
-  if (KERBEROS_FLAG) return 'kerberos';
-  if (KEY) return 'key';
-  if (PASSWORD) return 'password';
-  return undefined;
-}
+const registry = new TransportRegistry();
 
-async function buildTransportConfig(): Promise<TransportConfig> {
-  if (!HOST || !USER) {
-    throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
+  // ssh2 transport reads key contents in memory; openssh uses -i path.
+  if (cfg.transport === 'ssh2' && cfg.keyPath && !cfg.privateKey) {
+    const fs = await import('fs/promises');
+    cfg.privateKey = await fs.readFile(cfg.keyPath, 'utf8');
   }
+}
 
-  const cfg: TransportConfig = {
-    host: HOST,
-    port: PORT,
-    username: USER,
-    transport: resolveTransport(),
-    authMode: resolveAuthMode(),
-  };
-
-  if (PASSWORD) cfg.password = PASSWORD;
-  if (KEY) {
-    cfg.keyPath = KEY;
-    // ssh2 transport needs the key contents, not the path
-    if (cfg.transport === 'ssh2') {
-      const fs = await import('fs/promises');
-      cfg.privateKey = await fs.readFile(KEY, 'utf8');
+async function bootstrapRegistry(): Promise<void> {
+  if (isMultiHost) {
+    for (const raw of sshJsonArgs) {
+      const cfg = parseServerConfigJson(raw);
+      await prepareKeyContents(cfg);
+      registry.register(cfg);
     }
+  } else {
+    if (!HOST || !USER) return; // Test mode with no CLI — tools will error if called
+    const authMode: AuthMode | undefined = KERBEROS_FLAG ? 'kerberos'
+      : KEY ? 'key'
+      : PASSWORD ? 'password'
+      : undefined;
+    const resolvedTransport: 'ssh2' | 'openssh' =
+      (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) ? 'openssh' : 'ssh2';
+
+    const cfg: ServerConfig = {
+      name: 'default',
+      host: HOST,
+      port: PORT,
+      username: USER,
+      transport: resolvedTransport,
+      authMode,
+    };
+    if (PASSWORD) cfg.password = PASSWORD;
+    if (KEY) cfg.keyPath = KEY;
+    if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
+    if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
+    if (KERBEROS_FLAG) cfg.kerberos = true;
+    if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
+    if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
+    if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+    await prepareKeyContents(cfg);
+    registry.register(cfg);
   }
-  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
-  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
-  if (KERBEROS_FLAG) cfg.kerberos = true;
-  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
-  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
-  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
-
-  return cfg;
 }
 
-let activeTransport: ISshTransport | null = null;
-
-async function getOrCreateTransport(): Promise<ISshTransport> {
-  if (activeTransport) return activeTransport;
-  const cfg = await buildTransportConfig();
-  activeTransport = createTransport(cfg);
-  await activeTransport.init();
-  return activeTransport;
-}
-
-/**
- * Map ExecResult to MCP tool response. Preserves upstream semantics:
- *   - stderr present → reject with McpError (wraps as "Error (code N):\n<stderr>")
- *   - auth/host_key/connect/transport categories → reject with descriptive error
- *   - timeout → reject with timeout error
- *   - success → return {content: [{type:'text', text: stdout}]}
- */
 function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
@@ -202,24 +267,25 @@ function resultToMcpContent(result: ExecResult) {
 
 const server = new McpServer({
   name: 'SSH MCP Server',
-  version: '2.0.0',
-  capabilities: {
-    resources: {},
-    tools: {},
-  },
+  version: '2.1.0',
+  capabilities: { resources: {}, tools: {} },
 });
+
+const connectionNameSchema = z.string().optional()
+  .describe('Name of the SSH connection (from --ssh config). Optional when only one server is configured.');
 
 server.tool(
   'exec',
-  'Execute a shell command on the remote SSH server and return the output.',
+  'Execute a shell command on a remote SSH server and return the output.',
   {
     command: z.string().describe('Shell command to execute on the remote SSH server'),
     description: z.string().optional().describe('Optional description of what this command will do'),
+    connectionName: connectionNameSchema,
   },
-  async ({ command, description }) => {
+  async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
     try {
-      const t = await getOrCreateTransport();
+      const t = await registry.get(connectionName);
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
@@ -235,25 +301,28 @@ server.tool(
 if (!DISABLE_SUDO) {
   server.tool(
     'sudo-exec',
-    'Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.',
+    'Execute a shell command on a remote SSH server using sudo. Uses the configured sudoPassword if provided; otherwise assumes passwordless sudo.',
     {
       command: z.string().describe('Shell command to execute with sudo on the remote SSH server'),
       description: z.string().optional().describe('Optional description of what this command will do'),
+      connectionName: connectionNameSchema,
     },
-    async ({ command, description }) => {
+    async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
       try {
-        const t = await getOrCreateTransport();
+        const t = await registry.get(connectionName);
         const commandWithDescription = description
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
-        const sudoPwd = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined)
+        // Legacy single-host mode may still pass --sudoPassword on CLI; in
+        // multi-host mode each ServerConfig carries its own sudoPassword.
+        const legacySudo = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined && !isMultiHost)
           ? sanitizePassword(SUDOPASSWORD)
           : undefined;
         const result = await t.execElevated(commandWithDescription, {
           timeoutMs: DEFAULT_TIMEOUT,
           mode: 'sudo',
-          password: sudoPwd,
+          password: legacySudo,
         });
         return resultToMcpContent(result);
       } catch (err: any) {
@@ -264,11 +333,27 @@ if (!DISABLE_SUDO) {
   );
 }
 
-// ===========================================================================
-// Legacy exports: preserved so existing tests (which import SSHConnectionManager,
-// execSshCommandWithConnection, execSshCommand) keep working without modification.
-// These call through to Ssh2Transport-equivalent logic or directly to ssh2.
-// ===========================================================================
+server.tool(
+  'list-servers',
+  'List all configured SSH server connections, their auth mode, and current connection status.',
+  {},
+  async () => {
+    const rows = registry.list();
+    if (rows.length === 0) {
+      return { content: [{ type: 'text', text: 'No SSH servers are configured.' }] };
+    }
+    const text = rows.map(r => {
+      const tag = r.isDefault ? ' (default)' : '';
+      const state = r.connected ? 'connected' : 'not yet connected';
+      return `- ${r.name}${tag}: ${r.username}@${r.host}:${r.port} [transport=${r.transport}, auth=${r.authMode}, ${state}]`;
+    }).join('\n');
+    return { content: [{ type: 'text', text }] };
+  }
+);
+
+// =============================================================================
+// Legacy exports preserved for existing test files.
+// =============================================================================
 
 export async function execSshCommandWithConnection(
   manager: SSHConnectionManager,
@@ -420,45 +505,43 @@ export async function execSshCommand(
   });
 }
 
-// ===========================================================================
+// =============================================================================
 // Server lifecycle
-// ===========================================================================
+// =============================================================================
 
 async function main() {
+  await bootstrapRegistry();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error('SSH MCP Server running on stdio');
+  const mode = isMultiHost ? `multi-host (${registry.names().length} servers: ${registry.names().join(', ')})` : 'single-host';
+  console.error(`SSH MCP Server running on stdio — ${mode}`);
 
   const cleanup = () => {
     console.error('Shutting down SSH MCP Server...');
-    if (activeTransport) {
-      void activeTransport.close();
-      activeTransport = null;
-    }
+    void registry.closeAll();
     process.exit(0);
   };
 
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
-  process.on('exit', () => {
-    if (activeTransport) {
-      void activeTransport.close();
-    }
-  });
+  process.on('exit', () => { void registry.closeAll(); });
 }
 
 if (isTestMode) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(error => {
-    console.error('Fatal error connecting server:', error);
-    process.exit(1);
-  });
+  (async () => {
+    try {
+      await bootstrapRegistry();
+    } catch { /* tests may not configure hosts */ }
+    const transport = new StdioServerTransport();
+    server.connect(transport).catch(error => {
+      console.error('Fatal error connecting server:', error);
+      process.exit(1);
+    });
+  })();
 } else if (isCliEnabled) {
   main().catch((error) => {
     console.error('Fatal error in main():', error);
-    if (activeTransport) {
-      void activeTransport.close();
-    }
+    void registry.closeAll();
     process.exit(1);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,16 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       break;
     case 'key':
       cfg.transport = resolveJsonTransport(obj);
+      // The legacy single-host CLI used `--key=<path>`; the multi-host JSON
+      // schema uses `keyPath` (openssh -i / ssh2 read from disk) or
+      // `privateKey` (ssh2 inline contents). A legacy-shaped top-level `key`
+      // field is read by neither transport, so a config that supplies only
+      // `key` has NO key material and would silently fall back to ambient
+      // agent/default identities. Reject it with guidance instead of accepting
+      // a credential-less key config (Codex 3541767246).
+      if (obj.key !== undefined) {
+        throw new Error(`--ssh "${obj.name}" auth "key" uses "keyPath" (or "privateKey" for ssh2), not "key"`);
+      }
       // OpenSshTransport.buildArgs only passes cfg.keyPath via `-i`; an inline
       // privateKey would be silently ignored and ssh would fall back to
       // agent/default identities. Reject the combination so the configured
@@ -134,6 +144,17 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       }
       if (obj.keyPath) cfg.keyPath = obj.keyPath;
       if (obj.privateKey) cfg.privateKey = obj.privateKey;
+      // Require actual key material. Without keyPath (openssh -i / ssh2 read)
+      // or an inline privateKey (ssh2), buildArgs() omits `-i` and
+      // `IdentitiesOnly=yes`, and the ssh2 transport has no key, so the
+      // connection silently falls back to whatever default or agent identity is
+      // offered instead of the intended key. Fail at parse time rather than
+      // let a key-auth config connect with an ambient identity (Codex 3541767246).
+      if (!cfg.keyPath && !cfg.privateKey) {
+        throw new Error(
+          `--ssh "${obj.name}" auth "key" requires "keyPath"${cfg.transport === 'ssh2' ? ' or inline "privateKey"' : ''}`,
+        );
+      }
       break;
     case 'password':
       cfg.transport = resolveJsonTransport(obj);
@@ -344,7 +365,22 @@ export interface BuildTransportConfigInputs {
   strictHostKeyChecking?: string | null;
 }
 
-export async function buildTransportConfig(inputs: BuildTransportConfigInputs): Promise<TransportConfig> {
+export interface BuildTransportConfigOptions {
+  /**
+   * When true, an ssh2 key config records `keyPath` but does NOT read the key
+   * file contents into `privateKey`. The read is deferred to the registry's
+   * lazy `prepareKeyContents` hook on the first tool call. Used by the legacy
+   * single-host bootstrap so a key mounted after process launch still works —
+   * matching the pre-registry behavior where the key was only read inside
+   * getOrCreateTransport() on first use, not at startup.
+   */
+  deferKeyRead?: boolean;
+}
+
+export async function buildTransportConfig(
+  inputs: BuildTransportConfigInputs,
+  opts: BuildTransportConfigOptions = {},
+): Promise<TransportConfig> {
   const { host, username } = inputs;
   if (!host || !username) {
     throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
@@ -373,7 +409,12 @@ export async function buildTransportConfig(inputs: BuildTransportConfigInputs): 
     // stale/sample --key must NOT read the (possibly nonexistent) key file,
     // which would otherwise throw ENOENT before connecting (regression vs base
     // main, where password took precedence and the key was never read).
-    if (transport === 'ssh2' && authMode === 'key') {
+    //
+    // deferKeyRead skips the eager read entirely so the registry's lazy
+    // prepareKeyContents hook reads it on first tool call instead. The legacy
+    // single-host bootstrap uses this so a key mounted after process launch is
+    // still honored — startup must not read the key file (Codex 3541767256).
+    if (transport === 'ssh2' && authMode === 'key' && !opts.deferKeyRead) {
       const fs = await import('fs/promises');
       cfg.privateKey = await fs.readFile(inputs.key, 'utf8');
     }
@@ -415,10 +456,13 @@ async function bootstrapRegistry(): Promise<void> {
   } else {
     if (!HOST || !USER) return; // Test mode with no CLI — tools will error if called
     // Route the legacy single-host path through buildTransportConfig so it
-    // inherits the kerberos>password>key precedence and the gated key read
-    // (a password config carrying a stale --key must not ENOENT on a missing
-    // key file). buildTransportConfig already loads privateKey when key is the
-    // resolved auth mode, so no separate prepareKeyContents call is needed here.
+    // inherits the kerberos>password>key precedence. Pass deferKeyRead so the
+    // ssh2 key file is NOT read at startup: prepareKeyContents (the registry's
+    // lazy prepareConfig hook) reads it on the first tool call instead, exactly
+    // like the multi-host path. This preserves the pre-registry behavior where
+    // the key was read only inside getOrCreateTransport(), so a key-based
+    // deployment whose secret mount appears after process launch still starts
+    // (Codex 3541767256).
     const tcfg = await buildTransportConfig({
       host: HOST,
       port: PORT,
@@ -432,7 +476,7 @@ async function bootstrapRegistry(): Promise<void> {
       gssapiDelegateCredentials: GSSAPI_DELEGATE,
       knownHostsFile: KNOWN_HOSTS_FILE,
       strictHostKeyChecking: STRICT_HOST_KEY,
-    });
+    }, { deferKeyRead: true });
     registry.register({ ...tcfg, name: 'default' });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,9 +275,26 @@ async function getOrCreateTransport(): Promise<ISshTransport> {
  * StrictHostKeyChecking=accept-new, the first connection to a host prints
  * "Warning: Permanently added '<host>' ... to the list of known hosts." while
  * exiting 0). Throwing on any stderr would turn every first-connect into an
- * error. stderr is only an error indicator when the command actually failed
- * (non-zero exit) and no more specific category applies.
+ * error. On success the benign OpenSSH host-key warning is filtered out, but
+ * any remaining stderr is appended to the text response so callers do not lose
+ * useful command diagnostics/progress from tools (git clone, curl, build
+ * tools) that write to stderr while succeeding.
  */
+/**
+ * Strip the benign OpenSSH first-connect host-key notice from a stderr stream,
+ * leaving genuine command diagnostics intact. With StrictHostKeyChecking=
+ * accept-new the client prints
+ *   "Warning: Permanently added '<host>' (<keytype>) to the list of known hosts."
+ * on the first connection to a host while still exiting 0; that line is noise,
+ * not output the caller asked for.
+ */
+function stripBenignSshWarnings(stderr: string): string {
+  return stderr
+    .split('\n')
+    .filter(line => !/^Warning: Permanently added .*to the list of known hosts\.?\s*$/.test(line))
+    .join('\n')
+    .trim();
+}
 export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
@@ -298,10 +315,14 @@ export function resultToMcpContent(result: ExecResult) {
     const detail = result.stderr || `Command exited with status ${result.exitCode}`;
     throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${detail}`);
   }
+  const diagnostics = stripBenignSshWarnings(result.stderr);
+  const text = diagnostics
+    ? `${result.stdout}${result.stdout && !result.stdout.endsWith('\n') ? '\n' : ''}${diagnostics}`
+    : result.stdout;
   return {
     content: [{
       type: 'text' as const,
-      text: result.stdout,
+      text,
     }],
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,14 +52,38 @@ function collectSshJsonArgs(): string[] {
     .map(a => a.slice('--ssh='.length));
 }
 
+/**
+ * Resolve and validate the transport for a multi-host --ssh JSON config.
+ * Defaults to 'ssh2'; rejects any value that is not exactly 'ssh2' or 'openssh'
+ * so a typo like "opnssh" fails at parse time instead of silently running the
+ * default ssh2 transport. (createTransport treats any non-'openssh' value as
+ * ssh2, while prepareKeyContents only loads a key when transport === 'ssh2',
+ * so an unchecked typo would connect over ssh2 without the configured key.)
+ * Mirrors the legacy CLI's `Invalid --transport` rejection.
+ */
+function resolveJsonTransport(obj: any): 'ssh2' | 'openssh' {
+  const t = obj.transport ?? 'ssh2';
+  if (t !== 'ssh2' && t !== 'openssh') {
+    throw new Error(`--ssh "${obj.name}" invalid "transport": ${JSON.stringify(obj.transport)} (expected "ssh2" or "openssh")`);
+  }
+  return t;
+}
+
 export function parseServerConfigJson(raw: string): ServerConfig {
   let obj: any;
   try {
     obj = JSON.parse(raw);
   } catch (e: any) {
-    throw new Error(`--ssh JSON parse error: ${e?.message || e}\nRaw: ${raw}`);
+    // Do NOT echo the raw argument: a malformed --ssh config can still carry a
+    // password or private key alongside the syntax error, and main() prints the
+    // thrown error to stderr. Surface only the parser message, never the config.
+    throw new Error(`--ssh JSON parse error: ${e?.message || e}`);
   }
-  if (!obj.name) throw new Error('--ssh JSON missing required "name"');
+  // name must be a non-empty string: a numeric key (e.g. `"name": 1`) registers
+  // under a Map key the MCP tools' string connectionName can never resolve.
+  if (typeof obj.name !== 'string' || obj.name.length === 0) {
+    throw new Error('--ssh JSON requires a non-empty string "name"');
+  }
   if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
   const user = obj.user ?? obj.username;
   if (!user) throw new Error(`--ssh "${obj.name}" missing required "user" (or "username")`);
@@ -68,10 +92,23 @@ export function parseServerConfigJson(raw: string): ServerConfig {
     throw new Error(`--ssh "${obj.name}" requires "auth": "kerberos" | "key" | "password"`);
   }
 
+  // port: mirror the legacy --port numeric validation. An unchecked value fails
+  // only at first use (openssh `ssh -G -p abc` -> "Bad port", exit 255; ssh2
+  // receives a non-numeric port), advertised by list-servers as if healthy.
+  // Reject a non-integer / out-of-range port at parse time.
+  let port = 22;
+  if (obj.port !== undefined) {
+    const p = typeof obj.port === 'number' ? obj.port : Number(obj.port);
+    if (!Number.isInteger(p) || p < 1 || p > 65535) {
+      throw new Error(`--ssh "${obj.name}" invalid "port": ${JSON.stringify(obj.port)} (expected integer 1-65535)`);
+    }
+    port = p;
+  }
+
   const cfg: ServerConfig = {
     name: obj.name,
     host: obj.host,
-    port: obj.port ?? 22,
+    port,
     username: user,
     authMode: auth,
   };
@@ -80,21 +117,56 @@ export function parseServerConfigJson(raw: string): ServerConfig {
     case 'kerberos':
       cfg.kerberos = true;
       cfg.transport = 'openssh';
-      if (obj.gssapiDelegateCredentials) cfg.gssapiDelegateCredentials = obj.gssapiDelegateCredentials;
+      // Kerberos implies openssh; reject an explicit conflicting transport
+      // rather than silently overriding it (mirrors the legacy --kerberos rule).
+      if (obj.transport !== undefined && obj.transport !== 'openssh') {
+        throw new Error(`--ssh "${obj.name}" auth "kerberos" implies transport "openssh" (got ${JSON.stringify(obj.transport)})`);
+      }
       break;
     case 'key':
-      cfg.transport = obj.transport ?? 'ssh2';
+      cfg.transport = resolveJsonTransport(obj);
+      // OpenSshTransport.buildArgs only passes cfg.keyPath via `-i`; an inline
+      // privateKey would be silently ignored and ssh would fall back to
+      // agent/default identities. Reject the combination so the configured
+      // credential is actually used (or the user switches to keyPath).
+      if (cfg.transport === 'openssh' && obj.privateKey) {
+        throw new Error(`--ssh "${obj.name}" inline "privateKey" is not supported for transport "openssh"; use "keyPath"`);
+      }
       if (obj.keyPath) cfg.keyPath = obj.keyPath;
       if (obj.privateKey) cfg.privateKey = obj.privateKey;
       break;
     case 'password':
-      cfg.transport = obj.transport ?? 'ssh2';
+      cfg.transport = resolveJsonTransport(obj);
       if (obj.password) cfg.password = obj.password;
       break;
   }
 
   if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
   if (obj.suPassword) cfg.suPassword = obj.suPassword;
+
+  // gssapiDelegateCredentials: enum-validate and require kerberos auth (the only
+  // path that emits GSSAPIDelegateCredentials). An unchecked typo like "maybe"
+  // registers but fails every command (openssh `ssh -G -o
+  // GSSAPIDelegateCredentials=maybe` -> "unsupported option", exit 255).
+  // Mirrors the legacy rules "must be yes or no" + "requires --kerberos".
+  if (obj.gssapiDelegateCredentials !== undefined) {
+    if (!['yes', 'no'].includes(obj.gssapiDelegateCredentials)) {
+      throw new Error(`--ssh "${obj.name}" gssapiDelegateCredentials must be "yes" or "no" (got ${JSON.stringify(obj.gssapiDelegateCredentials)})`);
+    }
+    if (auth !== 'kerberos') {
+      throw new Error(`--ssh "${obj.name}" gssapiDelegateCredentials requires auth "kerberos"`);
+    }
+    cfg.gssapiDelegateCredentials = obj.gssapiDelegateCredentials;
+  }
+
+  // strictHostKeyChecking: enum-validate. An unchecked value fails every command
+  // (openssh `ssh -G -o StrictHostKeyChecking=maybe` -> "unsupported option",
+  // exit 255). Mirrors the legacy enum check.
+  if (obj.strictHostKeyChecking !== undefined &&
+      !['yes', 'no', 'accept-new'].includes(obj.strictHostKeyChecking)) {
+    throw new Error(`--ssh "${obj.name}" strictHostKeyChecking must be one of: yes, no, accept-new (got ${JSON.stringify(obj.strictHostKeyChecking)})`);
+  }
+
   // knownHostsFile / strictHostKeyChecking are openssh-transport-only. The ssh2
   // transport ignores both, so accepting them on an ssh2 config would silently
   // drop the requested host-key enforcement — a security downgrade. Mirror the
@@ -320,7 +392,7 @@ export async function buildTransportConfig(inputs: BuildTransportConfigInputs): 
 // Transport registry — lazy init, single entry for legacy single-host mode.
 // =============================================================================
 
-const registry = new TransportRegistry();
+const registry = new TransportRegistry(prepareKeyContents);
 
 async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
   // ssh2 transport reads key contents in memory; openssh uses -i path.
@@ -334,7 +406,10 @@ async function bootstrapRegistry(): Promise<void> {
   if (isMultiHost) {
     for (const raw of sshJsonArgs) {
       const cfg = parseServerConfigJson(raw);
-      await prepareKeyContents(cfg);
+      // Do NOT read key files here — prepareKeyContents is deferred to the
+      // registry's lazy get(name) path (passed as the registry's prepareConfig
+      // hook), so one host with a missing/unmounted key path can't break
+      // startup or list-servers for the other, healthy hosts.
       registry.register(cfg);
     }
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,14 @@ function validateConfig(config: Record<string, string | null>) {
 
   const transportExplicit = config.transport;
   const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+  // A value-less `--transport` is recorded as `null` by parseArgv; the nullish
+  // fallback below would treat it as absent and silently run the default ssh2
+  // transport, so a mistyped OpenSSH selection would run the wrong transport.
+  // Reject a present-but-value-less --transport like the other value-requiring
+  // flags.
+  if ('transport' in config && transportExplicit == null) {
+    errors.push('--transport requires a value (ssh2 or openssh)');
+  }
   // --kerberos alone implies --transport=openssh
   const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
 
@@ -106,6 +114,14 @@ function validateConfig(config: Record<string, string | null>) {
   }
   if ('knownHostsFile' in config && !config.knownHostsFile) {
     errors.push('--knownHostsFile requires a file path');
+  }
+  // GSSAPIDelegateCredentials is only emitted by the OpenSSH transport in the
+  // Kerberos auth branch (see OpenSshTransport.buildArgs). Accepting the flag
+  // without --kerberos would let a user request credential delegation while the
+  // server silently omits it, breaking second-hop SSO with no error. Require
+  // Kerberos auth so the requested delegation is actually honored.
+  if ('gssapiDelegateCredentials' in config && !kerberos) {
+    errors.push('--gssapiDelegateCredentials requires --kerberos');
   }
 
   if (errors.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,8 +183,12 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       break;
   }
 
-  if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
-  if (obj.suPassword) cfg.suPassword = obj.suPassword;
+  for (const field of ['sudoPassword', 'suPassword'] as const) {
+    if (obj[field] !== undefined && typeof obj[field] !== 'string') {
+      throw new Error(`--ssh "${obj.name}" "${field}" must be a string`);
+    }
+    if (obj[field]) cfg[field] = obj[field];
+  }
 
   // gssapiDelegateCredentials: enum-validate and require kerberos auth (the only
   // path that emits GSSAPIDelegateCredentials). An unchecked typo like "maybe"
@@ -214,7 +218,11 @@ export function parseServerConfigJson(raw: string): ServerConfig {
   // drop the requested host-key enforcement — a security downgrade. Mirror the
   // legacy single-host rule ("--knownHostsFile and --strictHostKeyChecking
   // require --transport=openssh") and reject the combination here.
-  if ((obj.knownHostsFile || obj.strictHostKeyChecking) && cfg.transport !== 'openssh') {
+  if (obj.knownHostsFile !== undefined &&
+      (typeof obj.knownHostsFile !== 'string' || obj.knownHostsFile.length === 0)) {
+    throw new Error(`--ssh "${obj.name}" "knownHostsFile" must be a non-empty string`);
+  }
+  if ((obj.knownHostsFile !== undefined || obj.strictHostKeyChecking !== undefined) && cfg.transport !== 'openssh') {
     throw new Error(
       `--ssh "${obj.name}" knownHostsFile/strictHostKeyChecking require "transport": "openssh" (got ${cfg.transport})`
     );
@@ -454,6 +462,7 @@ export async function buildTransportConfig(
 // Transport registry — lazy init, single entry for legacy single-host mode.
 // =============================================================================
 
+const fileLoadedKeyConfigs = new WeakSet<ServerConfig>();
 const registry = new TransportRegistry(prepareKeyContents);
 
 export async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
@@ -464,14 +473,20 @@ export async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
   // nonexistent) key file here — otherwise the first tool call fails with
   // ENOENT instead of using the password (Codex 3549295046). Mirrors the eager
   // read's `authMode === 'key'` guard in buildTransportConfig().
+  //
+  // Once this hook loads a keyPath, re-read it on every later init attempt. The
+  // registry retries rejected initialization with the same config object; the
+  // WeakSet distinguishes file-loaded contents from an explicit inline key so a
+  // key rotation can recover without a process restart.
   if (
     cfg.authMode === 'key' &&
     cfg.transport === 'ssh2' &&
     cfg.keyPath &&
-    !cfg.privateKey
+    (!cfg.privateKey || fileLoadedKeyConfigs.has(cfg))
   ) {
     const fs = await import('fs/promises');
     cfg.privateKey = await fs.readFile(cfg.keyPath, 'utf8');
+    fileLoadedKeyConfigs.add(cfg);
   }
 }
 

--- a/src/transports/factory.ts
+++ b/src/transports/factory.ts
@@ -1,0 +1,13 @@
+import { ISshTransport, TransportConfig } from './types.js';
+import { Ssh2Transport } from './ssh2.js';
+import { OpenSshTransport } from './openssh.js';
+
+/**
+ * Choose and construct a transport based on cfg.transport. Default is 'ssh2'
+ * to preserve upstream behaviour for users who don't opt in to OpenSSH.
+ */
+export function createTransport(cfg: TransportConfig): ISshTransport {
+  const choice = cfg.transport ?? 'ssh2';
+  if (choice === 'openssh') return new OpenSshTransport(cfg);
+  return new Ssh2Transport(cfg);
+}

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -316,6 +316,10 @@ export class OpenSshTransport implements ISshTransport {
       // command emitting more than ~8KB (inconsistent with runSsh, which
       // returns the full stream). Keep the full EXEC output here.
       let execCapture = '';
+      // The exact input line written to the root shell in the EXEC state. With
+      // `ssh -tt` the remote PTY echoes it back onto stdout, so it is stored
+      // here to strip that single echoed line from the captured output.
+      let execInput = '';
       let capturedStderr = '';
       let exitCode: number | null = null;
       let timedOut = false;
@@ -401,7 +405,11 @@ export class OpenSshTransport implements ISshTransport {
           // Send sentinel PS1 once we see a non-prompt line (typical: post-auth motd)
           // Trigger: any newline after password sent.
           if (/\r?\n/.test(text)) {
-            writeLine(`export PS1='${readyMark}$ '`);
+            // Set a sentinel PS1 so the root-shell prompt is machine-detectable,
+            // and clear PS2 to '' so the multiline subshell wrapper written in
+            // the EXEC state (see below) does not emit `> ` continuation prompts
+            // into the captured PTY stream.
+            writeLine(`export PS1='${readyMark}$ '; export PS2=''`);
             state = 'ROOT_SHELL';
             setStateTimer(5000, 'awaiting sentinel prompt');
             buffer = '';
@@ -415,9 +423,20 @@ export class OpenSshTransport implements ISshTransport {
           state = 'EXEC';
           buffer = '';
           stdoutTail = '';
-          // Execute user command, then echo sentinel+exitcode
-          writeLine(`${command}`);
-          writeLine(`echo ${endMark}$?`);
+          // Run the user command inside a subshell, then echo the sentinel and
+          // its exit status on the SAME input line.
+          //
+          //  - Subshell isolation: a command that exits or exec-replaces its
+          //    shell (e.g. `echo ok; exit 0`, `exec true`) only terminates the
+          //    subshell. The root control shell survives to run the sentinel, so
+          //    the real exit status is reported instead of the close path
+          //    mistaking a clean exit for a transport failure and dropping the
+          //    output. `$?` after `( ... )` is the subshell's exit status.
+          //  - Same-line sentinel: with `ssh -tt` the sentinel-emit is echoed as
+          //    part of this one input line, so it can never glue onto command
+          //    output that lacks a trailing newline (e.g. `printf foo`).
+          execInput = `( ${command} ); echo ${endMark}$?`;
+          writeLine(execInput);
           return;
         }
 
@@ -428,31 +447,24 @@ export class OpenSshTransport implements ISshTransport {
             // Derive output from the unbounded EXEC capture (not the truncated
             // scan buffer) so large command output is preserved in full. Locate
             // the end-marker within the full capture for the slice boundary.
+            // endRe requires a digit after the marker, so the echoed
+            // `echo <endMark>$?` (literal `$?`) never matches — only the real
+            // sentinel output does.
             const em = execCapture.match(endRe);
             const endIdx = em ? em.index! : execCapture.length;
             capturedStdout = execCapture.slice(0, endIdx).replace(/\r\n/g, '\n');
             // Strip the echoed PS1-sentinel leftovers if any
             capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
-            // Strip the echoed command lines (best effort). With `ssh -tt` the
-            // remote PTY's line discipline echoes every line written to stdin
-            // back onto stdout, so the EXEC capture is polluted by the echoed
-            // user command and the echoed `echo <endMark>$?` sentinel-emit
-            // command. Remove both so the caller sees only the command's real
-            // stdout instead of its own input replayed back.
+            // Strip the single echoed input line the remote PTY replayed at the
+            // head of the capture (present with `ssh -tt`). Because the command
+            // and sentinel-emit are combined into one known `execInput` line,
+            // removing exactly that line (and its trailing newline) yields the
+            // command's real stdout — even when the output is unterminated.
             const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            // 1. Drop the echoed sentinel-emit command line wherever it appears.
             capturedStdout = capturedStdout.replace(
-              new RegExp(`^echo ${escapeRe(endMark)}\\$\\?[ \\t]*\\n?`, 'm'),
+              new RegExp(`^${escapeRe(execInput)}\\r?\\n?`),
               '',
             );
-            // 2. Drop the echoed user command line(s) at the head of the capture.
-            const cmdLines = command.split('\n');
-            const outLines = capturedStdout.split('\n');
-            while (cmdLines.length && outLines.length && outLines[0] === cmdLines[0]) {
-              outLines.shift();
-              cmdLines.shift();
-            }
-            capturedStdout = outLines.join('\n');
             state = 'DONE';
             writeLine('exit');
             writeLine('exit');

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -169,7 +169,15 @@ export class OpenSshTransport implements ISshTransport {
         );
         break;
       case 'key':
-        if (cfg.keyPath) a.push('-i', cfg.keyPath);
+        if (cfg.keyPath) {
+          a.push('-i', cfg.keyPath);
+          // Force OpenSSH to use ONLY the supplied key. Without
+          // IdentitiesOnly=yes, ssh still offers every ssh-agent identity
+          // first, which can exhaust the server's MaxAuthTries before the
+          // chosen `-i` key is ever tried. This matches the ssh2 path, which
+          // authenticates with exactly the configured key.
+          a.push('-o', 'IdentitiesOnly=yes');
+        }
         a.push(
           '-o', 'PreferredAuthentications=publickey',
           '-o', 'PasswordAuthentication=no',
@@ -209,6 +217,7 @@ export class OpenSshTransport implements ISshTransport {
     return new Promise((resolve) => {
       const args = [...this.buildArgs(opts), command];
       let timedOut = false;
+      let exited = false;
       let stdout = '';
       let stderr = '';
 
@@ -230,11 +239,16 @@ export class OpenSshTransport implements ISshTransport {
         timedOut = true;
         child.kill('SIGTERM');
         setTimeout(() => {
-          if (!child.killed) child.kill('SIGKILL');
+          // `child.killed` only reflects that a signal was *sent*, not that the
+          // process actually exited. Gate the SIGKILL fallback on the real
+          // `exited` flag (set from the close event) so a process ignoring
+          // SIGTERM is still force-killed instead of being left to hang.
+          if (!exited) child.kill('SIGKILL');
         }, 2000);
       }, opts.timeoutMs);
 
       child.on('error', (err: Error) => {
+        exited = true;
         clearTimeout(timer);
         resolve({
           stdout,
@@ -245,6 +259,7 @@ export class OpenSshTransport implements ISshTransport {
       });
 
       child.on('close', (code, signal) => {
+        exited = true;
         clearTimeout(timer);
         const category = timedOut ? 'timeout' : classifyError(code, stderr);
         resolve({
@@ -289,6 +304,7 @@ export class OpenSshTransport implements ISshTransport {
       let capturedStderr = '';
       let exitCode: number | null = null;
       let timedOut = false;
+      let exited = false;
       let stateTimer: NodeJS.Timeout | null = null;
 
       const child: ChildProcess = spawn('ssh', args, {
@@ -325,7 +341,11 @@ export class OpenSshTransport implements ISshTransport {
         timedOut = true;
         clearStateTimer();
         child.kill('SIGTERM');
-        setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
+        // Gate the SIGKILL fallback on the real `exited` flag, not
+        // `child.killed` (which is set the instant SIGTERM is *sent*, so the
+        // fallback would always be skipped and a process ignoring SIGTERM
+        // could hang past the deadline).
+        setTimeout(() => { if (!exited) child.kill('SIGKILL'); }, 2000);
       }, opts.timeoutMs);
 
       child.stdout?.on('data', (chunk: Buffer) => {
@@ -338,7 +358,16 @@ export class OpenSshTransport implements ISshTransport {
         // scan buffer so large command output is not lost (see execCapture decl).
         if (state === 'EXEC') execCapture += text;
 
-        if (failRe.test(stdoutTail)) {
+        // Auth-failure detection must run ONLY during the su/login phases.
+        // Once the state machine reaches EXEC, the stream carries the user
+        // command's own stdout, which may legitimately contain phrases like
+        // "incorrect password" or "authentication failure" (e.g. grepping auth
+        // logs). Matching there would kill the session and mis-report the
+        // command's output as an auth error, so gate the check on the pre-EXEC
+        // login states.
+        const inLoginPhase =
+          state === 'SU_PROMPT' || state === 'PASSWORD_SENT' || state === 'ROOT_SHELL';
+        if (inLoginPhase && failRe.test(stdoutTail)) {
           clearStateTimer();
           capturedStderr += stdoutTail;
           child.kill('SIGTERM');
@@ -389,7 +418,26 @@ export class OpenSshTransport implements ISshTransport {
             capturedStdout = execCapture.slice(0, endIdx).replace(/\r\n/g, '\n');
             // Strip the echoed PS1-sentinel leftovers if any
             capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
-            // Strip the echoed command lines (best effort)
+            // Strip the echoed command lines (best effort). With `ssh -tt` the
+            // remote PTY's line discipline echoes every line written to stdin
+            // back onto stdout, so the EXEC capture is polluted by the echoed
+            // user command and the echoed `echo <endMark>$?` sentinel-emit
+            // command. Remove both so the caller sees only the command's real
+            // stdout instead of its own input replayed back.
+            const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            // 1. Drop the echoed sentinel-emit command line wherever it appears.
+            capturedStdout = capturedStdout.replace(
+              new RegExp(`^echo ${escapeRe(endMark)}\\$\\?[ \\t]*\\n?`, 'm'),
+              '',
+            );
+            // 2. Drop the echoed user command line(s) at the head of the capture.
+            const cmdLines = command.split('\n');
+            const outLines = capturedStdout.split('\n');
+            while (cmdLines.length && outLines.length && outLines[0] === cmdLines[0]) {
+              outLines.shift();
+              cmdLines.shift();
+            }
+            capturedStdout = outLines.join('\n');
             state = 'DONE';
             writeLine('exit');
             writeLine('exit');
@@ -402,6 +450,7 @@ export class OpenSshTransport implements ISshTransport {
       });
 
       child.on('error', (err: Error) => {
+        exited = true;
         clearStateTimer();
         clearTimeout(overallTimer);
         resolve({
@@ -413,6 +462,7 @@ export class OpenSshTransport implements ISshTransport {
       });
 
       child.on('close', (code, signal) => {
+        exited = true;
         clearStateTimer();
         clearTimeout(overallTimer);
 

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -11,7 +11,6 @@ import {
   ErrorCategory,
   TransportConfig,
 } from './types.js';
-import { buildSudoWrapper } from './ssh2.js';
 
 /**
  * OpenSshTransport — spawns the system `ssh` binary per command.
@@ -77,7 +76,18 @@ export class OpenSshTransport implements ISshTransport {
       if (pwd === undefined && this.cfg.suPassword) {
         return this.runSuViaPty(command, this.cfg.suPassword, opts);
       }
-      const wrapped = buildSudoWrapper(command, pwd);
+      if (pwd !== undefined) {
+        // OpenSSH receives the remote command as a local ssh argv element.
+        // Embedding the sudo password in that command (the ssh2 wrapper style)
+        // exposes it to local process inspection. Keep argv password-free and
+        // feed sudo -S via stdin instead.
+        const wrapped = buildOpenSshSudoWrapper(command, true);
+        return this.runSsh(wrapped, {
+          ...opts,
+          stdin: `${pwd}\n${opts.stdin ?? ''}`,
+        });
+      }
+      const wrapped = buildOpenSshSudoWrapper(command, false);
       return this.runSsh(wrapped, opts);
     }
     const suPwd = opts.password ?? this.cfg.suPassword;
@@ -480,7 +490,11 @@ export class OpenSshTransport implements ISshTransport {
         if (state === 'DONE' && exitCode !== null) {
           resolve({
             stdout: capturedStdout,
-            stderr: '',
+            // A PTY merges remote stdout and stderr into the captured stdout
+            // stream. Preserve that merged diagnostic text as stderr for
+            // non-zero exits so resultToMcpContent can surface `ls: cannot
+            // access ...` instead of only a generic exit status.
+            stderr: exitCode === 0 ? '' : capturedStdout,
             exitCode,
             category: exitCode === 0 ? undefined : 'remote_exit',
           });
@@ -501,6 +515,22 @@ export class OpenSshTransport implements ISshTransport {
       });
     });
   }
+}
+
+/**
+ * Build a sudo wrapper for the OpenSSH subprocess transport.
+ *
+ * Unlike the ssh2 wrapper, this must never embed the sudo password in the
+ * command string: OpenSSH receives the remote command as a local `ssh` argv
+ * element. When a password is needed, the caller supplies it through stdin for
+ * `sudo -S` instead.
+ */
+export function buildOpenSshSudoWrapper(command: string, expectsPassword: boolean): string {
+  const escaped = command.replace(/'/g, "'\\''");
+  if (expectsPassword) {
+    return `sudo -p "" -S sh -c '${escaped}'`;
+  }
+  return `sudo -n sh -c '${escaped}'`;
 }
 
 /**

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -73,15 +73,20 @@ export class OpenSshTransport implements ISshTransport {
   }
 
   /**
-   * Update everConnected from a completed exec result. A command that reached
-   * the remote host — success, a non-zero remote exit, or an auth/host-key
-   * rejection (all of which require a completed TCP+SSH handshake) — proves the
-   * host is live. Only connect/transport-layer failures (TCP refused, DNS
-   * failure, ssh spawn error) and a bare timeout leave the flag unchanged,
-   * since they do not prove the host ever answered.
+   * Update everConnected from a completed exec result. Only a usable remote
+   * session — success or a remote command's own non-zero exit — proves this
+   * OpenSSH transport can run commands. Authentication and host-key rejections
+   * may reach the server, but they do not establish a usable session and should
+   * not make list-servers report the server as connected.
    */
   private recordLiveness(result: ExecResult): void {
-    if (result.category === 'connect' || result.category === 'transport' || result.category === 'timeout') {
+    if (
+      result.category === 'auth' ||
+      result.category === 'host_key' ||
+      result.category === 'connect' ||
+      result.category === 'transport' ||
+      result.category === 'timeout'
+    ) {
       return;
     }
     this.everConnected = true;

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -32,14 +32,13 @@ export class OpenSshTransport implements ISshTransport {
   private askpassEnvName?: string;
   private cleanupRegistered = false;
   /**
-   * True once at least one command has completed a live SSH session (an exec
-   * whose failure, if any, was not a connect/transport-layer failure). OpenSSH
-   * has no persistent connection — init() only verifies the local ssh binary —
-   * so this is the only proof the configured host is actually reachable.
-   * list-servers reads it via isConnected() so it does not report a merely
-   * initialized transport as "connected" when the host has never answered.
+   * True when the most recent command completed a usable live SSH session (an
+   * exec whose failure, if any, was the remote command's own non-zero exit).
+   * OpenSSH has no persistent connection — init() only verifies the local ssh
+   * binary — so list-servers must reflect the latest session attempt rather
+   * than retain historical success after a later auth/transport failure.
    */
-  private everConnected = false;
+  private lastSessionUsable = false;
 
   constructor(private cfg: TransportConfig) {}
 
@@ -73,7 +72,7 @@ export class OpenSshTransport implements ISshTransport {
   }
 
   /**
-   * Update everConnected from a completed exec result. Only a usable remote
+   * Update lastSessionUsable from a completed exec result. Only a usable remote
    * session — success or a remote command's own non-zero exit — proves this
    * OpenSSH transport can run commands. Authentication and host-key rejections
    * may reach the server, but they do not establish a usable session and should
@@ -87,19 +86,20 @@ export class OpenSshTransport implements ISshTransport {
       result.category === 'transport' ||
       result.category === 'timeout'
     ) {
+      this.lastSessionUsable = false;
       return;
     }
-    this.everConnected = true;
+    this.lastSessionUsable = true;
   }
 
   /**
-   * OpenSSH has no persistent connection; report a live connection only after a
-   * command has actually completed a session (see everConnected). This keeps
-   * list-servers from advertising a merely-initialized transport as connected
-   * when the host has never answered (Codex 3541767250).
+   * OpenSSH has no persistent connection; report a live connection only when the
+   * most recent command completed a usable session (see lastSessionUsable). This
+   * keeps list-servers from advertising a merely-initialized transport as
+   * connected or retaining stale success after a later connection failure.
    */
   isConnected(): boolean {
-    return this.everConnected;
+    return this.lastSessionUsable;
   }
 
   async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -31,6 +31,15 @@ export class OpenSshTransport implements ISshTransport {
   private askpassDir?: string;
   private askpassEnvName?: string;
   private cleanupRegistered = false;
+  /**
+   * True once at least one command has completed a live SSH session (an exec
+   * whose failure, if any, was not a connect/transport-layer failure). OpenSSH
+   * has no persistent connection — init() only verifies the local ssh binary —
+   * so this is the only proof the configured host is actually reachable.
+   * list-servers reads it via isConnected() so it does not report a merely
+   * initialized transport as "connected" when the host has never answered.
+   */
+  private everConnected = false;
 
   constructor(private cfg: TransportConfig) {}
 
@@ -56,10 +65,36 @@ export class OpenSshTransport implements ISshTransport {
   async exec(command: string, opts: ExecOptions): Promise<ExecResult> {
     // If suPassword is configured, route through PTY-su state machine to
     // preserve the implicit-su behaviour that ssh2 transport has.
-    if (this.cfg.suPassword) {
-      return this.runSuViaPty(command, this.cfg.suPassword, opts);
+    const result = this.cfg.suPassword
+      ? await this.runSuViaPty(command, this.cfg.suPassword, opts)
+      : await this.runSsh(command, opts);
+    this.recordLiveness(result);
+    return result;
+  }
+
+  /**
+   * Update everConnected from a completed exec result. A command that reached
+   * the remote host — success, a non-zero remote exit, or an auth/host-key
+   * rejection (all of which require a completed TCP+SSH handshake) — proves the
+   * host is live. Only connect/transport-layer failures (TCP refused, DNS
+   * failure, ssh spawn error) and a bare timeout leave the flag unchanged,
+   * since they do not prove the host ever answered.
+   */
+  private recordLiveness(result: ExecResult): void {
+    if (result.category === 'connect' || result.category === 'transport' || result.category === 'timeout') {
+      return;
     }
-    return this.runSsh(command, opts);
+    this.everConnected = true;
+  }
+
+  /**
+   * OpenSSH has no persistent connection; report a live connection only after a
+   * command has actually completed a session (see everConnected). This keeps
+   * list-servers from advertising a merely-initialized transport as connected
+   * when the host has never answered (Codex 3541767250).
+   */
+  isConnected(): boolean {
+    return this.everConnected;
   }
 
   async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
@@ -74,7 +109,9 @@ export class OpenSshTransport implements ISshTransport {
       // no sudo password is available but a su password is, run the command as
       // root via su to preserve equivalent behaviour.
       if (pwd === undefined && this.cfg.suPassword) {
-        return this.runSuViaPty(command, this.cfg.suPassword, opts);
+        const r = await this.runSuViaPty(command, this.cfg.suPassword, opts);
+        this.recordLiveness(r);
+        return r;
       }
       if (pwd !== undefined) {
         // OpenSSH receives the remote command as a local ssh argv element.
@@ -82,16 +119,21 @@ export class OpenSshTransport implements ISshTransport {
         // exposes it to local process inspection. Keep argv password-free and
         // feed sudo -S via stdin instead.
         const wrapped = buildOpenSshSudoWrapper(command, true);
-        return this.runSsh(wrapped, {
+        const r = await this.runSsh(wrapped, {
           ...opts,
           stdin: `${pwd}\n${opts.stdin ?? ''}`,
         });
+        this.recordLiveness(r);
+        return r;
       }
       const wrapped = buildOpenSshSudoWrapper(command, false);
-      return this.runSsh(wrapped, opts);
+      const r = await this.runSsh(wrapped, opts);
+      this.recordLiveness(r);
+      return r;
     }
     const suPwd = opts.password ?? this.cfg.suPassword;
     if (!suPwd) {
+      // Config error — no command runs, so this does not prove host liveness.
       return {
         stdout: '',
         stderr: 'su elevation requires --suPassword',
@@ -99,7 +141,9 @@ export class OpenSshTransport implements ISshTransport {
         category: 'auth',
       };
     }
-    return this.runSuViaPty(command, suPwd, opts);
+    const r = await this.runSuViaPty(command, suPwd, opts);
+    this.recordLiveness(r);
+    return r;
   }
 
   async close(): Promise<void> {

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -66,6 +66,17 @@ export class OpenSshTransport implements ISshTransport {
   async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
     if (opts.mode === 'sudo') {
       const pwd = opts.password ?? this.cfg.sudoPassword;
+      // Match ssh2 persistent-root semantics: the ssh2 transport establishes a
+      // root `su` shell at connect time when --suPassword is set, so its
+      // sudo-exec re-enters that already-root shell and `sudo -n` trivially
+      // succeeds. The OpenSSH transport spawns a fresh process per command, so a
+      // plain `sudo -n` would run as the unprivileged user and fail for users
+      // who followed the documented persistent-root `--suPassword` setup. When
+      // no sudo password is available but a su password is, run the command as
+      // root via su to preserve equivalent behaviour.
+      if (pwd === undefined && this.cfg.suPassword) {
+        return this.runSuViaPty(command, this.cfg.suPassword, opts);
+      }
       const wrapped = buildSudoWrapper(command, pwd);
       return this.runSsh(wrapped, opts);
     }
@@ -111,7 +122,7 @@ export class OpenSshTransport implements ISshTransport {
   }
 
   /**
-   * Write a `.cmd` askpass helper to a temp dir and remember its path.
+   * Write a `.cmd`/`.sh` askpass helper to a temp dir and remember its path.
    * Password lives in an env var passed only to spawned ssh children —
    * never written to disk, never placed in argv.
    */
@@ -121,9 +132,7 @@ export class OpenSshTransport implements ISshTransport {
     const isWindows = process.platform === 'win32';
     const helperName = isWindows ? 'askpass.cmd' : 'askpass.sh';
     const helperPath = path.join(dir, helperName);
-    const content = isWindows
-      ? `@echo off\r\necho %${envName}%\r\n`
-      : `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
+    const content = renderAskpassHelper(envName, isWindows);
     await fs.writeFile(helperPath, content, { encoding: 'utf8' });
     if (!isWindows) {
       await fs.chmod(helperPath, 0o700);
@@ -271,6 +280,12 @@ export class OpenSshTransport implements ISshTransport {
       let buffer = '';
       let stdoutTail = '';
       let capturedStdout = '';
+      // Unbounded capture of all stdout received while in the EXEC state. The
+      // scanning `buffer` below is truncated to ~4KB to bound regex cost, but
+      // truncating the captured output would silently drop the head of any
+      // command emitting more than ~8KB (inconsistent with runSsh, which
+      // returns the full stream). Keep the full EXEC output here.
+      let execCapture = '';
       let capturedStderr = '';
       let exitCode: number | null = null;
       let timedOut = false;
@@ -301,12 +316,17 @@ export class OpenSshTransport implements ISshTransport {
       // Initial state: wait up to 10s for `su` password prompt
       setStateTimer(10000, 'awaiting su password prompt');
 
+      // Overall hard deadline. types.ts ExecOptions.timeoutMs is documented as a
+      // hard ceiling every transport must enforce; runSsh applies it to the
+      // whole spawn, so the su path must too. The handshake phases (su prompt,
+      // password, root-shell sentinel) are bounded by their own per-state timers
+      // above; they do not get an extra budget on top of the contract deadline.
       const overallTimer = setTimeout(() => {
         timedOut = true;
         clearStateTimer();
         child.kill('SIGTERM');
         setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
-      }, opts.timeoutMs + 30000);
+      }, opts.timeoutMs);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const text = chunk.toString('utf8');
@@ -314,6 +334,9 @@ export class OpenSshTransport implements ISshTransport {
         // Keep last ~4KB for regex scanning
         if (buffer.length > 8192) buffer = buffer.slice(buffer.length - 4096);
         stdoutTail = buffer;
+        // Accumulate the full EXEC-state output separately from the truncated
+        // scan buffer so large command output is not lost (see execCapture decl).
+        if (state === 'EXEC') execCapture += text;
 
         if (failRe.test(stdoutTail)) {
           clearStateTimer();
@@ -358,7 +381,12 @@ export class OpenSshTransport implements ISshTransport {
           const m = stdoutTail.match(endRe);
           if (m) {
             exitCode = parseInt(m[1], 10);
-            capturedStdout = stdoutTail.slice(0, m.index).replace(/\r\n/g, '\n');
+            // Derive output from the unbounded EXEC capture (not the truncated
+            // scan buffer) so large command output is preserved in full. Locate
+            // the end-marker within the full capture for the slice boundary.
+            const em = execCapture.match(endRe);
+            const endIdx = em ? em.index! : execCapture.length;
+            capturedStdout = execCapture.slice(0, endIdx).replace(/\r\n/g, '\n');
             // Strip the echoed PS1-sentinel leftovers if any
             capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
             // Strip the echoed command lines (best effort)
@@ -423,6 +451,32 @@ export class OpenSshTransport implements ISshTransport {
       });
     });
   }
+}
+
+/**
+ * Render the askpass helper script body that prints the password held in the
+ * given environment variable, followed by a newline.
+ *
+ * Windows: a naive `@echo off` + `echo %VAR%` is unsafe — CMD expands `%VAR%`
+ * and then re-parses the resulting line, so a password containing `& | < > ^ %`
+ * breaks the echo (and thus auth). Even `setlocal EnableDelayedExpansion` +
+ * `echo !VAR!` mishandles `!`. Instead, shell out to PowerShell and read the
+ * variable verbatim via `$env:VAR`: the password value is fetched at runtime by
+ * PowerShell and never substituted onto a command line, so no metacharacter is
+ * ever re-interpreted. The env var NAME is `[A-Za-z0-9_]`-only (it is always
+ * `SSH_MCP_PW_<pid>`), so embedding it in the command string is safe.
+ *
+ * POSIX: `printf '%s\n' "$VAR"` is already metacharacter-safe.
+ */
+export function renderAskpassHelper(envName: string, isWindows: boolean): string {
+  if (isWindows) {
+    return (
+      `@echo off\r\n` +
+      `powershell -NoProfile -NonInteractive -Command ` +
+      `"[Console]::Out.Write($env:${envName} + [char]10)"\r\n`
+    );
+  }
+  return `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
 }
 
 /**

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -1,5 +1,5 @@
 import { spawn, ChildProcess, execFile } from 'node:child_process';
-import { promises as fs } from 'node:fs';
+import { promises as fs, rmSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -105,7 +105,12 @@ export class OpenSshTransport implements ISshTransport {
   async close(): Promise<void> {
     if (this.askpassDir) {
       try {
-        await fs.rm(this.askpassDir, { recursive: true, force: true });
+        // Synchronous removal: close() is invoked from process 'exit'/SIGINT/
+        // SIGTERM handlers (see init()), which cannot await. An async fs.rm()
+        // there would be discarded — the event loop is torn down by
+        // process.exit() before the removal runs, leaking the short-lived
+        // askpass temp dir. rmSync guarantees cleanup completes before exit.
+        rmSync(this.askpassDir, { recursive: true, force: true });
       } catch (e) {
         // best-effort cleanup
       }
@@ -564,7 +569,10 @@ export function renderAskpassHelper(envName: string, isWindows: boolean): string
  *
  *   exit 0                → undefined  (success)
  *   exit 1-254            → remote_exit (remote command's own non-zero exit)
- *   exit 255              → inspect stderr for SSH-layer failure type
+ *   exit 255              → inspect stderr for SSH-layer failure type;
+ *                           falls back to remote_exit when no SSH-layer
+ *                           signature matches (ssh(1) documents 255 as either
+ *                           an SSH error OR the remote command's own exit 255)
  *   exit null             → treated as transport failure
  */
 export function classifyError(code: number | null, stderr: string): ErrorCategory | undefined {
@@ -587,5 +595,9 @@ export function classifyError(code: number | null, stderr: string): ErrorCategor
   if (/connection reset/.test(s)) return 'connect';
   if (/could not resolve|name or service not known/.test(s)) return 'connect';
   if (/no route to host|network unreachable/.test(s)) return 'connect';
-  return 'transport';
+  // No SSH-layer signature matched. Per ssh(1), 255 is also the exit code a
+  // remote command can legitimately return, so surface it as the remote
+  // command's own non-zero exit (Error (code 255)) rather than masking it as
+  // a generic SSH transport error.
+  return 'remote_exit';
 }

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -30,6 +30,7 @@ export class OpenSshTransport implements ISshTransport {
 
   private askpassDir?: string;
   private askpassEnvName?: string;
+  private askpassConfigPath?: string;
   private cleanupRegistered = false;
 
   constructor(private cfg: TransportConfig) {}
@@ -116,6 +117,7 @@ export class OpenSshTransport implements ISshTransport {
       }
       this.askpassDir = undefined;
       this.askpassEnvName = undefined;
+      this.askpassConfigPath = undefined;
     }
   }
 
@@ -147,13 +149,22 @@ export class OpenSshTransport implements ISshTransport {
     const isWindows = process.platform === 'win32';
     const helperName = isWindows ? 'askpass.cmd' : 'askpass.sh';
     const helperPath = path.join(dir, helperName);
+    const configPath = path.join(dir, 'ssh_config');
     const content = renderAskpassHelper(envName, isWindows);
     await fs.writeFile(helperPath, content, { encoding: 'utf8' });
+    // OpenSSH copies variables selected by SendEnv from its own environment to
+    // the remote session. The askpass password must remain in that environment
+    // for the helper, so load the user's normal SSH config and then remove all
+    // SendEnv patterns in a final directive. Passing this file with -F keeps the
+    // rest of the user's SSH settings while preventing a broad `SendEnv *` from
+    // forwarding SSH_MCP_PW_* to the server.
+    await fs.writeFile(configPath, renderAskpassSshConfig(), { encoding: 'utf8' });
     if (!isWindows) {
       await fs.chmod(helperPath, 0o700);
     }
     this.askpassDir = dir;
     this.askpassEnvName = envName;
+    this.askpassConfigPath = configPath;
     (this as any)._askpassPath = helperPath;
     (this as any)._askpassPassword = password;
   }
@@ -169,6 +180,9 @@ export class OpenSshTransport implements ISshTransport {
       '-o', 'BatchMode=no',
       '-p', String(cfg.port),
     ];
+    if (cfg.authMode === 'password' && this.askpassConfigPath) {
+      a.push('-F', this.askpassConfigPath);
+    }
     if (cfg.knownHostsFile) {
       a.push('-o', `UserKnownHostsFile=${cfg.knownHostsFile}`);
     }
@@ -230,7 +244,20 @@ export class OpenSshTransport implements ISshTransport {
   /** Run a single command via `ssh host <cmd>`, collect output, enforce timeout. */
   private runSsh(command: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
-      const args = [...this.buildArgs(opts), command];
+      const nonce = randomBytes(8).toString('hex');
+      const endMark = `__SSH_MCP_END_${nonce}__`;
+      // Keep the user command in a subshell so `exit`/`exec` cannot prevent the
+      // sentinel. The leading newline in printf is an artificial separator;
+      // parsing removes exactly that byte and therefore preserves unterminated
+      // stdout. A random marker distinguishes the remote command's status 255
+      // from ssh(1)'s own transport/auth failure status 255.
+      const wrappedCommand = `(
+${command}
+)
+__ssh_mcp_rc=$?
+printf '\n${endMark}%s\n' "$__ssh_mcp_rc"
+exit 0`;
+      const args = [...this.buildArgs(opts), wrappedCommand];
       let timedOut = false;
       let exited = false;
       let stdout = '';
@@ -276,11 +303,22 @@ export class OpenSshTransport implements ISshTransport {
       child.on('close', (code, signal) => {
         exited = true;
         clearTimeout(timer);
-        const category = timedOut ? 'timeout' : classifyError(code, stderr);
+        const marker = `\n${endMark}`;
+        const markerIdx = stdout.lastIndexOf(marker);
+        const statusText = markerIdx >= 0
+          ? stdout.slice(markerIdx + marker.length).match(/^(\d{1,3})(?:\r?\n|$)/)
+          : null;
+        const remoteExit = statusText ? parseInt(statusText[1], 10) : null;
+        const commandStdout = remoteExit === null ? stdout : stdout.slice(0, markerIdx);
+        const category = timedOut
+          ? 'timeout'
+          : remoteExit === null
+            ? classifyError(code, stderr)
+            : (remoteExit === 0 ? undefined : 'remote_exit');
         resolve({
-          stdout,
+          stdout: commandStdout,
           stderr,
-          exitCode: timedOut ? null : (code ?? null),
+          exitCode: timedOut ? null : (remoteExit ?? code ?? null),
           signal: signal ?? undefined,
           category,
         });
@@ -424,7 +462,9 @@ export class OpenSshTransport implements ISshTransport {
           buffer = '';
           stdoutTail = '';
           // Run the user command inside a subshell, then echo the sentinel and
-          // its exit status on the SAME input line.
+          // its exit status. Newlines are intentional: a trailing shell comment
+          // (including the MCP description suffix) cannot consume the closing
+          // subshell or sentinel command.
           //
           //  - Subshell isolation: a command that exits or exec-replaces its
           //    shell (e.g. `echo ok; exit 0`, `exec true`) only terminates the
@@ -432,10 +472,10 @@ export class OpenSshTransport implements ISshTransport {
           //    the real exit status is reported instead of the close path
           //    mistaking a clean exit for a transport failure and dropping the
           //    output. `$?` after `( ... )` is the subshell's exit status.
-          //  - Same-line sentinel: with `ssh -tt` the sentinel-emit is echoed as
-          //    part of this one input line, so it can never glue onto command
-          //    output that lacks a trailing newline (e.g. `printf foo`).
-          execInput = `( ${command} ); echo ${endMark}$?`;
+          execInput = `(
+${command}
+)
+echo ${endMark}$?`;
           writeLine(execInput);
           return;
         }
@@ -574,6 +614,18 @@ export function renderAskpassHelper(envName: string, isWindows: boolean): string
     );
   }
   return `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
+}
+
+/**
+ * Per-process OpenSSH config used by askpass password authentication.
+ *
+ * `SendEnv` is a multi-value setting, so a command-line `-o SendEnv=-*` is
+ * evaluated before user configuration and cannot remove patterns added later
+ * by `~/.ssh/config`. Including the user config here and placing `SendEnv -*`
+ * last preserves all other settings while reliably clearing the final list.
+ */
+export function renderAskpassSshConfig(): string {
+  return 'Include ~/.ssh/config\nSendEnv -*\n';
 }
 
 /**

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -1,0 +1,457 @@
+import { spawn, ChildProcess, execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import {
+  ISshTransport,
+  ExecOptions,
+  ExecElevatedOptions,
+  ExecResult,
+  ErrorCategory,
+  TransportConfig,
+} from './types.js';
+import { buildSudoWrapper } from './ssh2.js';
+
+/**
+ * OpenSshTransport — spawns the system `ssh` binary per command.
+ *
+ * Rationale: the mscdex/ssh2 library does not implement GSSAPI/Kerberos
+ * userauth (upstream issue #333, open since 2015). Delegating to the OS's
+ * OpenSSH client is the only way to get Kerberos SSO support without
+ * reimplementing the SSH userauth state machine.
+ *
+ * No connection multiplexing: Win32-OpenSSH does not support ControlMaster
+ * (issue #1328), so each exec spawns a fresh `ssh` process. This accepts a
+ * per-call handshake cost (including Kerberos AP-REQ round trip) in
+ * exchange for feature completeness on Windows domain-joined clients.
+ */
+export class OpenSshTransport implements ISshTransport {
+  readonly name = 'openssh' as const;
+
+  private askpassDir?: string;
+  private askpassEnvName?: string;
+  private cleanupRegistered = false;
+
+  constructor(private cfg: TransportConfig) {}
+
+  async init(): Promise<void> {
+    await this.verifySshBinary();
+
+    if (this.cfg.authMode === 'password') {
+      if (!this.cfg.password) {
+        throw new Error('authMode=password requires --password');
+      }
+      await this.prepareAskpassHelper(this.cfg.password);
+    }
+
+    if (!this.cleanupRegistered) {
+      const cleanup = () => { void this.close(); };
+      process.once('exit', cleanup);
+      process.once('SIGINT', () => { cleanup(); process.exit(130); });
+      process.once('SIGTERM', () => { cleanup(); process.exit(143); });
+      this.cleanupRegistered = true;
+    }
+  }
+
+  async exec(command: string, opts: ExecOptions): Promise<ExecResult> {
+    // If suPassword is configured, route through PTY-su state machine to
+    // preserve the implicit-su behaviour that ssh2 transport has.
+    if (this.cfg.suPassword) {
+      return this.runSuViaPty(command, this.cfg.suPassword, opts);
+    }
+    return this.runSsh(command, opts);
+  }
+
+  async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
+    if (opts.mode === 'sudo') {
+      const pwd = opts.password ?? this.cfg.sudoPassword;
+      const wrapped = buildSudoWrapper(command, pwd);
+      return this.runSsh(wrapped, opts);
+    }
+    const suPwd = opts.password ?? this.cfg.suPassword;
+    if (!suPwd) {
+      return {
+        stdout: '',
+        stderr: 'su elevation requires --suPassword',
+        exitCode: null,
+        category: 'auth',
+      };
+    }
+    return this.runSuViaPty(command, suPwd, opts);
+  }
+
+  async close(): Promise<void> {
+    if (this.askpassDir) {
+      try {
+        await fs.rm(this.askpassDir, { recursive: true, force: true });
+      } catch (e) {
+        // best-effort cleanup
+      }
+      this.askpassDir = undefined;
+      this.askpassEnvName = undefined;
+    }
+  }
+
+  /** Verify `ssh` is on PATH and usable. Throws if missing. */
+  private async verifySshBinary(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      execFile('ssh', ['-V'], (err) => {
+        if (err) {
+          reject(new Error(
+            'ssh binary not found on PATH. ' +
+            'Install OpenSSH client (Windows: Settings > Apps > Optional features > OpenSSH Client; ' +
+            'Linux: apt install openssh-client).'
+          ));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Write a `.cmd` askpass helper to a temp dir and remember its path.
+   * Password lives in an env var passed only to spawned ssh children —
+   * never written to disk, never placed in argv.
+   */
+  private async prepareAskpassHelper(password: string): Promise<void> {
+    const envName = `SSH_MCP_PW_${process.pid}`;
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-'));
+    const isWindows = process.platform === 'win32';
+    const helperName = isWindows ? 'askpass.cmd' : 'askpass.sh';
+    const helperPath = path.join(dir, helperName);
+    const content = isWindows
+      ? `@echo off\r\necho %${envName}%\r\n`
+      : `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
+    await fs.writeFile(helperPath, content, { encoding: 'utf8' });
+    if (!isWindows) {
+      await fs.chmod(helperPath, 0o700);
+    }
+    this.askpassDir = dir;
+    this.askpassEnvName = envName;
+    (this as any)._askpassPath = helperPath;
+    (this as any)._askpassPassword = password;
+  }
+
+  /** Build the ssh argv array for a single invocation. */
+  buildArgs(opts: ExecOptions): string[] {
+    const cfg = this.cfg;
+    const a: string[] = [
+      '-o', `StrictHostKeyChecking=${cfg.strictHostKeyChecking ?? 'accept-new'}`,
+      '-o', `ConnectTimeout=${Math.max(1, Math.ceil(opts.timeoutMs / 1000))}`,
+      '-o', 'ServerAliveInterval=30',
+      '-o', 'ServerAliveCountMax=3',
+      '-o', 'BatchMode=no',
+      '-p', String(cfg.port),
+    ];
+    if (cfg.knownHostsFile) {
+      a.push('-o', `UserKnownHostsFile=${cfg.knownHostsFile}`);
+    }
+
+    switch (cfg.authMode) {
+      case 'kerberos':
+        a.push(
+          '-o', 'GSSAPIAuthentication=yes',
+          '-o', `GSSAPIDelegateCredentials=${cfg.gssapiDelegateCredentials ?? 'no'}`,
+          '-o', 'PreferredAuthentications=gssapi-with-mic',
+          '-o', 'PubkeyAuthentication=no',
+          '-o', 'PasswordAuthentication=no',
+        );
+        break;
+      case 'key':
+        if (cfg.keyPath) a.push('-i', cfg.keyPath);
+        a.push(
+          '-o', 'PreferredAuthentications=publickey',
+          '-o', 'PasswordAuthentication=no',
+          '-o', 'GSSAPIAuthentication=no',
+        );
+        break;
+      case 'password':
+        a.push(
+          '-o', 'PreferredAuthentications=password,keyboard-interactive',
+          '-o', 'PubkeyAuthentication=no',
+          '-o', 'GSSAPIAuthentication=no',
+        );
+        break;
+      default:
+        break;
+    }
+
+    if (opts.pty) a.push('-tt');
+    a.push(`${cfg.username}@${cfg.host}`);
+    return a;
+  }
+
+  /** Assemble env vars for spawned ssh process. Injects askpass env when needed. */
+  private buildEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (this.cfg.authMode === 'password' && (this as any)._askpassPath) {
+      env.SSH_ASKPASS = (this as any)._askpassPath;
+      env.SSH_ASKPASS_REQUIRE = 'force';
+      env.DISPLAY = env.DISPLAY ?? 'dummy:0';
+      env[this.askpassEnvName!] = (this as any)._askpassPassword;
+    }
+    return env;
+  }
+
+  /** Run a single command via `ssh host <cmd>`, collect output, enforce timeout. */
+  private runSsh(command: string, opts: ExecOptions): Promise<ExecResult> {
+    return new Promise((resolve) => {
+      const args = [...this.buildArgs(opts), command];
+      let timedOut = false;
+      let stdout = '';
+      let stderr = '';
+
+      const child: ChildProcess = spawn('ssh', args, {
+        env: this.buildEnv(),
+        windowsHide: true,
+      });
+
+      child.stdout?.on('data', (b: Buffer) => { stdout += b.toString('utf8'); });
+      child.stderr?.on('data', (b: Buffer) => { stderr += b.toString('utf8'); });
+
+      if (opts.stdin) {
+        try { child.stdin?.end(opts.stdin); } catch (e) { /* ignore */ }
+      } else {
+        try { child.stdin?.end(); } catch (e) { /* ignore */ }
+      }
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        setTimeout(() => {
+          if (!child.killed) child.kill('SIGKILL');
+        }, 2000);
+      }, opts.timeoutMs);
+
+      child.on('error', (err: Error) => {
+        clearTimeout(timer);
+        resolve({
+          stdout,
+          stderr: stderr + `\nspawn error: ${err.message}`,
+          exitCode: null,
+          category: 'transport',
+        });
+      });
+
+      child.on('close', (code, signal) => {
+        clearTimeout(timer);
+        const category = timedOut ? 'timeout' : classifyError(code, stderr);
+        resolve({
+          stdout,
+          stderr,
+          exitCode: timedOut ? null : (code ?? null),
+          signal: signal ?? undefined,
+          category,
+        });
+      });
+    });
+  }
+
+  /**
+   * PTY-based su interactive exec. Uses `ssh -tt` to force remote PTY
+   * allocation. Drives an expect-style state machine via sentinel prompts.
+   *
+   * Random nonce in sentinels prevents collision if remote command output
+   * happens to contain the same string literally.
+   */
+  private runSuViaPty(command: string, suPassword: string, opts: ExecOptions): Promise<ExecResult> {
+    const nonce = randomBytes(8).toString('hex');
+    const readyMark = `__SSH_MCP_READY_${nonce}__`;
+    const endMark = `__SSH_MCP_END_${nonce}__`;
+    const pwRe = /(?:^|\r?\n|[^\w])[Pp]assword(?:\s+for\s+\S+)?:\s*$/m;
+    const failRe = /(authentication failure|incorrect password|su: (?:failed|Authentication failure|incorrect))/i;
+    const readyRe = new RegExp(`${readyMark}`);
+    const endRe = new RegExp(`${endMark}(\\d{1,3})(?:\\r?\\n|$)`);
+
+    return new Promise((resolve) => {
+      const args = [...this.buildArgs({ ...opts, pty: true }), 'su -'];
+      let state: 'SU_PROMPT' | 'PASSWORD_SENT' | 'ROOT_SHELL' | 'EXEC' | 'DONE' = 'SU_PROMPT';
+      let buffer = '';
+      let stdoutTail = '';
+      let capturedStdout = '';
+      let capturedStderr = '';
+      let exitCode: number | null = null;
+      let timedOut = false;
+      let stateTimer: NodeJS.Timeout | null = null;
+
+      const child: ChildProcess = spawn('ssh', args, {
+        env: this.buildEnv(),
+        windowsHide: true,
+      });
+
+      const setStateTimer = (ms: number, reason: string) => {
+        if (stateTimer) clearTimeout(stateTimer);
+        stateTimer = setTimeout(() => {
+          stateTimer = null;
+          capturedStderr += `\nState timeout in ${state}: ${reason}`;
+          child.kill('SIGTERM');
+        }, ms);
+      };
+
+      const clearStateTimer = () => {
+        if (stateTimer) { clearTimeout(stateTimer); stateTimer = null; }
+      };
+
+      const writeLine = (s: string) => {
+        try { child.stdin?.write(s + '\n'); } catch (e) { /* ignore */ }
+      };
+
+      // Initial state: wait up to 10s for `su` password prompt
+      setStateTimer(10000, 'awaiting su password prompt');
+
+      const overallTimer = setTimeout(() => {
+        timedOut = true;
+        clearStateTimer();
+        child.kill('SIGTERM');
+        setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
+      }, opts.timeoutMs + 30000);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf8');
+        buffer += text;
+        // Keep last ~4KB for regex scanning
+        if (buffer.length > 8192) buffer = buffer.slice(buffer.length - 4096);
+        stdoutTail = buffer;
+
+        if (failRe.test(stdoutTail)) {
+          clearStateTimer();
+          capturedStderr += stdoutTail;
+          child.kill('SIGTERM');
+          return;
+        }
+
+        if (state === 'SU_PROMPT' && pwRe.test(stdoutTail)) {
+          clearStateTimer();
+          state = 'PASSWORD_SENT';
+          writeLine(suPassword);
+          setStateTimer(8000, 'awaiting root shell after password');
+          return;
+        }
+
+        if (state === 'PASSWORD_SENT') {
+          // Send sentinel PS1 once we see a non-prompt line (typical: post-auth motd)
+          // Trigger: any newline after password sent.
+          if (/\r?\n/.test(text)) {
+            writeLine(`export PS1='${readyMark}$ '`);
+            state = 'ROOT_SHELL';
+            setStateTimer(5000, 'awaiting sentinel prompt');
+            buffer = '';
+            stdoutTail = '';
+            return;
+          }
+        }
+
+        if (state === 'ROOT_SHELL' && readyRe.test(stdoutTail)) {
+          clearStateTimer();
+          state = 'EXEC';
+          buffer = '';
+          stdoutTail = '';
+          // Execute user command, then echo sentinel+exitcode
+          writeLine(`${command}`);
+          writeLine(`echo ${endMark}$?`);
+          return;
+        }
+
+        if (state === 'EXEC') {
+          const m = stdoutTail.match(endRe);
+          if (m) {
+            exitCode = parseInt(m[1], 10);
+            capturedStdout = stdoutTail.slice(0, m.index).replace(/\r\n/g, '\n');
+            // Strip the echoed PS1-sentinel leftovers if any
+            capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
+            // Strip the echoed command lines (best effort)
+            state = 'DONE';
+            writeLine('exit');
+            writeLine('exit');
+          }
+        }
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        capturedStderr += chunk.toString('utf8');
+      });
+
+      child.on('error', (err: Error) => {
+        clearStateTimer();
+        clearTimeout(overallTimer);
+        resolve({
+          stdout: capturedStdout,
+          stderr: capturedStderr + `\nspawn error: ${err.message}`,
+          exitCode: null,
+          category: 'transport',
+        });
+      });
+
+      child.on('close', (code, signal) => {
+        clearStateTimer();
+        clearTimeout(overallTimer);
+
+        if (timedOut) {
+          resolve({
+            stdout: capturedStdout,
+            stderr: capturedStderr || `PTY exec timed out after ${opts.timeoutMs}ms`,
+            exitCode: null,
+            signal: signal ?? undefined,
+            category: 'timeout',
+          });
+          return;
+        }
+
+        if (state === 'DONE' && exitCode !== null) {
+          resolve({
+            stdout: capturedStdout,
+            stderr: '',
+            exitCode,
+            category: exitCode === 0 ? undefined : 'remote_exit',
+          });
+          return;
+        }
+
+        // Did not reach DONE — classify based on stderr content
+        const category: ErrorCategory = failRe.test(stdoutTail + capturedStderr)
+          ? 'auth'
+          : (classifyError(code, capturedStderr) ?? 'transport');
+        resolve({
+          stdout: capturedStdout,
+          stderr: capturedStderr || stdoutTail,
+          exitCode: code ?? null,
+          signal: signal ?? undefined,
+          category,
+        });
+      });
+    });
+  }
+}
+
+/**
+ * Map SSH exit code + stderr to structured ErrorCategory.
+ *
+ *   exit 0                → undefined  (success)
+ *   exit 1-254            → remote_exit (remote command's own non-zero exit)
+ *   exit 255              → inspect stderr for SSH-layer failure type
+ *   exit null             → treated as transport failure
+ */
+export function classifyError(code: number | null, stderr: string): ErrorCategory | undefined {
+  if (code === 0) return undefined;
+  if (code === null) return 'transport';
+  if (code !== 255) return 'remote_exit';
+
+  const s = stderr.toLowerCase();
+  if (/permission denied/.test(s)) return 'auth';
+  if (/authentication failed|authentication failure/.test(s)) return 'auth';
+  if (/no credentials cache|no credential/.test(s)) return 'auth';
+  if (/ticket expired/.test(s)) return 'auth';
+  if (/gss.*credential|gssapi.*failure|gssapi.*unspecified/.test(s)) return 'auth';
+  if (/clock skew too great/.test(s)) return 'auth';
+  if (/server not found in kerberos database/.test(s)) return 'auth';
+  if (/host key verification failed/.test(s)) return 'host_key';
+  if (/remote host identification has changed/.test(s)) return 'host_key';
+  if (/connection refused/.test(s)) return 'connect';
+  if (/connection timed out/.test(s)) return 'connect';
+  if (/connection reset/.test(s)) return 'connect';
+  if (/could not resolve|name or service not known/.test(s)) return 'connect';
+  if (/no route to host|network unreachable/.test(s)) return 'connect';
+  return 'transport';
+}

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -145,6 +145,17 @@ export class TransportRegistry {
     const defaultUsable = this.defaultExplicit || this.configs.size === 1;
     const out = [];
     for (const [name, cfg] of this.configs) {
+      // A cached transport is "initialized" — but for OpenSSH that only means
+      // the local ssh binary/askpass setup passed; no live connection is proven
+      // until a command actually runs (openssh spawns per-exec, has no
+      // persistent socket). Prefer the transport's own isConnected() liveness
+      // probe when present so list-servers does not report an initialized-only
+      // OpenSSH host as connected when it has never answered. Fall back to
+      // "cached after successful init" only for transports without a probe.
+      const cached = this.transports.get(name);
+      const connected = cached
+        ? (typeof cached.isConnected === 'function' ? cached.isConnected() : true)
+        : false;
       out.push({
         name,
         host: cfg.host,
@@ -152,7 +163,7 @@ export class TransportRegistry {
         username: cfg.username,
         transport: (cfg.transport ?? (cfg.kerberos ? 'openssh' : 'ssh2')) as 'ssh2' | 'openssh',
         authMode: cfg.authMode ?? (cfg.kerberos ? 'kerberos' : cfg.keyPath || cfg.privateKey ? 'key' : cfg.password ? 'password' : 'unspecified'),
-        connected: this.transports.has(name),
+        connected,
         isDefault: defaultUsable && this.defaultName === name,
       });
     }

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -19,6 +19,16 @@ export class TransportRegistry {
   /** True only when setDefault() was called; first-registered fallback leaves this false. */
   private defaultExplicit = false;
 
+  /**
+   * @param prepareConfig Optional per-host preparation run lazily on first
+   *   get(name), inside the init path — NOT at register() time. Used to defer
+   *   expensive/failure-prone work (e.g. reading an ssh2 key file from disk)
+   *   until the host is actually selected, so one secondary host with a
+   *   missing/unmounted key path does not break startup or block list-servers
+   *   and commands against otherwise-healthy hosts.
+   */
+  constructor(private prepareConfig?: (cfg: ServerConfig) => Promise<void>) {}
+
   register(config: ServerConfig): void {
     if (!config.name) {
       throw new Error('ServerConfig.name is required');
@@ -91,18 +101,24 @@ export class TransportRegistry {
 
     const cfg = this.configs.get(resolved)!;
     const initPromise = (async () => {
-      const t = createTransport(cfg);
       try {
+        // Lazy per-host prep (e.g. reading the ssh2 key file). Deferred to here
+        // so a missing key on this host fails only when the host is used, not at
+        // startup. Kept inside the try so the finally below clears the in-flight
+        // entry on a prep failure too — a later get() retries instead of
+        // replaying the cached rejection (same contract as a rejected init).
+        if (this.prepareConfig) await this.prepareConfig(cfg);
+        const t = createTransport(cfg);
         await t.init();
         // Cache the live transport only on successful init.
         this.transports.set(resolved, t);
         return t;
       } finally {
-        // Always clear the in-flight entry so a rejected init (e.g. a transient
-        // connect timeout to a temporarily-unreachable host) is NOT cached.
-        // Otherwise every later get() would replay the same rejection via the
-        // pending-promise return above, and the connection could never retry
-        // without a process restart.
+        // Always clear the in-flight entry so a rejected prep/init (e.g. a
+        // missing key file, or a transient connect timeout to a temporarily-
+        // unreachable host) is NOT cached. Otherwise every later get() would
+        // replay the same rejection via the pending-promise return above, and
+        // the connection could never retry without a process restart.
         this.initPromises.delete(resolved);
       }
     })();
@@ -121,6 +137,12 @@ export class TransportRegistry {
     connected: boolean;
     isDefault: boolean;
   }> {
+    // A name is only a *usable* default when it can actually be selected with an
+    // omitted connectionName: either it's the lone server, or setDefault() was
+    // called. In the normal multi-host case (>1 server, no explicit default)
+    // resolveName() rejects an omitted name, so advertising the first-registered
+    // host as "(default)" would be misleading — report isDefault=false there.
+    const defaultUsable = this.defaultExplicit || this.configs.size === 1;
     const out = [];
     for (const [name, cfg] of this.configs) {
       out.push({
@@ -131,7 +153,7 @@ export class TransportRegistry {
         transport: (cfg.transport ?? (cfg.kerberos ? 'openssh' : 'ssh2')) as 'ssh2' | 'openssh',
         authMode: cfg.authMode ?? (cfg.kerberos ? 'kerberos' : cfg.keyPath || cfg.privateKey ? 'key' : cfg.password ? 'password' : 'unspecified'),
         connected: this.transports.has(name),
-        isDefault: this.defaultName === name,
+        isDefault: defaultUsable && this.defaultName === name,
       });
     }
     return out;

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -55,6 +55,27 @@ export class TransportRegistry {
     return this.defaultName;
   }
 
+  /**
+   * Resolve the profile/attribution name for an audit record WITHOUT throwing.
+   *
+   * Mirrors resolveName()'s ambiguity rules but is side-effect free and never
+   * rejects, so it is safe to call on the failure/catch path. Critically, for
+   * the ambiguous multi-host case (connectionName omitted, more than one server
+   * registered, no explicit default) it returns the '(unresolved)' sentinel
+   * rather than getDefaultName()'s first-registered server — that call is
+   * rejected by resolveName() before any command runs, so attributing its
+   * failure audit record to the first host would corrupt attribution.
+   */
+  resolveProfileName(name?: string): string {
+    // An explicitly-requested name is the accurate attribution even if it is
+    // unknown (registry.get throws later; the record should still name what the
+    // caller asked for, not a sentinel).
+    if (name) return name;
+    if (this.defaultName === null) return 'default';
+    if (this.configs.size > 1 && !this.defaultExplicit) return '(unresolved)';
+    return this.defaultName;
+  }
+
   /** Resolve name argument → canonical name. Falls back to default. */
   private resolveName(name?: string): string {
     if (name && this.configs.has(name)) return name;

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -1,0 +1,127 @@
+import { ISshTransport, ServerConfig } from './types.js';
+import { createTransport } from './factory.js';
+
+/**
+ * Registry of named SSH transports for multi-host MCP mode.
+ *
+ * Transports are lazily created on first use (so startup cost is O(1)
+ * regardless of how many hosts are configured). Each transport is reused
+ * across subsequent tool calls to the same connection name.
+ *
+ * When only a single config is registered, its name becomes the default
+ * — callers may omit connectionName from tool arguments.
+ */
+export class TransportRegistry {
+  private configs = new Map<string, ServerConfig>();
+  private transports = new Map<string, ISshTransport>();
+  private initPromises = new Map<string, Promise<ISshTransport>>();
+  private defaultName: string | null = null;
+
+  register(config: ServerConfig): void {
+    if (!config.name) {
+      throw new Error('ServerConfig.name is required');
+    }
+    if (this.configs.has(config.name)) {
+      throw new Error(`Duplicate server name: ${config.name}`);
+    }
+    this.configs.set(config.name, config);
+    // First registered becomes the default unless explicitly overridden.
+    if (this.defaultName === null) {
+      this.defaultName = config.name;
+    }
+  }
+
+  /** Override which name is used when tool calls omit connectionName. */
+  setDefault(name: string): void {
+    if (!this.configs.has(name)) {
+      throw new Error(`Cannot set default to unknown server: ${name}`);
+    }
+    this.defaultName = name;
+  }
+
+  /** Returns names of all registered servers in registration order. */
+  names(): string[] {
+    return Array.from(this.configs.keys());
+  }
+
+  hasAny(): boolean {
+    return this.configs.size > 0;
+  }
+
+  getDefaultName(): string | null {
+    return this.defaultName;
+  }
+
+  /** Resolve name argument → canonical name. Falls back to default. */
+  private resolveName(name?: string): string {
+    if (name && this.configs.has(name)) return name;
+    if (name && !this.configs.has(name)) {
+      throw new Error(
+        `Unknown connection name: ${name}. Registered: ${this.names().join(', ') || '(none)'}`
+      );
+    }
+    if (this.defaultName === null) {
+      throw new Error('No servers registered');
+    }
+    return this.defaultName;
+  }
+
+  /** Get (or lazily create+init) the transport for a given name. */
+  async get(name?: string): Promise<ISshTransport> {
+    const resolved = this.resolveName(name);
+    const existing = this.transports.get(resolved);
+    if (existing) return existing;
+
+    // Serialize concurrent init requests for the same name
+    const pending = this.initPromises.get(resolved);
+    if (pending) return pending;
+
+    const cfg = this.configs.get(resolved)!;
+    const initPromise = (async () => {
+      const t = createTransport(cfg);
+      await t.init();
+      this.transports.set(resolved, t);
+      this.initPromises.delete(resolved);
+      return t;
+    })();
+    this.initPromises.set(resolved, initPromise);
+    return initPromise;
+  }
+
+  /** Snapshot status for list-servers tool. */
+  list(): Array<{
+    name: string;
+    host: string;
+    port: number;
+    username: string;
+    transport: 'ssh2' | 'openssh';
+    authMode: string;
+    connected: boolean;
+    isDefault: boolean;
+  }> {
+    const out = [];
+    for (const [name, cfg] of this.configs) {
+      out.push({
+        name,
+        host: cfg.host,
+        port: cfg.port,
+        username: cfg.username,
+        transport: (cfg.transport ?? (cfg.kerberos ? 'openssh' : 'ssh2')) as 'ssh2' | 'openssh',
+        authMode: cfg.authMode ?? (cfg.kerberos ? 'kerberos' : cfg.keyPath || cfg.privateKey ? 'key' : cfg.password ? 'password' : 'unspecified'),
+        connected: this.transports.has(name),
+        isDefault: this.defaultName === name,
+      });
+    }
+    return out;
+  }
+
+  async closeAll(): Promise<void> {
+    const tasks: Promise<void>[] = [];
+    for (const t of this.transports.values()) {
+      tasks.push(t.close().catch(() => { /* best effort */ }));
+    }
+    this.transports.clear();
+    this.initPromises.clear();
+    await Promise.allSettled(tasks);
+  }
+}

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -16,6 +16,8 @@ export class TransportRegistry {
   private transports = new Map<string, ISshTransport>();
   private initPromises = new Map<string, Promise<ISshTransport>>();
   private defaultName: string | null = null;
+  /** True only when setDefault() was called; first-registered fallback leaves this false. */
+  private defaultExplicit = false;
 
   register(config: ServerConfig): void {
     if (!config.name) {
@@ -37,6 +39,7 @@ export class TransportRegistry {
       throw new Error(`Cannot set default to unknown server: ${name}`);
     }
     this.defaultName = name;
+    this.defaultExplicit = true;
   }
 
   /** Returns names of all registered servers in registration order. */
@@ -63,6 +66,16 @@ export class TransportRegistry {
     if (this.defaultName === null) {
       throw new Error('No servers registered');
     }
+    // When connectionName is omitted and more than one server is configured,
+    // refuse to silently pick the first-registered host — the command could
+    // land on the wrong machine. The connectionName tool arg is advertised as
+    // optional only for the single-server case (see connectionNameSchema in
+    // index.ts). A deliberate setDefault() re-enables the omit-name shortcut.
+    if (!name && this.configs.size > 1 && !this.defaultExplicit) {
+      throw new Error(
+        `connectionName is required when multiple servers are configured: ${this.names().join(', ')}`
+      );
+    }
     return this.defaultName;
   }
 
@@ -79,10 +92,19 @@ export class TransportRegistry {
     const cfg = this.configs.get(resolved)!;
     const initPromise = (async () => {
       const t = createTransport(cfg);
-      await t.init();
-      this.transports.set(resolved, t);
-      this.initPromises.delete(resolved);
-      return t;
+      try {
+        await t.init();
+        // Cache the live transport only on successful init.
+        this.transports.set(resolved, t);
+        return t;
+      } finally {
+        // Always clear the in-flight entry so a rejected init (e.g. a transient
+        // connect timeout to a temporarily-unreachable host) is NOT cached.
+        // Otherwise every later get() would replay the same rejection via the
+        // pending-promise return above, and the connection could never retry
+        // without a process restart.
+        this.initPromises.delete(resolved);
+      }
     })();
     this.initPromises.set(resolved, initPromise);
     return initPromise;

--- a/src/transports/ssh2.ts
+++ b/src/transports/ssh2.ts
@@ -1,0 +1,414 @@
+import { Client, ClientChannel } from 'ssh2';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ISshTransport,
+  ExecOptions,
+  ExecElevatedOptions,
+  ExecResult,
+  TransportConfig,
+} from './types.js';
+import { escapeCommandForShell } from '../utils/shell.js';
+
+/**
+ * Connection manager extracted verbatim from upstream src/index.ts. Behaviour
+ * is preserved byte-for-byte. It is re-exported from src/index.ts so existing
+ * tests (persistent-connection.test.ts) continue to import it.
+ */
+export interface SSHConfig {
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  privateKey?: string;
+  suPassword?: string;
+  sudoPassword?: string;
+}
+
+export class SSHConnectionManager {
+  private conn: Client | null = null;
+  private sshConfig: SSHConfig;
+  private isConnecting = false;
+  private connectionPromise: Promise<void> | null = null;
+  private suShell: any = null;
+  private suPromise: Promise<void> | null = null;
+  private isElevated = false;
+
+  constructor(config: SSHConfig) {
+    this.sshConfig = config;
+  }
+
+  async connect(): Promise<void> {
+    if (this.conn && this.isConnected()) {
+      return;
+    }
+    if (this.isConnecting && this.connectionPromise) {
+      return this.connectionPromise;
+    }
+
+    this.isConnecting = true;
+    this.connectionPromise = new Promise((resolve, reject) => {
+      this.conn = new Client();
+
+      const timeoutId = setTimeout(() => {
+        this.conn?.end();
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+        reject(new McpError(ErrorCode.InternalError, 'SSH connection timeout'));
+      }, 30000);
+
+      this.conn.on('ready', async () => {
+        clearTimeout(timeoutId);
+        this.isConnecting = false;
+        if (this.sshConfig.suPassword && !process.env.SSH_MCP_TEST) {
+          try {
+            await this.ensureElevated();
+          } catch (err) {
+            // Do not reject connection; commands fall back to non-elevated.
+          }
+        }
+        resolve();
+      });
+
+      this.conn.on('error', (err: Error) => {
+        clearTimeout(timeoutId);
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+        reject(new McpError(ErrorCode.InternalError, `SSH connection error: ${err.message}`));
+      });
+
+      this.conn.on('end', () => {
+        console.error('SSH connection ended');
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+      });
+
+      this.conn.on('close', () => {
+        console.error('SSH connection closed');
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+      });
+
+      this.conn.connect(this.sshConfig);
+    });
+
+    return this.connectionPromise;
+  }
+
+  isConnected(): boolean {
+    return this.conn !== null && (this.conn as any)._sock && !(this.conn as any)._sock.destroyed;
+  }
+
+  getSudoPassword(): string | undefined {
+    return this.sshConfig.sudoPassword;
+  }
+
+  getSuPassword(): string | undefined {
+    return this.sshConfig.suPassword;
+  }
+
+  async setSuPassword(pwd?: string): Promise<void> {
+    this.sshConfig.suPassword = pwd;
+    if (pwd) {
+      try {
+        await this.ensureElevated();
+      } catch (err) {
+        console.error('setSuPassword: failed to elevate to su shell:', err);
+      }
+    } else {
+      if (this.suShell) {
+        try { this.suShell.end(); } catch (e) { /* ignore */ }
+        this.suShell = null;
+        this.isElevated = false;
+      }
+    }
+  }
+
+  async ensureElevated(): Promise<void> {
+    if (this.isElevated && this.suShell) return;
+    if (!this.sshConfig.suPassword) return;
+    if (this.suPromise) return this.suPromise;
+
+    this.suPromise = new Promise((resolve, reject) => {
+      const conn = this.getConnection();
+
+      const timeoutId = setTimeout(() => {
+        this.suPromise = null;
+        reject(new McpError(ErrorCode.InternalError, 'su elevation timed out'));
+      }, 10000);
+
+      conn.shell({ term: 'xterm', cols: 80, rows: 24 }, (err: Error | undefined, stream: ClientChannel) => {
+        if (err) {
+          clearTimeout(timeoutId);
+          this.suPromise = null;
+          reject(new McpError(ErrorCode.InternalError, `Failed to start interactive shell for su: ${err.message}`));
+          return;
+        }
+
+        let buffer = '';
+        let passwordSent = false;
+        const cleanup = () => {
+          try { stream.removeAllListeners('data'); } catch (e) { /* ignore */ }
+        };
+
+        const onData = (data: Buffer) => {
+          const text = data.toString();
+          buffer += text;
+
+          if (!passwordSent && /password[: ]/i.test(buffer)) {
+            passwordSent = true;
+            stream.write(this.sshConfig.suPassword + '\n');
+          }
+
+          if (passwordSent) {
+            if (/#/.test(buffer)) {
+              clearTimeout(timeoutId);
+              cleanup();
+              this.suShell = stream;
+              this.isElevated = true;
+              this.suPromise = null;
+              resolve();
+              return;
+            }
+          }
+
+          if (/authentication failure|incorrect password|su: .*failed|su: failure/i.test(buffer)) {
+            clearTimeout(timeoutId);
+            cleanup();
+            this.suPromise = null;
+            reject(new McpError(ErrorCode.InternalError, `su authentication failed: ${buffer}`));
+            return;
+          }
+        };
+
+        stream.on('data', onData);
+        stream.on('close', () => {
+          clearTimeout(timeoutId);
+          if (!this.isElevated) {
+            this.suPromise = null;
+            reject(new McpError(ErrorCode.InternalError, 'su shell closed before elevation completed'));
+          }
+        });
+
+        stream.write('su -\n');
+      });
+    });
+
+    return this.suPromise;
+  }
+
+  async ensureConnected(): Promise<void> {
+    if (!this.isConnected()) {
+      await this.connect();
+    }
+  }
+
+  getConnection(): Client {
+    if (!this.conn) {
+      throw new McpError(ErrorCode.InternalError, 'SSH connection not established');
+    }
+    return this.conn;
+  }
+
+  /** Internal accessor used by execSshCommandWithConnection and Ssh2Transport. */
+  getSuShell(): any {
+    return this.suShell;
+  }
+
+  /** Internal mutator used by tool handlers that update config after construction. */
+  updateSudoPassword(pwd?: string): void {
+    this.sshConfig.sudoPassword = pwd;
+  }
+
+  close(): void {
+    if (this.conn) {
+      if (this.suShell) {
+        try { this.suShell.end(); } catch (e) { /* ignore */ }
+        this.suShell = null;
+        this.isElevated = false;
+      }
+      this.conn.end();
+      this.conn = null;
+    }
+  }
+}
+
+/**
+ * Ssh2Transport — ISshTransport adapter around SSHConnectionManager.
+ *
+ * Behaviour: preserves the upstream implementation exactly. If the underlying
+ * manager has an active `suShell` (created by ensureElevated), exec()
+ * routes through it. Otherwise it uses `conn.exec()`.
+ */
+export class Ssh2Transport implements ISshTransport {
+  readonly name = 'ssh2' as const;
+  private manager: SSHConnectionManager;
+
+  constructor(private cfg: TransportConfig) {
+    const sshCfg: SSHConfig = {
+      host: cfg.host,
+      port: cfg.port,
+      username: cfg.username,
+      password: cfg.password,
+      privateKey: cfg.privateKey,
+      suPassword: cfg.suPassword,
+      sudoPassword: cfg.sudoPassword,
+    };
+    this.manager = new SSHConnectionManager(sshCfg);
+  }
+
+  /** Exposed for legacy tests and tool handlers that need direct manager access. */
+  getManager(): SSHConnectionManager {
+    return this.manager;
+  }
+
+  async init(): Promise<void> {
+    await this.manager.connect();
+  }
+
+  async exec(command: string, opts: ExecOptions): Promise<ExecResult> {
+    await this.manager.ensureConnected();
+
+    // Mirror upstream behaviour: if suPassword was configured, ensure elevation
+    // before executing. Idempotent; no-op if already elevated.
+    if (this.manager.getSuPassword()) {
+      try {
+        await Promise.race([
+          this.manager.ensureElevated(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000)),
+        ]);
+      } catch (err) {
+        // Fall back to non-elevated execution on elevation failure.
+      }
+    }
+
+    return this.runOnConnection(command, opts);
+  }
+
+  async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
+    if (opts.mode === 'sudo') {
+      const pwd = opts.password ?? this.manager.getSudoPassword();
+      const wrapped = buildSudoWrapper(command, pwd);
+      return this.exec(wrapped, opts);
+    }
+    // mode === 'su' — configure password on manager, ensure elevation, then exec
+    if (opts.password) {
+      await this.manager.setSuPassword(opts.password);
+    }
+    return this.exec(command, opts);
+  }
+
+  async close(): Promise<void> {
+    this.manager.close();
+  }
+
+  private runOnConnection(command: string, opts: ExecOptions): Promise<ExecResult> {
+    return new Promise((resolve) => {
+      let timeoutId: NodeJS.Timeout;
+      let isResolved = false;
+      const timeoutMs = opts.timeoutMs;
+
+      const conn = this.manager.getConnection();
+      const shell = this.manager.getSuShell();
+
+      timeoutId = setTimeout(() => {
+        if (!isResolved) {
+          isResolved = true;
+          resolve({
+            stdout: '',
+            stderr: `Command execution timed out after ${timeoutMs}ms`,
+            exitCode: null,
+            category: 'timeout',
+          });
+        }
+      }, timeoutMs);
+
+      if (shell) {
+        let buffer = '';
+        const dataHandler = (data: Buffer) => {
+          const text = data.toString();
+          buffer += text;
+
+          if (/#/.test(buffer)) {
+            if (!isResolved) {
+              isResolved = true;
+              clearTimeout(timeoutId);
+              const lines = buffer.split('\n');
+              const output = lines.slice(1, -1).join('\n');
+              resolve({
+                stdout: output + (output ? '\n' : ''),
+                stderr: '',
+                exitCode: 0,
+              });
+            }
+            shell.removeListener('data', dataHandler);
+          }
+        };
+
+        shell.on('data', dataHandler);
+        shell.write(command + '\n');
+        return;
+      }
+
+      conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
+        if (err) {
+          if (!isResolved) {
+            isResolved = true;
+            clearTimeout(timeoutId);
+            resolve({
+              stdout: '',
+              stderr: `SSH exec error: ${err.message}`,
+              exitCode: null,
+              category: 'transport',
+            });
+          }
+          return;
+        }
+
+        let stdout = '';
+        let stderr = '';
+
+        if (opts.stdin && opts.stdin.length > 0) {
+          try {
+            stream.write(opts.stdin);
+          } catch (e) {
+            console.error('Error writing to stdin:', e);
+          }
+        }
+        try { stream.end(); } catch (e) { /* ignore */ }
+
+        stream.on('data', (data: Buffer) => {
+          stdout += data.toString();
+        });
+        stream.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+        stream.on('close', (code: number, _signal: string) => {
+          if (!isResolved) {
+            isResolved = true;
+            clearTimeout(timeoutId);
+            resolve({
+              stdout,
+              stderr,
+              exitCode: code ?? 0,
+              category: stderr ? 'remote_exit' : undefined,
+            });
+          }
+        });
+      });
+    });
+  }
+}
+
+/** Build a sudo-wrapped command exactly the way upstream sudo-exec tool does. */
+export function buildSudoWrapper(command: string, sudoPassword?: string): string {
+  const escaped = command.replace(/'/g, "'\\''");
+  if (!sudoPassword) {
+    return `sudo -n sh -c '${escaped}'`;
+  }
+  const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
+  return `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${escaped}'`;
+}

--- a/src/transports/ssh2.ts
+++ b/src/transports/ssh2.ts
@@ -305,6 +305,14 @@ export class Ssh2Transport implements ISshTransport {
     this.manager.close();
   }
 
+  /**
+   * ssh2 keeps a persistent Client socket established at init() time, so live
+   * connection status is the underlying manager's socket state.
+   */
+  isConnected(): boolean {
+    return this.manager.isConnected();
+  }
+
   private runOnConnection(command: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       let timeoutId: NodeJS.Timeout;

--- a/src/transports/ssh2.ts
+++ b/src/transports/ssh2.ts
@@ -390,11 +390,12 @@ export class Ssh2Transport implements ISshTransport {
           if (!isResolved) {
             isResolved = true;
             clearTimeout(timeoutId);
+            const exitCode = code ?? 0;
             resolve({
               stdout,
               stderr,
-              exitCode: code ?? 0,
-              category: stderr ? 'remote_exit' : undefined,
+              exitCode,
+              category: exitCode !== 0 ? 'remote_exit' : undefined,
             });
           }
         });

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -94,3 +94,13 @@ export interface TransportConfig {
   knownHostsFile?: string;
   strictHostKeyChecking?: 'yes' | 'no' | 'accept-new';
 }
+
+/**
+ * Named server configuration for multi-host mode. Emits TransportConfig
+ * at registry time, plus a required `name` that the MCP tools reference
+ * via `connectionName`.
+ */
+export interface ServerConfig extends TransportConfig {
+  /** Unique identifier referenced by MCP tools' connectionName argument. */
+  name: string;
+}

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -63,6 +63,24 @@ export interface ISshTransport {
 
   /** Release resources. Idempotent — safe to call multiple times. */
   close(): Promise<void>;
+
+  /**
+   * Optional liveness probe. When present, list-servers uses it to distinguish
+   * a transport that is merely *initialized* (cached after init()) from one
+   * with a *proven live connection*.
+   *
+   *   - ssh2 keeps a persistent Client socket, so init() establishes a real
+   *     connection; isConnected() reflects the live socket state.
+   *   - openssh has NO persistent connection — init() only verifies the local
+   *     ssh binary/askpass setup and each command spawns a fresh process. Being
+   *     initialized therefore does not prove the host is reachable (the first
+   *     command can still fail with connection refused). isConnected() reports
+   *     whether at least one command has actually run over a live SSH session.
+   *
+   * When a transport does not implement this, the registry falls back to
+   * treating "cached after successful init" as connected.
+   */
+  isConnected?(): boolean;
 }
 
 /** Auth mode for OpenSshTransport. Ssh2Transport selects auth from SshConfig fields. */

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Pluggable SSH transport abstraction.
+ *
+ * Two implementations:
+ *   - Ssh2Transport   (default; uses mscdex/ssh2 library)
+ *   - OpenSshTransport (opt-in via --transport=openssh or --kerberos; spawns ssh binary)
+ *
+ * Transport chosen at startup via factory. Tool handlers consume ExecResult
+ * and map to MCP responses.
+ */
+
+export type ErrorCategory =
+  | 'auth'        // bad password / bad key / Kerberos ticket missing or expired
+  | 'host_key'    // StrictHostKeyChecking rejection
+  | 'connect'     // TCP/DNS failure
+  | 'timeout'     // exec exceeded deadline
+  | 'remote_exit' // ran but exited non-zero
+  | 'transport';  // ssh2/openssh internal error (spawn failed, etc.)
+
+export interface ExecOptions {
+  /** Hard ceiling; transport must enforce and return category='timeout' on breach. */
+  timeoutMs: number;
+  /** Piped into remote stdin (e.g. sudo password). */
+  stdin?: string;
+  /** Request TTY allocation (needed for su -tt flow). */
+  pty?: boolean;
+}
+
+export type ElevationMode = 'sudo' | 'su';
+
+export interface ExecElevatedOptions extends ExecOptions {
+  mode: ElevationMode;
+  /** sudo -S stdin password, or su password. Optional for passwordless sudo. */
+  password?: string;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  /** Non-null only when killed by signal (POSIX). Always null on Windows. */
+  signal?: string;
+  /** Set when exec failed in a classifiable way. Undefined on success. */
+  category?: ErrorCategory;
+}
+
+/**
+ * Transport contract. Implementations decide connection-lifetime strategy
+ * internally (ssh2 keeps one persistent Client; openssh spawns per command
+ * because ControlMaster is unsupported on Windows).
+ */
+export interface ISshTransport {
+  readonly name: 'ssh2' | 'openssh';
+
+  /** Prepare resources. Connect ssh2 Client, verify ssh binary exists, etc. */
+  init(): Promise<void>;
+
+  /** Run a single remote command. */
+  exec(command: string, opts: ExecOptions): Promise<ExecResult>;
+
+  /** Elevated (sudo or su) exec. Transport handles the elevation mechanics. */
+  execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult>;
+
+  /** Release resources. Idempotent — safe to call multiple times. */
+  close(): Promise<void>;
+}
+
+/** Auth mode for OpenSshTransport. Ssh2Transport selects auth from SshConfig fields. */
+export type AuthMode = 'kerberos' | 'key' | 'password';
+
+/**
+ * Unified config shared by both transports. Supersedes the original SSHConfig.
+ * Backwards-compatible: ssh2 path reads the legacy fields (host/port/username/
+ * password/privateKey/suPassword/sudoPassword) unchanged.
+ */
+export interface TransportConfig {
+  // Connection
+  host: string;
+  port: number;
+  username: string;
+
+  // Auth (legacy, used by both transports)
+  password?: string;
+  privateKey?: string;  // private-key contents (not path)
+  suPassword?: string;
+  sudoPassword?: string;
+
+  // OpenSshTransport only
+  transport?: 'ssh2' | 'openssh';
+  authMode?: AuthMode;
+  keyPath?: string;     // path to key file (openssh uses -i)
+  kerberos?: boolean;
+  gssapiDelegateCredentials?: 'yes' | 'no';
+  knownHostsFile?: string;
+  strictHostKeyChecking?: 'yes' | 'no' | 'accept-new';
+}

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,44 @@
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Validate and trim a command string. Enforces maxChars if finite.
+ * Shared by both transports so limit semantics are identical.
+ */
+export function sanitizeCommand(command: string, maxChars: number): string {
+  if (typeof command !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'Command must be a string');
+  }
+
+  const trimmedCommand = command.trim();
+  if (!trimmedCommand) {
+    throw new McpError(ErrorCode.InvalidParams, 'Command cannot be empty');
+  }
+
+  if (Number.isFinite(maxChars) && trimmedCommand.length > maxChars) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Command is too long (max ${maxChars} characters)`
+    );
+  }
+
+  return trimmedCommand;
+}
+
+/**
+ * Return undefined for empty/non-string; otherwise the raw password.
+ * No content mutation, no logging.
+ */
+export function sanitizePassword(password: string | undefined): string | undefined {
+  if (typeof password !== 'string') return undefined;
+  if (password.length === 0) return undefined;
+  return password;
+}
+
+/**
+ * Escape a command for safe embedding inside a single-quoted POSIX shell
+ * context on the remote side, e.g. `sh -c '<escaped>'`. Applies the canonical
+ * `'\''` technique: close-quote, escape a single quote, re-open-quote.
+ */
+export function escapeCommandForShell(command: string): string {
+  return command.replace(/'/g, "'\"'\"'");
+}

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -8,6 +8,7 @@ import {
   resolveAuthMode,
   buildTransportConfig,
   getOrCreateInitializedTransport,
+  validateConfig,
 } from '../src/index';
 import type { ExecResult, ISshTransport } from '../src/transports/types';
 
@@ -86,6 +87,35 @@ describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
         resultToMcpContent({ stdout: '', stderr: 'x', exitCode: 0, category }),
       ).toThrow(McpError);
     }
+  });
+
+  it('preserves the timeout context even when stderr was written before the deadline', () => {
+    // A build/tool that prints progress or diagnostics to stderr and then hangs
+    // must NOT be reported as an ordinary error that hides the timeout; the
+    // timeout message stays, with stderr kept as trailing context.
+    let caught: unknown;
+    try {
+      resultToMcpContent({
+        stdout: '',
+        stderr: 'Building... step 3/9\nlinking objects',
+        exitCode: null,
+        category: 'timeout',
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    const msg = (caught as McpError).message;
+    expect(msg).toMatch(/timed out after \d+ms/);
+    // stderr diagnostics are retained as context, not dropped.
+    expect(msg).toContain('Building... step 3/9');
+    expect(msg).toContain('linking objects');
+  });
+
+  it('reports a bare timeout message when no stderr was captured', () => {
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: '', exitCode: null, category: 'timeout' }),
+    ).toThrow(/timed out after \d+ms/);
   });
 });
 
@@ -205,5 +235,51 @@ describe('getOrCreateInitializedTransport (Codex P2: do not publish before init 
     await expect(getOrCreateInitializedTransport(cache, createInitializedTransport)).resolves.toMatchObject({ name: 'openssh' });
     expect(createInitializedTransport).toHaveBeenCalledTimes(2);
     expect(cache.activeTransport?.name).toBe('openssh');
+  });
+});
+
+describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', () => {
+  const baseCfg = { host: 'h', user: 'u', transport: 'openssh' };
+
+  it('rejects a value-less --strictHostKeyChecking (parsed as null) instead of silently defaulting', () => {
+    // parseArgv records `null` for `--strictHostKeyChecking` with no `=value`.
+    // A truthiness guard would skip validation and let the option be dropped,
+    // silently weakening the host-key policy to the default.
+    expect(() =>
+      validateConfig({ ...baseCfg, strictHostKeyChecking: null }),
+    ).toThrow(/--strictHostKeyChecking must be one of: yes, no, accept-new/);
+  });
+
+  it('rejects a value-less --gssapiDelegateCredentials (parsed as null)', () => {
+    expect(() =>
+      validateConfig({ ...baseCfg, gssapiDelegateCredentials: null }),
+    ).toThrow(/--gssapiDelegateCredentials must be yes or no/);
+  });
+
+  it('rejects a value-less --knownHostsFile (parsed as null)', () => {
+    expect(() =>
+      validateConfig({ ...baseCfg, knownHostsFile: null }),
+    ).toThrow(/--knownHostsFile requires a file path/);
+  });
+
+  it('rejects an invalid explicit --strictHostKeyChecking value', () => {
+    expect(() =>
+      validateConfig({ ...baseCfg, strictHostKeyChecking: 'maybe' }),
+    ).toThrow(/--strictHostKeyChecking must be one of/);
+  });
+
+  it('accepts valid explicit OpenSSH option values', () => {
+    expect(() =>
+      validateConfig({
+        ...baseCfg,
+        strictHostKeyChecking: 'yes',
+        gssapiDelegateCredentials: 'no',
+        knownHostsFile: '/etc/ssh/known_hosts',
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not require OpenSSH option values when the flags are absent', () => {
+    expect(() => validateConfig({ ...baseCfg })).not.toThrow();
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -249,6 +249,9 @@ describe('prepareKeyContents (Codex 3549295046: skip deferred key reads when pas
       };
       await prepareKeyContents(cfg);
       expect(cfg.privateKey).toBe('KEYDATA');
+      await fs.writeFile(keyPath, 'ROTATED');
+      await prepareKeyContents(cfg);
+      expect(cfg.privateKey).toBe('ROTATED');
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -28,6 +28,28 @@ describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
     expect(out.content[0]).toEqual({ type: 'text', text: 'ok' });
   });
 
+  it('appends genuine stderr diagnostics on success (exit 0), filtering only the benign host-key warning', () => {
+    // Tools like git clone / curl / build systems write progress + warnings to
+    // stderr while still exiting 0; that output must reach the caller.
+    const out = resultToMcpContent({
+      stdout: 'cloned',
+      stderr: "Warning: Permanently added 'h' (ED25519) to the list of known hosts.\nCloning into 'repo'...\nReceiving objects: 100%",
+      exitCode: 0,
+      category: undefined,
+    });
+    expect(out.content[0].text).toBe("cloned\nCloning into 'repo'...\nReceiving objects: 100%");
+  });
+
+  it('returns only stdout when stderr is nothing but the benign host-key warning', () => {
+    const out = resultToMcpContent({
+      stdout: 'done',
+      stderr: "Warning: Permanently added '[h]:2222' (RSA) to the list of known hosts.",
+      exitCode: 0,
+      category: undefined,
+    });
+    expect(out.content[0].text).toBe('done');
+  });
+
   it('returns content for a plain success (exit 0, no stderr)', () => {
     const out = resultToMcpContent({ stdout: 'hello', stderr: '', exitCode: 0 });
     expect(out.content[0].text).toBe('hello');

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -7,9 +7,10 @@ import {
   resultToMcpContent,
   resolveAuthMode,
   buildTransportConfig,
+  prepareKeyContents,
   validateConfig,
 } from '../src/index';
-import type { ExecResult } from '../src/transports/types';
+import type { ExecResult, ServerConfig } from '../src/transports/types';
 
 // Pure-function unit tests for the CLI config/result mapping layer. These
 // import from src/index, which is safe because the test runner sets
@@ -213,6 +214,53 @@ describe('buildTransportConfig (Codex 3541767256: deferKeyRead keeps legacy key 
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('prepareKeyContents (Codex 3549295046: skip deferred key reads when password auth wins)', () => {
+  it('does NOT read a stale keyPath when the resolved authMode is password', async () => {
+    // The registry hook must mirror buildTransportConfig()'s eager-read guard:
+    // a `--password=... --key=/stale` config records keyPath but authMode is
+    // 'password', so the first tool call must use the password, not ENOENT on
+    // the stale/nonexistent key file.
+    const cfg: ServerConfig = {
+      name: 'n',
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authMode: 'password',
+      transport: 'ssh2',
+      password: 'pw',
+      keyPath: '/nonexistent/path/to/stale-key',
+    };
+    await prepareKeyContents(cfg);
+    expect(cfg.privateKey).toBeUndefined();
+    expect(cfg.password).toBe('pw');
+  });
+
+  it('reads the ssh2 keyPath when the resolved authMode is key', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-test-'));
+    const keyPath = path.join(dir, 'id_test');
+    await fs.writeFile(keyPath, 'KEYDATA');
+    try {
+      const cfg: ServerConfig = {
+        name: 'n', host: 'h', port: 22, username: 'u',
+        authMode: 'key', transport: 'ssh2', keyPath,
+      };
+      await prepareKeyContents(cfg);
+      expect(cfg.privateKey).toBe('KEYDATA');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read the key for an openssh key config (uses -i path instead)', async () => {
+    const cfg: ServerConfig = {
+      name: 'n', host: 'h', port: 22, username: 'u',
+      authMode: 'key', transport: 'openssh', keyPath: '/nonexistent/path/to/key',
+    };
+    await prepareKeyContents(cfg);
+    expect(cfg.privateKey).toBeUndefined();
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -186,6 +186,36 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
   });
 });
 
+describe('buildTransportConfig (Codex 3541767256: deferKeyRead keeps legacy key reads lazy)', () => {
+  it('does NOT read the ssh2 key file at build time when deferKeyRead is set', async () => {
+    // The legacy single-host bootstrap passes deferKeyRead so startup never
+    // reads the key file — a key mounted after process launch must still work,
+    // matching the pre-registry behavior (read on first tool call, not startup).
+    const cfg = await buildTransportConfig(
+      { host: 'h', port: 22, username: 'u', key: '/nonexistent/path/to/key' },
+      { deferKeyRead: true },
+    );
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.authMode).toBe('key');
+    // keyPath is recorded so the registry's lazy prepareKeyContents can read it
+    // on first use, but the (nonexistent) file must NOT be read now.
+    expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
+    expect(cfg.privateKey).toBeUndefined();
+  });
+
+  it('still reads the ssh2 key eagerly when deferKeyRead is not set (default)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-test-'));
+    const keyPath = path.join(dir, 'id_test');
+    await fs.writeFile(keyPath, 'KEYDATA');
+    try {
+      const cfg = await buildTransportConfig({ host: 'h', port: 22, username: 'u', key: keyPath });
+      expect(cfg.privateKey).toBe('KEYDATA');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', () => {
   const baseCfg = { host: 'h', user: 'u', transport: 'openssh' };
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -252,7 +252,7 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
 
   it('rejects a value-less --gssapiDelegateCredentials (parsed as null)', () => {
     expect(() =>
-      validateConfig({ ...baseCfg, gssapiDelegateCredentials: null }),
+      validateConfig({ ...baseCfg, kerberos: null, gssapiDelegateCredentials: null }),
     ).toThrow(/--gssapiDelegateCredentials must be yes or no/);
   });
 
@@ -272,6 +272,7 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
     expect(() =>
       validateConfig({
         ...baseCfg,
+        kerberos: null, // --kerberos alone; required for gssapiDelegateCredentials
         strictHostKeyChecking: 'yes',
         gssapiDelegateCredentials: 'no',
         knownHostsFile: '/etc/ssh/known_hosts',
@@ -281,5 +282,29 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
 
   it('does not require OpenSSH option values when the flags are absent', () => {
     expect(() => validateConfig({ ...baseCfg })).not.toThrow();
+  });
+
+  it('rejects a value-less --transport (parsed as null) instead of silently defaulting to ssh2', () => {
+    // parseArgv records `null` for `--transport` with no `=value`; the nullish
+    // fallback would treat it as absent and run the default ssh2 transport,
+    // silently ignoring a mistyped OpenSSH selection.
+    expect(() =>
+      validateConfig({ host: 'h', user: 'u', transport: null }),
+    ).toThrow(/--transport requires a value/);
+  });
+
+  it('rejects --gssapiDelegateCredentials without --kerberos (delegation would be silently dropped)', () => {
+    // buildArgs only emits GSSAPIDelegateCredentials in the kerberos auth
+    // branch, so accepting it without --kerberos would silently omit it and
+    // break second-hop SSO.
+    expect(() =>
+      validateConfig({ ...baseCfg, gssapiDelegateCredentials: 'yes' }),
+    ).toThrow(/--gssapiDelegateCredentials requires --kerberos/);
+  });
+
+  it('accepts --gssapiDelegateCredentials when --kerberos is present', () => {
+    expect(() =>
+      validateConfig({ host: 'h', user: 'u', kerberos: null, gssapiDelegateCredentials: 'yes' }),
+    ).not.toThrow();
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
@@ -7,8 +7,9 @@ import {
   resultToMcpContent,
   resolveAuthMode,
   buildTransportConfig,
+  getOrCreateInitializedTransport,
 } from '../src/index';
-import type { ExecResult } from '../src/transports/types';
+import type { ExecResult, ISshTransport } from '../src/transports/types';
 
 // Pure-function unit tests for the CLI config/result mapping layer. These
 // import from src/index, which is safe because the test runner sets
@@ -128,5 +129,59 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
     expect(cfg.transport).toBe('openssh');
     expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
     expect(cfg.privateKey).toBeUndefined();
+  });
+});
+
+describe('getOrCreateInitializedTransport (Codex P2: do not publish before init resolves)', () => {
+  function fakeTransport(): ISshTransport {
+    return {
+      name: 'openssh',
+      init: vi.fn(),
+      exec: vi.fn(),
+      execElevated: vi.fn(),
+      close: vi.fn(),
+    };
+  }
+
+  it('shares an in-flight initialization promise and publishes only after it resolves', async () => {
+    const cache = { activeTransport: null as ISshTransport | null, initPromise: null as Promise<ISshTransport> | null };
+    const transport = fakeTransport();
+    let resolveInit!: (value: ISshTransport) => void;
+    const createInitializedTransport = vi.fn(() => new Promise<ISshTransport>((resolve) => {
+      resolveInit = resolve;
+    }));
+
+    const p1 = getOrCreateInitializedTransport(cache, createInitializedTransport);
+    const p2 = getOrCreateInitializedTransport(cache, createInitializedTransport);
+
+    expect(createInitializedTransport).toHaveBeenCalledTimes(1);
+    expect(p2).toBe(p1);
+    // Critical regression guard: no half-initialized transport is visible while
+    // init is still pending, so concurrent OpenSSH/password calls cannot enter
+    // runSsh before SSH_ASKPASS exists.
+    expect(cache.activeTransport).toBeNull();
+    expect(cache.initPromise).toBe(p1);
+
+    resolveInit(transport);
+    await expect(p1).resolves.toBe(transport);
+    await expect(p2).resolves.toBe(transport);
+    expect(cache.activeTransport).toBe(transport);
+    expect(cache.initPromise).toBeNull();
+  });
+
+  it('clears the cached init promise after initialization failure so a retry can initialize', async () => {
+    const cache = { activeTransport: null as ISshTransport | null, initPromise: null as Promise<ISshTransport> | null };
+    const createInitializedTransport = vi
+      .fn<() => Promise<ISshTransport>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(fakeTransport());
+
+    await expect(getOrCreateInitializedTransport(cache, createInitializedTransport)).rejects.toThrow('boom');
+    expect(cache.activeTransport).toBeNull();
+    expect(cache.initPromise).toBeNull();
+
+    await expect(getOrCreateInitializedTransport(cache, createInitializedTransport)).resolves.toMatchObject({ name: 'openssh' });
+    expect(createInitializedTransport).toHaveBeenCalledTimes(2);
+    expect(cache.activeTransport?.name).toBe('openssh');
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  resultToMcpContent,
+  resolveAuthMode,
+  buildTransportConfig,
+} from '../src/index';
+import type { ExecResult } from '../src/transports/types';
+
+// Pure-function unit tests for the CLI config/result mapping layer. These
+// import from src/index, which is safe because the test runner sets
+// SSH_MCP_DISABLE_MAIN=1 (isCliEnabled=false) so no server/CLI side effects run
+// on import.
+
+describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
+  it('treats exit 0 as success even when stderr carries an OpenSSH host-key warning', () => {
+    const result: ExecResult = {
+      stdout: 'ok',
+      stderr: "Warning: Permanently added 'h' (ED25519) to the list of known hosts.",
+      exitCode: 0,
+      category: undefined,
+    };
+    const out = resultToMcpContent(result);
+    expect(out.content[0]).toEqual({ type: 'text', text: 'ok' });
+  });
+
+  it('returns content for a plain success (exit 0, no stderr)', () => {
+    const out = resultToMcpContent({ stdout: 'hello', stderr: '', exitCode: 0 });
+    expect(out.content[0].text).toBe('hello');
+  });
+
+  it('still throws for a genuine non-zero exit with stderr', () => {
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: 'boom', exitCode: 2, category: 'remote_exit' as any }),
+    ).toThrow(McpError);
+  });
+
+  it('throws for a non-zero exit even without a category set', () => {
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: 'segfault', exitCode: 139 }),
+    ).toThrow(/Error \(code 139\)/);
+  });
+
+  it('throws on auth/host_key/connect/transport/timeout categories regardless of exit code', () => {
+    for (const category of ['auth', 'host_key', 'connect', 'transport', 'timeout'] as const) {
+      expect(() =>
+        resultToMcpContent({ stdout: '', stderr: 'x', exitCode: 0, category }),
+      ).toThrow(McpError);
+    }
+  });
+});
+
+describe('resolveAuthMode (finding 2: password-over-key precedence)', () => {
+  it('ranks password above key when both are present', () => {
+    expect(resolveAuthMode({ password: 'pw', key: '/path/to/key' })).toBe('password');
+  });
+
+  it('resolves key when only a key is present', () => {
+    expect(resolveAuthMode({ key: '/path/to/key' })).toBe('key');
+  });
+
+  it('resolves password when only a password is present', () => {
+    expect(resolveAuthMode({ password: 'pw' })).toBe('password');
+  });
+
+  it('ranks kerberos above everything', () => {
+    expect(resolveAuthMode({ kerberos: true, password: 'pw', key: '/k' })).toBe('kerberos');
+  });
+
+  it('returns undefined when no credentials are supplied', () => {
+    expect(resolveAuthMode({})).toBeUndefined();
+  });
+});
+
+describe('buildTransportConfig (finding 2: no unconditional key read for password configs)', () => {
+  it('does NOT read the key file when a password config carries a stale --key (ssh2)', async () => {
+    const cfg = await buildTransportConfig({
+      host: 'h',
+      port: 22,
+      username: 'u',
+      password: 'pw',
+      key: '/nonexistent/path/to/stale-key',
+      // transport defaults to ssh2
+    });
+    expect(cfg.authMode).toBe('password');
+    expect(cfg.password).toBe('pw');
+    // keyPath is still recorded, but the (nonexistent) file must not be read.
+    expect(cfg.privateKey).toBeUndefined();
+  });
+
+  it('reads the key contents when key is the resolved auth mode (ssh2)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-test-'));
+    const keyPath = path.join(dir, 'id_test');
+    await fs.writeFile(keyPath, 'KEYDATA');
+    try {
+      const cfg = await buildTransportConfig({ host: 'h', port: 22, username: 'u', key: keyPath });
+      expect(cfg.authMode).toBe('key');
+      expect(cfg.privateKey).toBe('KEYDATA');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read the key file for the openssh transport (uses -i path instead)', async () => {
+    const cfg = await buildTransportConfig({
+      host: 'h',
+      port: 22,
+      username: 'u',
+      key: '/nonexistent/path/to/key',
+      transportFlag: 'openssh',
+    });
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
+    expect(cfg.privateKey).toBeUndefined();
+  });
+});

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -44,6 +44,19 @@ describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
     ).toThrow(/Error \(code 139\)/);
   });
 
+  it('throws for a non-zero exit with EMPTY stderr (e.g. `false`, `test -f missing`)', () => {
+    // Regression for the openssh transport: `false` / `test -f missing` exit
+    // non-zero with no stderr, and must NOT be reported as success.
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: '', exitCode: 1, category: 'remote_exit' as any }),
+    ).toThrow(/Error \(code 1\)[\s\S]*Command exited with status 1/);
+  });
+
+  it('treats a null exit code with no error category as success (handshake-less success path)', () => {
+    const out = resultToMcpContent({ stdout: 'done', stderr: '', exitCode: null });
+    expect(out.content[0].text).toBe('done');
+  });
+
   it('throws on auth/host_key/connect/transport/timeout categories regardless of exit code', () => {
     for (const category of ['auth', 'host_key', 'connect', 'transport', 'timeout'] as const) {
       expect(() =>

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { parseServerConfigJson, validateConfig } from '../src/index';
+
+// Unit tests for the multi-host (--ssh=<JSON>) config layer. Imported from
+// src/index, which is safe because the runner sets SSH_MCP_DISABLE_MAIN=1
+// (isCliEnabled=false) so no server/CLI side effects run on import.
+
+describe('parseServerConfigJson (happy path)', () => {
+  it('parses a password/ssh2 config with name/host/user', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'web1', host: 'web1.example', user: 'deploy', auth: 'password', password: 'pw',
+    }));
+    expect(cfg.name).toBe('web1');
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.authMode).toBe('password');
+    expect(cfg.password).toBe('pw');
+    expect(cfg.port).toBe(22);
+  });
+
+  it('accepts "username" as an alias for "user"', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'k', host: 'k.example', username: 'svc', auth: 'kerberos',
+    }));
+    expect(cfg.username).toBe('svc');
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.kerberos).toBe(true);
+  });
+
+  it('throws on missing name / host / user / auth', () => {
+    expect(() => parseServerConfigJson('{}')).toThrow(/missing required "name"/);
+    expect(() => parseServerConfigJson(JSON.stringify({ name: 'a' }))).toThrow(/missing required "host"/);
+    expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h' }))).toThrow(/missing required "user"/);
+    expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h', user: 'u' }))).toThrow(/requires "auth"/);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseServerConfigJson('{not json')).toThrow(/--ssh JSON parse error/);
+  });
+});
+
+describe('parseServerConfigJson (finding 4: ssh2 must not silently drop host-key enforcement)', () => {
+  it('rejects strictHostKeyChecking on an ssh2 (default) key config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'key', keyPath: '/k', strictHostKeyChecking: 'yes',
+    }))).toThrow(/require "transport": "openssh"/);
+  });
+
+  it('rejects knownHostsFile on an ssh2 (default) password config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'password', password: 'pw', knownHostsFile: '/tmp/known',
+    }))).toThrow(/require "transport": "openssh"/);
+  });
+
+  it('accepts strictHostKeyChecking when transport is explicitly openssh', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'key', keyPath: '/k', transport: 'openssh', strictHostKeyChecking: 'yes',
+    }));
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.strictHostKeyChecking).toBe('yes');
+  });
+
+  it('accepts knownHostsFile for a kerberos config (implies openssh)', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'kerberos', knownHostsFile: '/tmp/known',
+    }));
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.knownHostsFile).toBe('/tmp/known');
+  });
+});
+
+describe('validateConfig multi-host (finding 2: legacy flags must be rejected)', () => {
+  it('rejects --port mixed with --ssh', () => {
+    expect(() => validateConfig({ port: '2222' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);
+  });
+
+  it('rejects --sudoPassword mixed with --ssh', () => {
+    expect(() => validateConfig({ sudoPassword: 'x' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);
+  });
+
+  it('rejects --suPassword mixed with --ssh', () => {
+    expect(() => validateConfig({ suPassword: 'x' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);
+  });
+
+  it('names the offending flag(s) in the error', () => {
+    expect(() => validateConfig({ port: '2222', sudoPassword: 'x' }, true)).toThrow(/--port/);
+    expect(() => validateConfig({ port: '2222', sudoPassword: 'x' }, true)).toThrow(/--sudoPassword/);
+  });
+
+  it('passes for a clean multi-host invocation (no legacy flags)', () => {
+    expect(() => validateConfig({}, true)).not.toThrow();
+  });
+});

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -27,7 +27,7 @@ describe('parseServerConfigJson (happy path)', () => {
   });
 
   it('throws on missing name / host / user / auth', () => {
-    expect(() => parseServerConfigJson('{}')).toThrow(/missing required "name"/);
+    expect(() => parseServerConfigJson('{}')).toThrow(/non-empty string "name"/);
     expect(() => parseServerConfigJson(JSON.stringify({ name: 'a' }))).toThrow(/missing required "host"/);
     expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h' }))).toThrow(/missing required "user"/);
     expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h', user: 'u' }))).toThrow(/requires "auth"/);
@@ -65,6 +65,100 @@ describe('parseServerConfigJson (finding 4: ssh2 must not silently drop host-key
     }));
     expect(cfg.transport).toBe('openssh');
     expect(cfg.knownHostsFile).toBe('/tmp/known');
+  });
+});
+
+describe('parseServerConfigJson (round-2: input validation hardening)', () => {
+  it('does not echo the raw config in a JSON parse error (no secret leak)', () => {
+    const raw = '{"name":"x","password":"s3cret",}'; // trailing comma -> parse error
+    try {
+      parseServerConfigJson(raw);
+      throw new Error('expected parse to throw');
+    } catch (e: any) {
+      expect(e.message).toMatch(/--ssh JSON parse error/);
+      expect(e.message).not.toMatch(/s3cret/);
+    }
+  });
+
+  it('requires name to be a non-empty string (rejects numeric name)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 1, host: 'h', user: 'u', auth: 'password', password: 'pw',
+    }))).toThrow(/non-empty string "name"/);
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: '', host: 'h', user: 'u', auth: 'password', password: 'pw',
+    }))).toThrow(/non-empty string "name"/);
+  });
+
+  it('rejects a non-integer / out-of-range port', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 'abc',
+    }))).toThrow(/invalid "port"/);
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 70000,
+    }))).toThrow(/invalid "port"/);
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 0,
+    }))).toThrow(/invalid "port"/);
+  });
+
+  it('accepts a valid numeric port (and a numeric-string port)', () => {
+    expect(parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 2222,
+    })).port).toBe(2222);
+    expect(parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: '2200',
+    })).port).toBe(2200);
+  });
+
+  it('rejects an invalid transport value (typo)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', keyPath: '/k', transport: 'opnssh',
+    }))).toThrow(/invalid "transport"/);
+  });
+
+  it('rejects a kerberos config whose explicit transport is not openssh', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'kerberos', transport: 'ssh2',
+    }))).toThrow(/implies transport "openssh"/);
+  });
+
+  it('rejects an inline privateKey for an openssh key config (buildArgs ignores it)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', transport: 'openssh', privateKey: '-----BEGIN...',
+    }))).toThrow(/inline "privateKey" is not supported for transport "openssh"/);
+  });
+
+  it('still accepts an inline privateKey for an ssh2 key config', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', privateKey: '-----BEGIN...',
+    }));
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.privateKey).toBe('-----BEGIN...');
+  });
+
+  it('rejects an invalid gssapiDelegateCredentials value', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'kerberos', gssapiDelegateCredentials: 'maybe',
+    }))).toThrow(/gssapiDelegateCredentials must be "yes" or "no"/);
+  });
+
+  it('rejects gssapiDelegateCredentials on a non-kerberos config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', gssapiDelegateCredentials: 'yes',
+    }))).toThrow(/gssapiDelegateCredentials requires auth "kerberos"/);
+  });
+
+  it('accepts a valid gssapiDelegateCredentials on a kerberos config', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'kerberos', gssapiDelegateCredentials: 'yes',
+    }));
+    expect(cfg.gssapiDelegateCredentials).toBe('yes');
+  });
+
+  it('rejects an invalid strictHostKeyChecking value (on an openssh config)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', keyPath: '/k', transport: 'openssh', strictHostKeyChecking: 'maybe',
+    }))).toThrow(/strictHostKeyChecking must be one of: yes, no, accept-new/);
   });
 });
 

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -203,6 +203,43 @@ describe('parseServerConfigJson (Codex 3541767246: key auth requires key materia
   });
 });
 
+describe('parseServerConfigJson (Codex 3549295040: password auth requires a non-empty password)', () => {
+  it('rejects a password config with a missing password', () => {
+    // Without password material the server still registers as password-authed
+    // but fails on first use: OpenSshTransport.init() throws, and the ssh2 path
+    // connects without the promised credential. Fail at parse time instead.
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password',
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('rejects a password config with an empty-string password', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: '',
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('rejects a password config with a non-string password', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 123,
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('rejects a missing password for an explicit openssh password config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', transport: 'openssh',
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('still accepts a password config with a non-empty password', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw',
+    }));
+    expect(cfg.authMode).toBe('password');
+    expect(cfg.password).toBe('pw');
+  });
+});
+
 describe('validateConfig multi-host (finding 2: legacy flags must be rejected)', () => {
   it('rejects --port mixed with --ssh', () => {
     expect(() => validateConfig({ port: '2222' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -89,6 +89,34 @@ describe('parseServerConfigJson (round-2: input validation hardening)', () => {
     }))).toThrow(/non-empty string "name"/);
   });
 
+  it('requires host and user aliases to be non-empty strings', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw' };
+    for (const host of [123, {}, '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, host })))
+        .toThrow(/required "host".*non-empty string/);
+    }
+    for (const user of [123, {}, '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, user })))
+        .toThrow(/required "user".*non-empty string/);
+    }
+    for (const username of [123, {}, '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, user: undefined, username })))
+        .toThrow(/required "user".*non-empty string/);
+    }
+  });
+
+  it('requires keyPath and privateKey to be non-empty strings when provided', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'key' };
+    for (const keyPath of [123, {}, [], '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, keyPath })))
+        .toThrow(/"keyPath".*non-empty string/);
+    }
+    for (const privateKey of [123, {}, [], '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, privateKey })))
+        .toThrow(/"privateKey".*non-empty string/);
+    }
+  });
+
   it('rejects a non-integer / out-of-range port', () => {
     expect(() => parseServerConfigJson(JSON.stringify({
       name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 'abc',

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -162,6 +162,47 @@ describe('parseServerConfigJson (round-2: input validation hardening)', () => {
   });
 });
 
+describe('parseServerConfigJson (Codex 3541767246: key auth requires key material)', () => {
+  it('rejects an ssh2 key config with no keyPath and no privateKey', () => {
+    // Without key material the ssh2 transport has no key and openssh omits -i,
+    // so the connection silently falls back to an ambient agent/default
+    // identity. Fail at parse time instead.
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key',
+    }))).toThrow(/auth "key" requires "keyPath" or inline "privateKey"/);
+  });
+
+  it('rejects an openssh key config with no keyPath (inline privateKey is unsupported there)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', transport: 'openssh',
+    }))).toThrow(/auth "key" requires "keyPath"/);
+  });
+
+  it('rejects a legacy-shaped top-level "key" field (read by neither transport)', () => {
+    // The multi-host schema uses keyPath/privateKey; a legacy `key` field is
+    // ignored, leaving the config with no usable key material.
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', key: '/home/u/.ssh/id_ed25519',
+    }))).toThrow(/uses "keyPath" \(or "privateKey" for ssh2\), not "key"/);
+  });
+
+  it('accepts an ssh2 key config with keyPath', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', keyPath: '/home/u/.ssh/id_ed25519',
+    }));
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.keyPath).toBe('/home/u/.ssh/id_ed25519');
+  });
+
+  it('accepts an openssh key config with keyPath', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', transport: 'openssh', keyPath: '/home/u/.ssh/id_ed25519',
+    }));
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.keyPath).toBe('/home/u/.ssh/id_ed25519');
+  });
+});
+
 describe('validateConfig multi-host (finding 2: legacy flags must be rejected)', () => {
   it('rejects --port mixed with --ssh', () => {
     expect(() => validateConfig({ port: '2222' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -117,6 +117,24 @@ describe('parseServerConfigJson (round-2: input validation hardening)', () => {
     }
   });
 
+  it('requires elevation passwords to be strings when provided', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw' };
+    for (const field of ['sudoPassword', 'suPassword'] as const) {
+      for (const value of [123, true, {}, []]) {
+        expect(() => parseServerConfigJson(JSON.stringify({ ...base, [field]: value })))
+          .toThrow(new RegExp(`"${field}".*string`));
+      }
+    }
+  });
+
+  it('requires knownHostsFile to be a non-empty string when provided', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'kerberos' };
+    for (const knownHostsFile of [123, true, {}, [], '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, knownHostsFile })))
+        .toThrow(/"knownHostsFile".*non-empty string/);
+    }
+  });
+
   it('rejects a non-integer / out-of-range port', () => {
     expect(() => parseServerConfigJson(JSON.stringify({
       name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 'abc',

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -178,6 +178,25 @@ describe('runSuViaPty auth-failure scoping (finding 5: limit failRe to login pha
     expect(res.stdout).toContain('authentication failure');
   });
 
+  it('preserves merged PTY diagnostics as stderr on non-zero command exit', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('ls /missing', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+    emit(fc, 'ls /missing\n');
+    emit(fc, "ls: cannot access '/missing': No such file or directory\n");
+    emit(fc, `${endMark}2\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(2);
+    expect(res.category).toBe('remote_exit');
+    expect(res.stderr).toContain("ls: cannot access '/missing'");
+  });
+
   it('still detects an auth failure during the su login phase', async () => {
     const fc = new FakeChild();
     spawnMock.mockReturnValue(fc);

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -106,4 +106,92 @@ describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling
     const res = await p;
     expect(res.category).toBe('timeout');
   });
+
+  it('escalates to SIGKILL when the process ignores SIGTERM past the grace window (P2: track real exit, not child.killed)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    (t as any).runSuViaPty('sleep 999', 'pw', { timeoutMs: 5000 });
+
+    // Hit the overall deadline → SIGTERM sent.
+    vi.advanceTimersByTime(5000);
+    expect(fc.kill).toHaveBeenCalledWith('SIGTERM');
+    // The process does NOT exit (no close event). The old code gated the
+    // fallback on `child.killed`, which FakeChild.kill sets true, so SIGKILL
+    // was wrongly skipped. The fix gates on a real `exited` flag.
+    vi.advanceTimersByTime(2000);
+    expect(fc.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+});
+
+describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su results)', () => {
+  it('removes the echoed user command and sentinel-emit lines from captured stdout', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('id -un', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // `ssh -tt` echoes every stdin line back onto stdout: the user command,
+    // then the real output, then the echoed `echo <endMark>$?` line, then the
+    // sentinel itself.
+    emit(fc, 'id -un\n');
+    emit(fc, 'root\n');
+    emit(fc, `echo ${endMark}$?\n`);
+    emit(fc, `${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    // Only the real command output should remain — no echoed input.
+    expect(res.stdout.trim()).toBe('root');
+    expect(res.stdout).not.toContain('id -un');
+    expect(res.stdout).not.toContain(`echo ${endMark}`);
+  });
+});
+
+describe('runSuViaPty auth-failure scoping (finding 5: limit failRe to login phase)', () => {
+  it('does NOT treat command output containing "authentication failure" as an auth error during EXEC', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('grep failure /var/log/auth.log', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // Legitimate root command output that literally contains the failure
+    // phrases. The old unconditional failRe match killed SSH here and reported
+    // an auth error; the fix scopes failRe to the pre-EXEC login states.
+    emit(fc, 'grep failure /var/log/auth.log\n');
+    emit(fc, 'pam_unix(su:auth): authentication failure; logname=...\n');
+    emit(fc, 'sshd: incorrect password attempt for baduser\n');
+    emit(fc, `${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    expect(res.category).toBeUndefined();
+    expect(res.stdout).toContain('authentication failure');
+  });
+
+  it('still detects an auth failure during the su login phase', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'wrong' });
+
+    const p = (t as any).runSuViaPty('whoami', 'wrong', { timeoutMs: 60000 }) as Promise<any>;
+
+    // SU_PROMPT: send password, then the remote rejects it before any EXEC.
+    emit(fc, 'Password: ');
+    emit(fc, '\nsu: Authentication failure\n');
+    expect(fc.kill).toHaveBeenCalledWith('SIGTERM');
+
+    fc.emit('close', 1, null);
+    const res = await p;
+    expect(res.category).toBe('auth');
+  });
 });

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -84,6 +84,42 @@ describe('runSuViaPty large output (finding 3: no ~4KB truncation)', () => {
   });
 });
 
+describe('OpenSSH command sentinels', () => {
+  it('puts the su closing subshell and sentinel after a command comment', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+    const p = (t as any).runSuViaPty('echo ok # described command', 'pw', { timeoutMs: 60000 });
+
+    const { endMark } = driveToExec(fc);
+    const execInput = fc.writes.at(-1)!;
+    expect(execInput).toContain('echo ok # described command\n)\necho ' + endMark);
+    emit(fc, execInput.replace(/\n$/, '') + '\n' + 'ok\n' + endMark + '0\n');
+    fc.emit('close', 0, null);
+
+    await expect(p).resolves.toMatchObject({ exitCode: 0, stdout: 'ok\n' });
+  });
+
+  it('uses the remote sentinel to classify a command exit 255 as remote_exit', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u' });
+    const p = (t as any).runSsh("echo Permission denied >&2; exit 255", { timeoutMs: 60000 });
+
+    const command = spawnMock.mock.calls[0][1].at(-1) as string;
+    const endMark = command.match(/(__SSH_MCP_END_[0-9a-f]+__)/)![1];
+    fc.stderr.emit('data', Buffer.from('Permission denied\n'));
+    emit(fc, `\n${endMark}255\n`);
+    fc.emit('close', 0, null);
+
+    await expect(p).resolves.toMatchObject({
+      exitCode: 255,
+      category: 'remote_exit',
+      stderr: 'Permission denied\n',
+    });
+  });
+});
+
 describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling)', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
@@ -135,10 +171,9 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
 
     const { endMark } = driveToExec(fc);
 
-    // The command and sentinel-emit are combined into ONE input line; with
-    // `ssh -tt` the remote PTY echoes exactly that line back onto stdout.
-    const execInput = `( id -un ); echo ${endMark}$?`;
-    emit(fc, execInput + '\r\n');
+    // `ssh -tt` echoes the multiline input written to the root shell.
+    const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('id -un'))!;
+    emit(fc, execInput.replace(/\n$/, '') + '\r\n');
     emit(fc, 'root\n');
     emit(fc, `${endMark}0\n`);
     fc.emit('close', 0, null);
@@ -165,7 +200,7 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
     // terminates the subshell; the control shell survives to emit the sentinel.
     const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('echo'));
     expect(execInput).toBeDefined();
-    expect(execInput!.trim()).toBe(`( echo ok; exit 0 ); echo ${endMark}$?`);
+    expect(execInput!.trim()).toBe(`(\necho ok; exit 0\n)\necho ${endMark}$?`);
 
     emit(fc, execInput!.replace(/\n$/, '') + '\r\n');
     emit(fc, 'ok\n');
@@ -189,12 +224,10 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
 
     const { endMark } = driveToExec(fc);
 
-    // `printf foo` emits no trailing newline, so the echoed sentinel would glue
-    // directly after the real output. With the combined single input line and
-    // the digit-anchored end regex, only the real sentinel output is consumed
-    // and the caller sees exactly `foo` — not `foo__SSH_MCP_END_...$?`.
-    const execInput = `( printf foo ); echo ${endMark}$?`;
-    emit(fc, execInput + '\r\n');
+    // The multiline command wrapper is echoed first. The real `printf foo`
+    // output remains unterminated and therefore glues directly to the marker.
+    const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('printf foo'))!;
+    emit(fc, execInput.replace(/\n$/, '') + '\r\n');
     emit(fc, `foo${endMark}0\r\n`);
     fc.emit('close', 0, null);
 

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -126,7 +126,7 @@ describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling
 });
 
 describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su results)', () => {
-  it('removes the echoed user command and sentinel-emit lines from captured stdout', async () => {
+  it('removes the echoed combined command+sentinel input line from captured stdout', async () => {
     const fc = new FakeChild();
     spawnMock.mockReturnValue(fc);
     const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
@@ -135,12 +135,11 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
 
     const { endMark } = driveToExec(fc);
 
-    // `ssh -tt` echoes every stdin line back onto stdout: the user command,
-    // then the real output, then the echoed `echo <endMark>$?` line, then the
-    // sentinel itself.
-    emit(fc, 'id -un\n');
+    // The command and sentinel-emit are combined into ONE input line; with
+    // `ssh -tt` the remote PTY echoes exactly that line back onto stdout.
+    const execInput = `( id -un ); echo ${endMark}$?`;
+    emit(fc, execInput + '\r\n');
     emit(fc, 'root\n');
-    emit(fc, `echo ${endMark}$?\n`);
     emit(fc, `${endMark}0\n`);
     fc.emit('close', 0, null);
 
@@ -150,6 +149,60 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
     expect(res.stdout.trim()).toBe('root');
     expect(res.stdout).not.toContain('id -un');
     expect(res.stdout).not.toContain(`echo ${endMark}`);
+  });
+
+  it('wraps the user command in a subshell so its own exit does not kill the sentinel (P2)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('echo ok; exit 0', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // The EXEC input written to the root shell must run the command in a
+    // subshell `( ... )` so a command that exits/exec-replaces its shell only
+    // terminates the subshell; the control shell survives to emit the sentinel.
+    const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('echo'));
+    expect(execInput).toBeDefined();
+    expect(execInput!.trim()).toBe(`( echo ok; exit 0 ); echo ${endMark}$?`);
+
+    emit(fc, execInput!.replace(/\n$/, '') + '\r\n');
+    emit(fc, 'ok\n');
+    emit(fc, `${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    // Because the sentinel still runs, the real exit status is reported and the
+    // output is preserved instead of being dropped as a transport failure.
+    expect(res.exitCode).toBe(0);
+    expect(res.category).toBeUndefined();
+    expect(res.stdout.trim()).toBe('ok');
+  });
+
+  it('strips the echoed sentinel even when command output is unterminated (P2: printf foo)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('printf foo', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // `printf foo` emits no trailing newline, so the echoed sentinel would glue
+    // directly after the real output. With the combined single input line and
+    // the digit-anchored end regex, only the real sentinel output is consumed
+    // and the caller sees exactly `foo` — not `foo__SSH_MCP_END_...$?`.
+    const execInput = `( printf foo ); echo ${endMark}$?`;
+    emit(fc, execInput + '\r\n');
+    emit(fc, `foo${endMark}0\r\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe('foo');
+    expect(res.stdout).not.toContain(endMark);
+    expect(res.stdout).not.toContain('echo ');
   });
 });
 

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { spawn } from 'node:child_process';
+import { OpenSshTransport } from '../src/transports/openssh';
+
+// These tests drive the private runSuViaPty PTY state machine with a mocked
+// `spawn`, so they need no live sshd. They cover:
+//   - finding 3: large EXEC output must not be truncated to the ~4KB scan window
+//   - finding 4: the overall hard deadline must equal opts.timeoutMs (no +30000)
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+const spawnMock = spawn as unknown as Mock;
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  writes: string[] = [];
+  killed = false;
+  stdin = {
+    write: (s: string) => {
+      this.writes.push(s);
+      return true;
+    },
+  };
+  kill = vi.fn((_sig?: string) => {
+    this.killed = true;
+    return true;
+  });
+}
+
+function emit(fc: FakeChild, s: string) {
+  fc.stdout.emit('data', Buffer.from(s, 'utf8'));
+}
+
+/** Parse the random nonce out of the `export PS1='__SSH_MCP_READY_<nonce>...'` line. */
+function nonceFromWrites(fc: FakeChild): string {
+  const line = fc.writes.find((w) => w.includes('export PS1='));
+  if (!line) throw new Error('PS1 export not written: ' + JSON.stringify(fc.writes));
+  const m = line.match(/__SSH_MCP_READY_([0-9a-f]+)__/);
+  if (!m) throw new Error('no nonce in PS1 line: ' + line);
+  return m[1];
+}
+
+/** Drive the state machine SU_PROMPT -> PASSWORD_SENT -> ROOT_SHELL -> EXEC. */
+function driveToExec(fc: FakeChild): { readyMark: string; endMark: string } {
+  emit(fc, 'Password: ');           // SU_PROMPT -> PASSWORD_SENT
+  emit(fc, '\nLast login: today\n'); // PASSWORD_SENT -> ROOT_SHELL (writes PS1 export)
+  const nonce = nonceFromWrites(fc);
+  const readyMark = `__SSH_MCP_READY_${nonce}__`;
+  const endMark = `__SSH_MCP_END_${nonce}__`;
+  emit(fc, readyMark + '$ ');       // ROOT_SHELL -> EXEC (writes command + echo endMark)
+  return { readyMark, endMark };
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+});
+
+describe('runSuViaPty large output (finding 3: no ~4KB truncation)', () => {
+  it('preserves the full head of command output exceeding the scan window', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('big', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    const big = 'A'.repeat(20000); // >> the 8KB/4KB scan-buffer cap
+    emit(fc, big);
+    emit(fc, `\n${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    // Old code derived stdout from the truncated ~4KB scan buffer and would lose
+    // the head. The fix keeps an unbounded EXEC capture, so all 20000 bytes survive.
+    expect(res.stdout.length).toBeGreaterThanOrEqual(20000);
+    expect(res.stdout.startsWith(big)).toBe(true);
+  });
+});
+
+describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('kills the process at exactly opts.timeoutMs (not timeoutMs + 30000)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('sleep 999', 'pw', { timeoutMs: 5000 }) as Promise<any>;
+
+    // Advance to exactly the contract deadline. Under the old +30000 budget the
+    // overall timer would not have fired yet (and the 10s state timer is also
+    // still pending), so the process would NOT be killed at 5000ms.
+    vi.advanceTimersByTime(5000);
+    expect(fc.kill).toHaveBeenCalledWith('SIGTERM');
+
+    // Process exits in response to the signal; resolve as a timeout.
+    fc.emit('close', null, 'SIGTERM');
+    const res = await p;
+    expect(res.category).toBe('timeout');
+  });
+});

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -306,6 +306,20 @@ describe('OpenSshTransport.isConnected (Codex 3541767250: initialized != connect
     expect(t.isConnected()).toBe(false);
   });
 
+  it('stays NOT connected after authentication is rejected', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'password', password: 'wrong' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'Permission denied', exitCode: 255, category: 'auth' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('stays NOT connected after host-key verification is rejected', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'key', keyPath: '/tmp/id_test' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'Host key verification failed.', exitCode: 255, category: 'host_key' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
   it('reports connected once a later command succeeds after an initial connect failure', async () => {
     const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
     runSsh

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { classifyError, OpenSshTransport } from '../src/transports/openssh';
+
+describe('classifyError', () => {
+  it('returns undefined for success (exit 0)', () => {
+    expect(classifyError(0, '')).toBeUndefined();
+  });
+
+  it('returns transport for null exit code', () => {
+    expect(classifyError(null, '')).toBe('transport');
+  });
+
+  it('returns remote_exit for non-255 non-zero codes', () => {
+    expect(classifyError(1, 'something')).toBe('remote_exit');
+    expect(classifyError(127, 'command not found')).toBe('remote_exit');
+    expect(classifyError(254, '')).toBe('remote_exit');
+  });
+
+  describe('SSH layer (exit 255) classification', () => {
+    it('classifies auth failures', () => {
+      expect(classifyError(255, 'Permission denied (publickey).')).toBe('auth');
+      expect(classifyError(255, 'Authentication failed.')).toBe('auth');
+      expect(classifyError(255, 'No credentials cache found')).toBe('auth');
+      expect(classifyError(255, 'Ticket expired')).toBe('auth');
+      expect(classifyError(255, 'GSSAPI Error: Unspecified GSS failure')).toBe('auth');
+      expect(classifyError(255, 'Clock skew too great')).toBe('auth');
+      expect(classifyError(255, 'Server not found in Kerberos database')).toBe('auth');
+    });
+
+    it('classifies host-key failures', () => {
+      expect(classifyError(255, 'Host key verification failed.')).toBe('host_key');
+      expect(classifyError(255, 'WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!')).toBe('host_key');
+    });
+
+    it('classifies connectivity failures', () => {
+      expect(classifyError(255, 'ssh: connect to host foo port 22: Connection refused')).toBe('connect');
+      expect(classifyError(255, 'ssh: connect to host foo port 22: Connection timed out')).toBe('connect');
+      expect(classifyError(255, 'ssh: connect to host foo port 22: Connection reset')).toBe('connect');
+      expect(classifyError(255, 'ssh: Could not resolve hostname foo')).toBe('connect');
+      expect(classifyError(255, 'Name or service not known')).toBe('connect');
+      expect(classifyError(255, 'No route to host')).toBe('connect');
+      expect(classifyError(255, 'Network unreachable')).toBe('connect');
+    });
+
+    it('falls back to transport for unknown 255 stderr', () => {
+      expect(classifyError(255, 'some unknown ssh error')).toBe('transport');
+      expect(classifyError(255, '')).toBe('transport');
+    });
+  });
+});
+
+describe('OpenSshTransport.buildArgs', () => {
+  const baseCfg = {
+    host: 'ubuntu-dev.example.internal',
+    port: 22,
+    username: 'aduser@EXAMPLE.INTERNAL',
+  };
+
+  it('emits Kerberos-specific flags when authMode=kerberos', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('GSSAPIAuthentication=yes');
+    expect(args).toContain('GSSAPIDelegateCredentials=no');
+    expect(args).toContain('PreferredAuthentications=gssapi-with-mic');
+    expect(args).toContain('PubkeyAuthentication=no');
+    expect(args).toContain('PasswordAuthentication=no');
+    expect(args.at(-1)).toBe('aduser@EXAMPLE.INTERNAL@ubuntu-dev.example.internal');
+  });
+
+  it('honors --gssapiDelegateCredentials', () => {
+    const t = new OpenSshTransport({
+      ...baseCfg,
+      authMode: 'kerberos',
+      gssapiDelegateCredentials: 'yes',
+    });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('GSSAPIDelegateCredentials=yes');
+  });
+
+  it('emits key-specific flags when authMode=key', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'key', keyPath: '/home/user/.ssh/id_ed25519' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('-i');
+    expect(args).toContain('/home/user/.ssh/id_ed25519');
+    expect(args).toContain('PreferredAuthentications=publickey');
+    expect(args).toContain('PasswordAuthentication=no');
+    expect(args).toContain('GSSAPIAuthentication=no');
+  });
+
+  it('emits password-specific flags when authMode=password', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'password', password: 'hunter2' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('PreferredAuthentications=password,keyboard-interactive');
+    expect(args).toContain('PubkeyAuthentication=no');
+    expect(args).toContain('GSSAPIAuthentication=no');
+  });
+
+  it('respects custom strictHostKeyChecking and knownHostsFile', () => {
+    const t = new OpenSshTransport({
+      ...baseCfg,
+      authMode: 'kerberos',
+      strictHostKeyChecking: 'yes',
+      knownHostsFile: '/etc/ssh/managed_known_hosts',
+    });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('StrictHostKeyChecking=yes');
+    expect(args).toContain('UserKnownHostsFile=/etc/ssh/managed_known_hosts');
+  });
+
+  it('defaults StrictHostKeyChecking to accept-new', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('StrictHostKeyChecking=accept-new');
+  });
+
+  it('scales ConnectTimeout with opts.timeoutMs', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    expect(t.buildArgs({ timeoutMs: 5000 })).toContain('ConnectTimeout=5');
+    expect(t.buildArgs({ timeoutMs: 120000 })).toContain('ConnectTimeout=120');
+  });
+
+  it('appends -tt when opts.pty is true', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000, pty: true });
+    expect(args).toContain('-tt');
+  });
+
+  it('includes port via -p', () => {
+    const t = new OpenSshTransport({ ...baseCfg, port: 2222, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    const pIdx = args.indexOf('-p');
+    expect(pIdx).toBeGreaterThanOrEqual(0);
+    expect(args[pIdx + 1]).toBe('2222');
+  });
+
+  it('includes ServerAlive keepalive options', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('ServerAliveInterval=30');
+    expect(args).toContain('ServerAliveCountMax=3');
+  });
+});

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -42,9 +42,13 @@ describe('classifyError', () => {
       expect(classifyError(255, 'Network unreachable')).toBe('connect');
     });
 
-    it('falls back to transport for unknown 255 stderr', () => {
-      expect(classifyError(255, 'some unknown ssh error')).toBe('transport');
-      expect(classifyError(255, '')).toBe('transport');
+    it('falls back to remote_exit for unknown 255 stderr (ssh(1): 255 is also a valid remote command exit)', () => {
+      // When no SSH-layer signature matches, a 255 exit is surfaced as the
+      // remote command's own non-zero exit (Error (code 255)) rather than a
+      // generic SSH transport error, so legitimate remote `exit 255` is not
+      // masked. See classifyError + resultToMcpContent.
+      expect(classifyError(255, 'some unknown ssh error')).toBe('remote_exit');
+      expect(classifyError(255, '')).toBe('remote_exit');
     });
   });
 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -251,3 +251,69 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     expect(runOpts.stdin).toBe('callpw\n');
   });
 });
+
+describe('OpenSshTransport.isConnected (Codex 3541767250: initialized != connected)', () => {
+  function makeTransport(cfg: any) {
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', ...cfg });
+    const runSsh = vi.fn();
+    const runSuViaPty = vi.fn();
+    (t as any).runSsh = runSsh;
+    (t as any).runSuViaPty = runSuViaPty;
+    return { t, runSsh, runSuViaPty };
+  }
+
+  it('reports NOT connected before any command runs (init-only, no live session)', () => {
+    // OpenSSH init() only verifies the local ssh binary/askpass setup; no SSH
+    // session is established until the first exec. A merely-initialized
+    // transport must not claim a live connection.
+    const { t } = makeTransport({ authMode: 'kerberos' });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('reports connected after a command completes a live session (exit 0)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(true);
+  });
+
+  it('reports connected after a non-zero REMOTE exit (host answered, command failed)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'nope', exitCode: 1, category: 'remote_exit' });
+    await t.exec('false', { timeoutMs: 60000 });
+    // A remote command's own non-zero exit still proves the host is live.
+    expect(t.isConnected()).toBe(true);
+  });
+
+  it('stays NOT connected after a connect-layer failure (e.g. connection refused)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'Connection refused', exitCode: 255, category: 'connect' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('stays NOT connected after a transport-layer failure (ssh spawn error)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'spawn error', exitCode: null, category: 'transport' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('stays NOT connected after a bare timeout (no proof the host answered)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: '', exitCode: null, category: 'timeout' });
+    await t.exec('sleep 100', { timeoutMs: 10 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('reports connected once a later command succeeds after an initial connect failure', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh
+      .mockResolvedValueOnce({ stdout: '', stderr: 'Connection refused', exitCode: 255, category: 'connect' })
+      .mockResolvedValueOnce({ stdout: 'ok', stderr: '', exitCode: 0 });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(true);
+  });
+});

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
-import { buildOpenSshSudoWrapper, classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
+import {
+  buildOpenSshSudoWrapper,
+  classifyError,
+  OpenSshTransport,
+  renderAskpassHelper,
+  renderAskpassSshConfig,
+} from '../src/transports/openssh';
 
 describe('classifyError', () => {
   it('returns undefined for success (exit 0)', () => {
@@ -113,6 +119,16 @@ describe('OpenSshTransport.buildArgs', () => {
     expect(args).toContain('PreferredAuthentications=password,keyboard-interactive');
     expect(args).toContain('PubkeyAuthentication=no');
     expect(args).toContain('GSSAPIAuthentication=no');
+  });
+
+  it('uses a post-user-config SendEnv guard for initialized askpass auth', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'password', password: 'hunter2' });
+    (t as any).askpassConfigPath = '/tmp/ssh-mcp/ssh_config';
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    const fIdx = args.indexOf('-F');
+    expect(fIdx).toBeGreaterThanOrEqual(0);
+    expect(args[fIdx + 1]).toBe('/tmp/ssh-mcp/ssh_config');
+    expect(renderAskpassSshConfig()).toBe('Include ~/.ssh/config\nSendEnv -*\n');
   });
 
   it('respects custom strictHostKeyChecking and knownHostsFile', () => {

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -87,6 +87,22 @@ describe('OpenSshTransport.buildArgs', () => {
     expect(args).toContain('GSSAPIAuthentication=no');
   });
 
+  it('forces IdentitiesOnly=yes when an explicit key is supplied (no agent-key spray)', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'key', keyPath: '/home/user/.ssh/id_ed25519' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('IdentitiesOnly=yes');
+    // The -i path and IdentitiesOnly=yes must both be present so ssh uses only
+    // the chosen key instead of offering every ssh-agent identity first.
+    const iIdx = args.indexOf('-i');
+    expect(iIdx).toBeGreaterThanOrEqual(0);
+    expect(args[iIdx + 1]).toBe('/home/user/.ssh/id_ed25519');
+  });
+
+  it('does not emit IdentitiesOnly for non-key auth modes', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    expect(t.buildArgs({ timeoutMs: 60000 })).not.toContain('IdentitiesOnly=yes');
+  });
+
   it('emits password-specific flags when authMode=password', () => {
     const t = new OpenSshTransport({ ...baseCfg, authMode: 'password', password: 'hunter2' });
     const args = t.buildArgs({ timeoutMs: 60000 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
+import { buildOpenSshSudoWrapper, classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
 
 describe('classifyError', () => {
   it('returns undefined for success (exit 0)', () => {
@@ -182,6 +182,19 @@ describe('renderAskpassHelper (finding 5: Windows metachar-safe password echo)',
   });
 });
 
+describe('buildOpenSshSudoWrapper (Codex P1: keep sudo password out of local ssh argv)', () => {
+  it('builds a passwordless sudo command without sudo -S', () => {
+    expect(buildOpenSshSudoWrapper('id -u', false)).toBe("sudo -n sh -c 'id -u'");
+  });
+
+  it('builds a sudo -S command but never embeds the password value', () => {
+    const cmd = buildOpenSshSudoWrapper("printf '%s' ok", true);
+    expect(cmd).toContain('sudo -p "" -S');
+    expect(cmd).toContain("sh -c 'printf '\\''%s'\\'' ok'");
+    expect(cmd).not.toContain('sudopw');
+  });
+});
+
 describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when only suPassword set)', () => {
   function makeTransport(cfg: any) {
     const t = new OpenSshTransport({
@@ -202,11 +215,15 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     expect(runSsh).not.toHaveBeenCalled();
   });
 
-  it('uses the normal sudo wrapper when a sudo password is available', async () => {
+  it('uses a stdin-fed sudo wrapper when a sudo password is available (password never in argv)', async () => {
     const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw', sudoPassword: 'sudopw' });
     await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
     expect(runSsh).toHaveBeenCalledTimes(1);
     expect(runSuViaPty).not.toHaveBeenCalled();
+    const [wrapped, runOpts] = runSsh.mock.calls[0];
+    expect(wrapped).toContain('sudo -p "" -S');
+    expect(wrapped).not.toContain('sudopw');
+    expect(runOpts.stdin).toBe('sudopw\n');
   });
 
   it('uses the normal sudo wrapper (passwordless) when neither su nor sudo password is set', async () => {
@@ -214,6 +231,9 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
     expect(runSsh).toHaveBeenCalledTimes(1);
     expect(runSuViaPty).not.toHaveBeenCalled();
+    const [wrapped, runOpts] = runSsh.mock.calls[0];
+    expect(wrapped).toBe("sudo -n sh -c 'whoami'");
+    expect(runOpts.stdin).toBeUndefined();
   });
 
   it('prefers an explicit per-call sudo password over the su fallback', async () => {
@@ -221,5 +241,9 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo', password: 'callpw' });
     expect(runSsh).toHaveBeenCalledTimes(1);
     expect(runSuViaPty).not.toHaveBeenCalled();
+    const [wrapped, runOpts] = runSsh.mock.calls[0];
+    expect(wrapped).toContain('sudo -p "" -S');
+    expect(wrapped).not.toContain('callpw');
+    expect(runOpts.stdin).toBe('callpw\n');
   });
 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { classifyError, OpenSshTransport } from '../src/transports/openssh';
+import { describe, it, expect, vi } from 'vitest';
+import { classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
 
 describe('classifyError', () => {
   it('returns undefined for success (exit 0)', () => {
@@ -138,5 +138,72 @@ describe('OpenSshTransport.buildArgs', () => {
     const args = t.buildArgs({ timeoutMs: 60000 });
     expect(args).toContain('ServerAliveInterval=30');
     expect(args).toContain('ServerAliveCountMax=3');
+  });
+});
+
+describe('renderAskpassHelper (finding 5: Windows metachar-safe password echo)', () => {
+  it('does not use a bare `echo %VAR%` on Windows', () => {
+    const content = renderAskpassHelper('SSH_MCP_PW_1234', true);
+    // The bug was `echo %VAR%`, which CMD re-parses and breaks on & | < > ^ %.
+    expect(content).not.toMatch(/echo\s+%SSH_MCP_PW_1234%/);
+  });
+
+  it('reads the password via PowerShell $env:VAR (no command-line substitution)', () => {
+    const content = renderAskpassHelper('SSH_MCP_PW_1234', true);
+    expect(content).toContain('powershell');
+    expect(content).toContain('$env:SSH_MCP_PW_1234');
+    // Password value itself is never placed in the script text.
+    expect(content).not.toContain('hunter2');
+  });
+
+  it('emits a metacharacter-safe printf on POSIX', () => {
+    const content = renderAskpassHelper('SSH_MCP_PW_1234', false);
+    expect(content).toContain('#!/bin/sh');
+    expect(content).toContain('printf');
+    expect(content).toContain('"$SSH_MCP_PW_1234"');
+    // Must NOT interpolate the value unquoted (would break on metacharacters).
+    expect(content).not.toMatch(/echo\s+\$SSH_MCP_PW_1234/);
+  });
+});
+
+describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when only suPassword set)', () => {
+  function makeTransport(cfg: any) {
+    const t = new OpenSshTransport({
+      host: 'h', port: 22, username: 'u', ...cfg,
+    });
+    const runSuViaPty = vi.fn().mockResolvedValue({ stdout: 'root-out', stderr: '', exitCode: 0 });
+    const runSsh = vi.fn().mockResolvedValue({ stdout: 'sudo-out', stderr: '', exitCode: 0 });
+    (t as any).runSuViaPty = runSuViaPty;
+    (t as any).runSsh = runSsh;
+    return { t, runSuViaPty, runSsh };
+  }
+
+  it('routes sudo-exec through the su PTY when only suPassword is set (no sudo password)', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw' });
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
+    expect(runSuViaPty).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).toHaveBeenCalledWith('whoami', 'supw', expect.objectContaining({ mode: 'sudo' }));
+    expect(runSsh).not.toHaveBeenCalled();
+  });
+
+  it('uses the normal sudo wrapper when a sudo password is available', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw', sudoPassword: 'sudopw' });
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
+    expect(runSsh).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).not.toHaveBeenCalled();
+  });
+
+  it('uses the normal sudo wrapper (passwordless) when neither su nor sudo password is set', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({});
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
+    expect(runSsh).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).not.toHaveBeenCalled();
+  });
+
+  it('prefers an explicit per-call sudo password over the su fallback', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw' });
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo', password: 'callpw' });
+    expect(runSsh).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).not.toHaveBeenCalled();
   });
 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -320,6 +320,23 @@ describe('OpenSshTransport.isConnected (Codex 3541767250: initialized != connect
     expect(t.isConnected()).toBe(false);
   });
 
+  it.each([
+    ['auth', 'Permission denied'],
+    ['host_key', 'Host key verification failed.'],
+    ['connect', 'Connection refused'],
+    ['transport', 'spawn error'],
+    ['timeout', 'timed out'],
+  ] as const)('clears stale connected state after a later %s failure', async (category, stderr) => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh
+      .mockResolvedValueOnce({ stdout: 'ok', stderr: '', exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: '', stderr, exitCode: 255, category });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(true);
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
   it('reports connected once a later command succeeds after an initial connect failure', async () => {
     const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
     runSsh

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -126,6 +126,47 @@ describe('TransportRegistry.get (finding 1: rejected init must not be cached)', 
     expect(init).toHaveBeenCalledTimes(1);
   });
 
+  // finding: per-host key reads must be deferred to get(name), not run at
+  // register()/bootstrap time, so a missing key on one host cannot break
+  // startup or list-servers for the other healthy hosts.
+  it('runs prepareConfig lazily on first get(name), never at register()', async () => {
+    const prepare = vi.fn<[ServerConfig], Promise<void>>().mockResolvedValue(undefined);
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry(prepare);
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    // Not called at register / list time.
+    expect(prepare).not.toHaveBeenCalled();
+    r.list();
+    expect(prepare).not.toHaveBeenCalled();
+
+    // Called exactly once, only for the selected host, on first get.
+    await r.get('a');
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(prepare.mock.calls[0][0].name).toBe('a');
+  });
+
+  it('a prepareConfig failure for one host is not cached and does not affect other hosts', async () => {
+    const prepare = vi.fn<[ServerConfig], Promise<void>>()
+      .mockRejectedValueOnce(new Error('ENOENT: missing key'))
+      .mockResolvedValue(undefined);
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry(prepare);
+    r.register(makeConfig('broken'));
+    r.register(makeConfig('healthy'));
+
+    // First get('broken'): prepare rejects -> get rejects, nothing cached.
+    await expect(r.get('broken')).rejects.toThrow(/missing key/);
+    // The other host is unaffected.
+    await expect(r.get('healthy')).resolves.toBe(stub);
+    // A later get('broken') retries prepare (now resolves).
+    await expect(r.get('broken')).resolves.toBe(stub);
+  });
+
   it('serializes concurrent gets so init runs once for parallel callers', async () => {
     let resolveInit: () => void = () => {};
     const init = vi.fn<() => Promise<void>>().mockImplementation(
@@ -200,13 +241,31 @@ describe('TransportRegistry.list / closeAll', () => {
 
     let rows = r.list();
     expect(rows.map((x) => x.name)).toEqual(['a', 'b']);
-    expect(rows.find((x) => x.name === 'a')!.isDefault).toBe(true);
+    // finding 6: with >1 server and no explicit setDefault(), get() rejects an
+    // omitted connectionName, so NO host is advertised as a usable default.
+    expect(rows.every((x) => x.isDefault === false)).toBe(true);
     expect(rows.every((x) => x.connected === false)).toBe(true);
 
     await r.get('a');
     rows = r.list();
     expect(rows.find((x) => x.name === 'a')!.connected).toBe(true);
     expect(rows.find((x) => x.name === 'b')!.connected).toBe(false);
+  });
+
+  it('marks the lone server as the default (single-server case)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('solo'));
+    expect(r.list().find((x) => x.name === 'solo')!.isDefault).toBe(true);
+  });
+
+  it('marks only the explicitly-set default when multiple servers are configured', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setDefault('b');
+    const rows = r.list();
+    expect(rows.find((x) => x.name === 'a')!.isDefault).toBe(false);
+    expect(rows.find((x) => x.name === 'b')!.isDefault).toBe(true);
   });
 
   it('closeAll closes connected transports and clears state', async () => {

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -221,3 +221,41 @@ describe('TransportRegistry.list / closeAll', () => {
     expect(r.list().find((x) => x.name === 'a')!.connected).toBe(false);
   });
 });
+
+describe('TransportRegistry.resolveProfileName (audit attribution, non-throwing)', () => {
+  it('returns the single registered name when connectionName is omitted', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('only'));
+    expect(r.resolveProfileName()).toBe('only');
+  });
+
+  it('returns (unresolved) for an ambiguous multi-host call (omitted name, >1 server, no explicit default)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    // This is exactly the case registry.get() rejects as ambiguous — the audit
+    // record must NOT be attributed to the first server ('a').
+    expect(r.resolveProfileName()).toBe('(unresolved)');
+  });
+
+  it('returns the explicit default when setDefault() re-enabled the omit-name shortcut', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setDefault('b');
+    expect(r.resolveProfileName()).toBe('b');
+  });
+
+  it('echoes an explicitly-requested name even if unknown (accurate caller intent)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    expect(r.resolveProfileName('b')).toBe('b');
+    expect(r.resolveProfileName('nope')).toBe('nope');
+  });
+
+  it('falls back to "default" when no servers are registered', () => {
+    const r = new TransportRegistry();
+    expect(r.resolveProfileName()).toBe('default');
+  });
+});

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -279,4 +279,29 @@ describe('TransportRegistry.list / closeAll', () => {
     expect(close).toHaveBeenCalledTimes(1);
     expect(r.list().find((x) => x.name === 'a')!.connected).toBe(false);
   });
+
+  // Codex 3541767250: a cached transport that exposes an isConnected() probe
+  // (OpenSSH) must have list() defer to it, so a merely-initialized transport
+  // with no proven live session is reported as NOT connected.
+  it('defers to a cached transport isConnected() probe for connected status', async () => {
+    let live = false;
+    const stub = {
+      name: 'openssh',
+      init: vi.fn().mockResolvedValue(undefined),
+      exec: vi.fn(),
+      execElevated: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+      isConnected: () => live,
+    } as unknown as ISshTransport;
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('oss'));
+    // After init the transport is cached, but the probe says no live session yet.
+    await r.get('oss');
+    expect(r.list().find((x) => x.name === 'oss')!.connected).toBe(false);
+    // Once a command proves the host is live, the probe flips to true.
+    live = true;
+    expect(r.list().find((x) => x.name === 'oss')!.connected).toBe(true);
+  });
 });

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ISshTransport, ServerConfig } from '../src/transports/types';
+
+// The registry lazily builds transports via the factory's createTransport. Mock
+// it so we can drive init() success/failure deterministically without any real
+// SSH connection. vi.hoisted keeps the mock fn available inside the hoisted
+// vi.mock factory.
+const { createTransportMock } = vi.hoisted(() => ({ createTransportMock: vi.fn() }));
+vi.mock('../src/transports/factory.js', () => ({ createTransport: createTransportMock }));
+
+import { TransportRegistry } from '../src/transports/registry';
+
+function makeConfig(name: string): ServerConfig {
+  return { name, host: `${name}.example`, port: 22, username: 'u', transport: 'ssh2', authMode: 'password', password: 'pw' };
+}
+
+function makeStub(init: () => Promise<void>): ISshTransport {
+  return {
+    name: 'ssh2',
+    init,
+    exec: vi.fn(),
+    execElevated: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ISshTransport;
+}
+
+beforeEach(() => {
+  createTransportMock.mockReset();
+});
+
+describe('TransportRegistry.register / names / duplicate', () => {
+  it('registers configs and lists names in registration order', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    expect(r.names()).toEqual(['a', 'b']);
+    expect(r.hasAny()).toBe(true);
+    expect(r.getDefaultName()).toBe('a'); // first registered is the default
+  });
+
+  it('rejects a config with no name', () => {
+    const r = new TransportRegistry();
+    expect(() => r.register({ ...makeConfig('x'), name: '' })).toThrow(/name is required/);
+  });
+
+  it('rejects a duplicate server name', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    expect(() => r.register(makeConfig('a'))).toThrow(/Duplicate server name: a/);
+  });
+});
+
+describe('TransportRegistry.resolveName (finding 3: omitted name in multi-host)', () => {
+  it('throws when name omitted and >1 server configured with no explicit default', async () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    await expect(r.get()).rejects.toThrow(/connectionName is required when multiple servers are configured: a, b/);
+  });
+
+  it('still resolves by explicit name when multiple servers are configured', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    await expect(r.get('b')).resolves.toBe(stub);
+  });
+
+  it('allows omitted name after an explicit setDefault() even with multiple servers', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setDefault('b');
+    await expect(r.get()).resolves.toBe(stub);
+  });
+
+  it('resolves the lone server when only one is configured and name is omitted', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('solo'));
+    await expect(r.get()).resolves.toBe(stub);
+  });
+
+  it('throws a descriptive error for an unknown name', async () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    await expect(r.get('nope')).rejects.toThrow(/Unknown connection name: nope\. Registered: a/);
+  });
+});
+
+describe('TransportRegistry.get (finding 1: rejected init must not be cached)', () => {
+  it('retries init on a later get() after the first init rejects', async () => {
+    const init = vi
+      .fn<[], Promise<void>>()
+      .mockRejectedValueOnce(new Error('connect timeout'))
+      .mockResolvedValue(undefined);
+    const stub = makeStub(init);
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('flaky'));
+
+    // First get(): init rejects.
+    await expect(r.get('flaky')).rejects.toThrow(/connect timeout/);
+    // Second get(): the rejected promise must NOT be cached, so init runs again
+    // and now resolves.
+    await expect(r.get('flaky')).resolves.toBe(stub);
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches the live transport on success (init runs once across repeated gets)', async () => {
+    const init = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const stub = makeStub(init);
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('stable'));
+
+    const a = await r.get('stable');
+    const b = await r.get('stable');
+    expect(a).toBe(b);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent gets so init runs once for parallel callers', async () => {
+    let resolveInit: () => void = () => {};
+    const init = vi.fn<() => Promise<void>>().mockImplementation(
+      () => new Promise<void>((res) => { resolveInit = res; }),
+    );
+    const stub = makeStub(init);
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('p'));
+
+    const p1 = r.get('p');
+    const p2 = r.get('p');
+    resolveInit();
+    const [t1, t2] = await Promise.all([p1, p2]);
+    expect(t1).toBe(stub);
+    expect(t2).toBe(stub);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TransportRegistry.list / closeAll', () => {
+  it('reports connection status and default flag', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+
+    let rows = r.list();
+    expect(rows.map((x) => x.name)).toEqual(['a', 'b']);
+    expect(rows.find((x) => x.name === 'a')!.isDefault).toBe(true);
+    expect(rows.every((x) => x.connected === false)).toBe(true);
+
+    await r.get('a');
+    rows = r.list();
+    expect(rows.find((x) => x.name === 'a')!.connected).toBe(true);
+    expect(rows.find((x) => x.name === 'b')!.connected).toBe(false);
+  });
+
+  it('closeAll closes connected transports and clears state', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const stub = { name: 'ssh2', init: vi.fn().mockResolvedValue(undefined), exec: vi.fn(), execElevated: vi.fn(), close } as unknown as ISshTransport;
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    await r.get('a');
+    await r.closeAll();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(r.list().find((x) => x.name === 'a')!.connected).toBe(false);
+  });
+});

--- a/test/result-mapper.test.ts
+++ b/test/result-mapper.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { resultToMcpContent } from '../src/index';
+import type { ExecResult } from '../src/transports/types';
+
+// Regression: previously any non-empty stderr threw "Error (code 0):" even when
+// the command exited 0. sudo-exec via ssh2 transport reliably tripped this
+// because sudo `-p "" -S` writes a trailing newline to stderr after consuming
+// the password, and many tools (curl/git/apt/dotnet) emit progress on stderr.
+
+describe('resultToMcpContent', () => {
+  const baseOk: ExecResult = { stdout: '', stderr: '', exitCode: 0 };
+
+  it('returns stdout on plain success', () => {
+    const r = resultToMcpContent({ ...baseOk, stdout: 'hello\n' });
+    expect(r.content[0]).toEqual({ type: 'text', text: 'hello\n' });
+  });
+
+  it('does NOT throw on exit 0 with stderr (regression for sudo-exec "Error (code 0):")', () => {
+    const r = resultToMcpContent({
+      stdout: 'uid=0(root)\n',
+      stderr: '\n', // sudo -S trailing newline
+      exitCode: 0,
+    });
+    expect((r.content[0] as any).type).toBe('text');
+    // Whitespace-only stderr is dropped; stdout is returned as-is.
+    expect((r.content[0] as any).text).toBe('uid=0(root)\n');
+  });
+
+  it('appends substantive stderr to stdout on exit 0', () => {
+    const r = resultToMcpContent({
+      stdout: 'apt output\n',
+      stderr: 'WARNING: apt does not have a stable CLI interface.\n',
+      exitCode: 0,
+    });
+    const text = (r.content[0] as any).text as string;
+    expect(text).toContain('apt output');
+    expect(text).toContain('[stderr]');
+    expect(text).toContain('stable CLI interface');
+  });
+
+  it('returns stderr-only output when stdout is empty and exit 0', () => {
+    const r = resultToMcpContent({
+      stdout: '',
+      stderr: 'progress info on stderr\n',
+      exitCode: 0,
+    });
+    expect((r.content[0] as any).text).toBe('progress info on stderr\n');
+  });
+
+  it('throws on non-zero exit with stderr', () => {
+    expect(() => resultToMcpContent({
+      stdout: '',
+      stderr: 'permission denied\n',
+      exitCode: 1,
+    })).toThrow(McpError);
+  });
+
+  it('treats null exitCode as 0 (legacy ssh2 close without code)', () => {
+    const r = resultToMcpContent({
+      stdout: 'data',
+      stderr: '\r\n',
+      exitCode: null,
+    });
+    expect((r.content[0] as any).text).toBe('data');
+  });
+
+  it('routes timeout category to typed error', () => {
+    expect(() => resultToMcpContent({
+      stdout: '',
+      stderr: 'Command execution timed out after 60000ms',
+      exitCode: null,
+      category: 'timeout',
+    })).toThrow(McpError);
+  });
+
+  it('routes auth category to typed error', () => {
+    expect(() => resultToMcpContent({
+      stdout: '',
+      stderr: 'permission denied (publickey)',
+      exitCode: 255,
+      category: 'auth',
+    })).toThrow(/SSH authentication error/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
Persist SSH command execution audit records to JSONL with rotation and redaction, including the follow-up fix for attached MySQL -pVALUE password masking.

## Compatibility / safety
Audit logging is append-only and redacts sensitive CLI secrets before persistence. Existing command execution flow is unchanged aside from logging side-effects.

## Test plan
- npm run test -- --runInBand src/audit/__tests__/redactor.test.ts
- npm run build

## Stack note
This PR is part of a staged stack from fork branches. GitHub displays cumulative diffs because fork branches cannot be used as upstream PR bases; merge/read in the order below.

1. `pr/connection-name-guard`
2. `pr/toml-config`
3. `pr/audit-log`
4. `pr/connection-name-toml-optout` — builds on pr/connection-name-guard, pr/toml-config
5. `pr/approval-engine` — builds on pr/toml-config
6. `pr/per-source-approval` — builds on pr/approval-engine
7. `pr/webui-readonly` — builds on pr/audit-log, pr/approval-engine
8. `pr/webui-manual-approval` — builds on pr/webui-readonly
9. `pr/webui-mode-switch` — builds on pr/webui-manual-approval
10. `pr/webui-description-edit` — builds on pr/per-source-approval, pr/webui-mode-switch
11. `pr/config-watch-reload` — builds on pr/webui-description-edit

## Dependency notes
None. This PR can be reviewed independently.
