### PR TITLE
feat: support per-profile approval settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dist
 build/
 manual-kerberos-test.mjs
 manual-multi-host-test.mjs
+
+# Per-lane test/build scratch (mandated TMPDIR)
+.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dist
 
 # Ignore build output
 build/
+manual-kerberos-test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dist
 # Ignore build output
 build/
 manual-kerberos-test.mjs
+manual-multi-host-test.mjs

--- a/README.md
+++ b/README.md
@@ -232,10 +232,17 @@ Equivalent expanded form:
 ```bash
 npx -y ssh-mcp -- \
   --transport=openssh \
+  --kerberos \
   --host=ubuntu-dev.example.internal \
   --user=aduser@EXAMPLE.INTERNAL \
   --strictHostKeyChecking=accept-new
 ```
+
+> `--kerberos` is what selects Kerberos/GSSAPI auth (it sets
+> `-o GSSAPIAuthentication=yes` and implies `--transport=openssh`). Passing
+> only `--transport=openssh` selects the OpenSSH transport but leaves auth in
+> its default mode — it does **not** enable GSSAPI on its own, so keep
+> `--kerberos` here for the example to be equivalent to the compact form above.
 
 ### CLI flags added by this mode
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - MCP-compliant server exposing SSH capabilities
 - Execute shell commands on remote Linux and Windows systems
 - Secure authentication via password or SSH key
+- **Kerberos / GSSAPI single-sign-on** via the OpenSSH subprocess transport — opt-in; see [Kerberos / OpenSSH Transport](#kerberos--openssh-transport)
 - Built with TypeScript and the official MCP SDK
 - **Configurable timeout protection** with automatic process abortion
 - **Graceful timeout handling** - attempts to kill hanging processes before closing connections
@@ -94,6 +95,11 @@ You can configure your IDE or LLM like Cursor, Windsurf, Claude Desktop to use t
 - `timeout`: Command execution timeout in milliseconds (default: 60000ms = 1 minute)
 - `maxChars`: Maximum allowed characters for the `command` input (default: 1000). Use `none` or `0` to disable the limit.
 - `disableSudo`: Flag to disable the `sudo-exec` tool completely. Useful when sudo access is not needed or not available.
+- `transport`: Transport implementation. `ssh2` (default, unchanged) or `openssh` (spawns the system `ssh` binary — needed for Kerberos). See [Kerberos / OpenSSH Transport](#kerberos--openssh-transport).
+- `kerberos`: Flag shorthand for `--transport=openssh` with `GSSAPIAuthentication=yes`. Requires an active Kerberos ticket (TGT) on the client.
+- `gssapiDelegateCredentials`: `yes` or `no` (default `no`). Forwards the client TGT to the remote host for second-hop SSO. Use only against trusted hosts.
+- `knownHostsFile`: Path to a pinned `known_hosts` file (openssh transport only).
+- `strictHostKeyChecking`: `yes`, `no`, or `accept-new` (default `accept-new`; openssh transport only).
 
 
 ```commandline
@@ -178,6 +184,75 @@ After adding the server, restart Claude Code and ask Cascade to execute a comman
 ```
 
 For more information about MCP in Claude Code, see the [official documentation](https://docs.claude.com/en/docs/claude-code/mcp).
+
+## Kerberos / OpenSSH Transport
+
+> Experimental. Backwards-compatible: unchanged when `--transport` and `--kerberos` are both omitted.
+
+The default `ssh2`-based transport does not implement GSSAPI/Kerberos authentication (upstream issue [mscdex/ssh2#333](https://github.com/mscdex/ssh2/issues/333), open since 2015). When an **opt-in** OpenSSH subprocess transport is selected, the server delegates SSH to the operating system's `ssh` binary, which supports:
+
+- Kerberos SSO via GSSAPI (`-o GSSAPIAuthentication=yes`)
+- Public-key auth (`-i <key>`)
+- Password auth (via `SSH_ASKPASS`; not recommended — prefer Kerberos or keys)
+
+### When to use it
+
+- Windows client (domain-joined) → Linux target (AD-joined via SSSD/realmd, `sshd_config: GSSAPIAuthentication yes`): the user's logon TGT is consumed automatically by Win32-OpenSSH via SSPI. **No password. No key file.**
+- Any environment where a Kerberos KDC issues tickets and SSH is preferred over re-entering credentials.
+
+### Prerequisites
+
+1. The `ssh` binary must be on `PATH` (Windows: enabled by default since Windows 10 1803; Linux: `apt install openssh-client`).
+2. The **remote** `sshd_config` must have `GSSAPIAuthentication yes`.
+3. The user must have a valid TGT:
+   - **Windows (AD-joined):** automatic on login. Verify with `klist`.
+   - **Linux (MIT Kerberos):** run `kinit <user@REALM>` or use `k5start` with a keytab for service accounts.
+4. For an AD-integrated Linux target, SSSD/realmd must be joined to the domain.
+
+### Example — Claude Code / any MCP client
+
+```json
+{
+  "mcpServers": {
+    "ssh-mcp": {
+      "command": "npx",
+      "args": [
+        "-y", "ssh-mcp", "--",
+        "--host=ubuntu-dev.example.internal",
+        "--user=aduser@EXAMPLE.INTERNAL",
+        "--kerberos"
+      ]
+    }
+  }
+}
+```
+
+Equivalent expanded form:
+
+```bash
+npx -y ssh-mcp -- \
+  --transport=openssh \
+  --host=ubuntu-dev.example.internal \
+  --user=aduser@EXAMPLE.INTERNAL \
+  --strictHostKeyChecking=accept-new
+```
+
+### CLI flags added by this mode
+
+| Flag | Values | Default | Notes |
+|---|---|---|---|
+| `--transport` | `ssh2` / `openssh` | `ssh2` | Selects implementation |
+| `--kerberos` | flag | off | Implies `--transport=openssh` |
+| `--gssapiDelegateCredentials` | `yes` / `no` | `no` | Forward TGT (trusted hosts only) |
+| `--knownHostsFile` | path | `~/.ssh/known_hosts` | `openssh` only |
+| `--strictHostKeyChecking` | `yes` / `no` / `accept-new` | `accept-new` | `openssh` only |
+
+### Caveats and limitations
+
+- **No connection multiplexing on Windows.** Win32-OpenSSH does not support `ControlMaster` ([issue #1328](https://github.com/PowerShell/Win32-OpenSSH/issues/1328)). Each `exec` call spawns a fresh `ssh.exe` and performs a full Kerberos AP-REQ round trip. Expect ~100–300 ms extra latency per invocation on Windows. Linux/macOS may work around this with user-provided `ssh_config` `ControlMaster` settings — the transport does not configure multiplexing itself.
+- **Password mode via `SSH_ASKPASS`.** When `--password` is combined with `--transport=openssh`, the server writes a short-lived askpass helper to `%TEMP%/ssh-mcp-<pid>/` and exports the password through a per-process environment variable. The password never appears in `argv` but is briefly visible to same-user-session process inspection. Prefer Kerberos or key auth.
+- **`--suPassword` over OpenSSH transport** is implemented via `ssh -tt` with a local expect-style state machine (random-nonce sentinel prompts). Works, but has more moving parts than the ssh2 path. Report issues with stderr output if you hit a regression.
+- **Delegation (`GSSAPIDelegateCredentials=yes`)** is off by default. Enabling it forwards your TGT to the remote host, which can then impersonate you elsewhere — use only against fully trusted infrastructure. See Microsoft's guidance on Kerberos delegation.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "1.2.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.2.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "ssh-mcp",
-  "version": "1.5.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.5.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.17.5",
         "ssh2": "^1.17.0",
         "zod": "3.23.8"
@@ -544,6 +545,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-mcp",
   "license": "MIT",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server exposing SSH control for Linux and Windows systems via Model Context Protocol.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build"
   ],
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@modelcontextprotocol/sdk": "^1.17.5",
     "ssh2": "^1.17.0",
     "zod": "3.23.8"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssh-mcp",
   "license": "MIT",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "MCP server exposing SSH control for Linux and Windows systems via Model Context Protocol.",
   "type": "module",
   "bin": {
@@ -52,7 +52,10 @@
     "automation",
     "remote",
     "cli",
-    "typescript"
+    "typescript",
+    "kerberos",
+    "gssapi",
+    "sso"
   ],
   "author": "tufantunc",
   "engines": {

--- a/src/approval/__tests__/audit-seam.test.ts
+++ b/src/approval/__tests__/audit-seam.test.ts
@@ -7,9 +7,9 @@
  * tests pin that contract so a future refactor can't silently make audit a
  * hard build/runtime prerequisite.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { loadAuditSink } from '../audit-seam.js';
+import { isOptionalAuditStoreMissing, loadAuditSink } from '../audit-seam.js';
 import type { ApprovalDecision } from '../types.js';
 
 describe('optional audit seam', () => {
@@ -51,5 +51,40 @@ describe('optional audit seam', () => {
         error: new Error('boom'),
       }),
     ).not.toThrow();
+  });
+
+  it('classifies only the optional store module itself as absent', () => {
+    const expected = 'file:///repo/build/audit/store.js';
+    const absent = Object.assign(
+      new Error("Cannot find module '/repo/build/audit/store.js' imported from /repo/build/approval/audit-seam.js"),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+    const absentRelative = Object.assign(
+      new Error("Cannot find module '../audit/store.js' imported from '/repo/src/approval/audit-seam.ts'"),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+    const brokenNestedImport = Object.assign(
+      new Error("Cannot find module '/repo/build/audit/missing.js' imported from /repo/build/audit/store.js"),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+
+    expect(isOptionalAuditStoreMissing(absent, expected)).toBe(true);
+    expect(isOptionalAuditStoreMissing(absentRelative, expected)).toBe(true);
+    expect(isOptionalAuditStoreMissing(brokenNestedImport, expected)).toBe(false);
+  });
+
+  it('surfaces broken imports from a present audit module before degrading to no-op', async () => {
+    const err = Object.assign(
+      new Error("Cannot find module '/repo/build/audit/missing.js' imported from /repo/build/audit/store.js"),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const sink = await loadAuditSink({}, async () => { throw err; });
+      expect(typeof sink.record).toBe('function');
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('audit module present but failed to load'));
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/approval/__tests__/audit-seam.test.ts
+++ b/src/approval/__tests__/audit-seam.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Optional audit-truth seam tests (Decision D2).
+ *
+ * On `pr/toml-config` (this lane's base) `src/audit/` is NOT present, so the
+ * seam MUST degrade to a safe no-op: `loadAuditSink()` resolves, `.record()`
+ * never throws, and the engine remains usable without the audit module. These
+ * tests pin that contract so a future refactor can't silently make audit a
+ * hard build/runtime prerequisite.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { loadAuditSink } from '../audit-seam.js';
+import type { ApprovalDecision } from '../types.js';
+
+describe('optional audit seam', () => {
+  it('loadAuditSink resolves to a usable sink even when src/audit/ is absent', async () => {
+    const sink = await loadAuditSink();
+    expect(sink).toBeTruthy();
+    expect(typeof sink.record).toBe('function');
+  });
+
+  it('record() is a no-op (never throws) on the audit-absent path', async () => {
+    const sink = await loadAuditSink({ auditDir: '/nonexistent/should-not-be-written' });
+    const approval: ApprovalDecision = {
+      decision: 'allow',
+      reason: 'smart allowed',
+      decided_by: 'smart-llm',
+      decided_at: new Date().toISOString(),
+      mode: 'smart',
+    };
+    expect(() =>
+      sink.record({
+        tool: 'exec',
+        profile: 'prod',
+        command: 'uptime',
+        startedAt: Date.now(),
+        result: { stdout: 'ok', stderr: '', exitCode: 0 },
+        approval,
+      }),
+    ).not.toThrow();
+  });
+
+  it('record() tolerates the error path (no decision, transport failure)', async () => {
+    const sink = await loadAuditSink();
+    expect(() =>
+      sink.record({
+        tool: 'sudo-exec',
+        profile: 'default',
+        command: 'reboot',
+        startedAt: Date.now(),
+        error: new Error('boom'),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/approval/__tests__/build-from-config.test.ts
+++ b/src/approval/__tests__/build-from-config.test.ts
@@ -108,6 +108,35 @@ describe('buildApprovalEngineFromConfig — mode dispatch', () => {
     ).toThrow(ManualApprovalDisabledError);
   });
 
+  it('omitted mode defaults to documented manual mode when [approval] is present', async () => {
+    const dispatcher = buildApprovalEngineFromConfig(
+      {},
+      { manualOpts: { webuiEnabled: true, timeout_ms: 5000 } },
+    );
+    setApprovalEngine(dispatcher);
+    try {
+      const p = gateApproval(baseCtx);
+      await Promise.resolve();
+      const pending = dispatcher.listPending();
+      expect(pending).toHaveLength(1);
+      dispatcher.resolvePending(pending[0].id, 'allow', 'default manual ok', 'webui:test');
+      const d = await p;
+      expect(d.mode).toBe('manual');
+      expect(d.decided_by).toBe('webui:test');
+    } finally {
+      setApprovalEngine(null);
+    }
+  });
+
+  it('omitted mode still enforces manual mode WebUI requirement', () => {
+    expect(() =>
+      buildApprovalEngineFromConfig(
+        {},
+        { manualOpts: { webuiEnabled: false } },
+      ),
+    ).toThrow(ManualApprovalDisabledError);
+  });
+
   it('per-source override forces the right sub-engine to be built', async () => {
     // default=yolo, but a per-source override declares manual mode — the
     // dispatcher must construct ManualApproval at boot, not lazily on first use.

--- a/src/approval/__tests__/build-from-config.test.ts
+++ b/src/approval/__tests__/build-from-config.test.ts
@@ -1,0 +1,170 @@
+/**
+ * buildApprovalEngineFromConfig — boot-time wiring tests.
+ *
+ * For each mode (yolo/smart/manual), assert that:
+ *   1. The dispatcher built from a [approval]-shaped config object actually
+ *      dispatches to the requested engine (no fall-through to legacy yolo).
+ *   2. The returned ApprovalDecision carries the right mode + decided_by so
+ *      audit records the truth.
+ *   3. ManualApproval without WebUI is fatal at boot (gate-12 invariant).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { buildApprovalEngineFromConfig } from '../engine.js';
+import { gateApproval, setApprovalEngine } from '../gate.js';
+import { ManualApprovalDisabledError } from '../manual.js';
+import { ApprovalContext } from '../types.js';
+
+const baseCtx: ApprovalContext = {
+  profile: { id: 'prod' },
+  tool: 'exec',
+  command: 'uptime',
+};
+
+describe('buildApprovalEngineFromConfig — mode dispatch', () => {
+  it('mode=yolo wires YoloApproval, decisions carry mode=yolo / decided_by=yolo', async () => {
+    const dispatcher = buildApprovalEngineFromConfig(
+      { defaultMode: 'yolo' },
+      { manualOpts: { webuiEnabled: false } },
+    );
+    setApprovalEngine(dispatcher);
+    try {
+      const d = await gateApproval(baseCtx);
+      expect(d.decision).toBe('allow');
+      expect(d.mode).toBe('yolo');
+      expect(d.decided_by).toBe('yolo');
+      // Not the legacy:no-engine path.
+      expect(d.decided_by).not.toBe('legacy:no-engine');
+    } finally {
+      setApprovalEngine(null);
+    }
+  });
+
+  it('mode=smart wires SmartApproval with stubbed fetch (no real LLM call)', async () => {
+    const fetchStub = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        choices: [{ message: { content: '{"allow": true, "reason": "stub allowed"}' } }],
+      }),
+    }));
+
+    const dispatcher = buildApprovalEngineFromConfig(
+      {
+        defaultMode: 'smart',
+        llm: { endpoint: 'http://stub/llm', model: 'stub-model', api_key: 'fake' },
+      },
+      { manualOpts: { webuiEnabled: false }, smartFetchImpl: fetchStub as any },
+    );
+    setApprovalEngine(dispatcher);
+    try {
+      const d = await gateApproval(baseCtx);
+      expect(fetchStub).toHaveBeenCalledTimes(1);
+      expect(d.decision).toBe('allow');
+      expect(d.mode).toBe('smart');
+      expect(d.decided_by).toBe('smart-llm');
+      expect(d.reason).toBe('stub allowed');
+    } finally {
+      setApprovalEngine(null);
+    }
+  });
+
+  it('mode=smart without llm.endpoint/model is fatal at construction', () => {
+    expect(() =>
+      buildApprovalEngineFromConfig(
+        { defaultMode: 'smart' },
+        { manualOpts: { webuiEnabled: false } },
+      ),
+    ).toThrow(/\[approval\.llm\]/);
+  });
+
+  it('mode=manual wires ManualApproval when WebUI is enabled', async () => {
+    const dispatcher = buildApprovalEngineFromConfig(
+      { defaultMode: 'manual' },
+      { manualOpts: { webuiEnabled: true, timeout_ms: 5000 } },
+    );
+    setApprovalEngine(dispatcher);
+    try {
+      const p = gateApproval(baseCtx);
+      await Promise.resolve();
+      const pending = dispatcher.listPending();
+      expect(pending).toHaveLength(1);
+      dispatcher.resolvePending(pending[0].id, 'allow', 'ok', 'webui:test');
+      const d = await p;
+      expect(d.mode).toBe('manual');
+      expect(d.decision).toBe('allow');
+      expect(d.decided_by).toBe('webui:test');
+    } finally {
+      setApprovalEngine(null);
+    }
+  });
+
+  it('mode=manual without WebUI is FATAL at boot (gate-12 invariant)', () => {
+    expect(() =>
+      buildApprovalEngineFromConfig(
+        { defaultMode: 'manual' },
+        { manualOpts: { webuiEnabled: false } },
+      ),
+    ).toThrow(ManualApprovalDisabledError);
+  });
+
+  it('per-source override forces the right sub-engine to be built', async () => {
+    // default=yolo, but a per-source override declares manual mode — the
+    // dispatcher must construct ManualApproval at boot, not lazily on first use.
+    const dispatcher = buildApprovalEngineFromConfig(
+      { defaultMode: 'yolo', perSourceModes: ['manual'] },
+      { manualOpts: { webuiEnabled: true, timeout_ms: 5000 } },
+    );
+    setApprovalEngine(dispatcher);
+    try {
+      // Default profile → yolo allow.
+      const yoloDecision = await gateApproval(baseCtx);
+      expect(yoloDecision.mode).toBe('yolo');
+
+      // Override profile → manual queues.
+      const ctxManual: ApprovalContext = {
+        ...baseCtx,
+        profile: { id: 'lab', approval: { mode: 'manual' } },
+      };
+      const p = gateApproval(ctxManual);
+      await Promise.resolve();
+      const pending = dispatcher.listPending();
+      expect(pending).toHaveLength(1);
+      dispatcher.resolvePending(pending[0].id, 'allow');
+      const d = await p;
+      expect(d.mode).toBe('manual');
+    } finally {
+      setApprovalEngine(null);
+    }
+  });
+});
+
+describe('buildApprovalEngineFromConfig — dispatcher emits queue events', () => {
+  it('manual enqueue/resolve are emitted on the dispatcher (for WebUI SSE)', async () => {
+    const dispatcher = buildApprovalEngineFromConfig(
+      { defaultMode: 'manual' },
+      { manualOpts: { webuiEnabled: true, timeout_ms: 5000 } },
+    );
+    const enq: any[] = [];
+    const res: any[] = [];
+    dispatcher.on('enqueue', (p: any) => enq.push(p));
+    dispatcher.on('resolve', (p: any, d: any) => res.push({ p, d }));
+    setApprovalEngine(dispatcher);
+    try {
+      const promise = dispatcher.decide(baseCtx);
+      await Promise.resolve();
+      expect(enq).toHaveLength(1);
+      expect(enq[0].id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+
+      const id = enq[0].id;
+      dispatcher.resolvePending(id, 'deny', 'nope', 'webui:bob');
+      const d = await promise;
+      expect(d.decision).toBe('deny');
+      expect(res).toHaveLength(1);
+      expect(res[0].d.decision).toBe('deny');
+      expect(res[0].d.decided_by).toBe('webui:bob');
+    } finally {
+      setApprovalEngine(null);
+    }
+  });
+});

--- a/src/approval/__tests__/engine.test.ts
+++ b/src/approval/__tests__/engine.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { YoloApproval } from '../yolo.js';
+import { ApprovalDispatcher } from '../engine.js';
+import { ApprovalContext } from '../types.js';
+
+const baseCtx: ApprovalContext = {
+  profile: { id: 'prod', description: 'production host' },
+  tool: 'exec',
+  command: 'uptime',
+};
+
+describe('YoloApproval', () => {
+  it('always allows', async () => {
+    const y = new YoloApproval();
+    const d = await y.decide(baseCtx);
+    expect(d.decision).toBe('allow');
+    expect(d.mode).toBe('yolo');
+    expect(d.decided_by).toBe('yolo');
+    expect(d.decided_at).toMatch(/T/);
+  });
+});
+
+describe('ApprovalDispatcher', () => {
+  it('dispatches to yolo when defaultMode=yolo', async () => {
+    const d = new ApprovalDispatcher({ defaultMode: 'yolo' });
+    const r = await d.decide(baseCtx);
+    expect(r.decision).toBe('allow');
+    expect(r.mode).toBe('yolo');
+  });
+
+  it('uses per-source override when provided', async () => {
+    const d = new ApprovalDispatcher({ defaultMode: 'yolo' });
+    // override to "yolo" again (no smart/manual configured) just to prove the
+    // override branch is hit without needing the other engines.
+    const ctx: ApprovalContext = {
+      ...baseCtx,
+      profile: { id: 'lab', approval: { mode: 'yolo' } },
+    };
+    const r = await d.decide(ctx);
+    expect(r.decision).toBe('allow');
+  });
+
+  it('throws when smart mode requested but llm options missing', () => {
+    expect(() => new ApprovalDispatcher({ defaultMode: 'smart' })).toThrow(
+      /\[approval\.llm\] is not configured/,
+    );
+  });
+
+  it('throws when manual mode requested but options missing', () => {
+    expect(() => new ApprovalDispatcher({ defaultMode: 'manual' })).toThrow(
+      /WebUI\/manual options/,
+    );
+  });
+
+  it('rejects per-source override pointing at unconfigured mode', async () => {
+    const d = new ApprovalDispatcher({ defaultMode: 'yolo' });
+    const ctx: ApprovalContext = {
+      ...baseCtx,
+      profile: { id: 'prod', approval: { mode: 'smart' } },
+    };
+    await expect(d.decide(ctx)).rejects.toThrow(/\[approval\.llm\] is not configured/);
+  });
+
+  it('listPending returns [] when manual not configured', () => {
+    const d = new ApprovalDispatcher({ defaultMode: 'yolo' });
+    expect(d.listPending()).toEqual([]);
+    expect(d.resolvePending('nonexistent', 'allow')).toBe(false);
+  });
+});

--- a/src/approval/__tests__/gate.test.ts
+++ b/src/approval/__tests__/gate.test.ts
@@ -4,6 +4,7 @@ import {
   gateApproval,
   setApprovalEngine,
   getApprovalEngine,
+  getApprovalDecisionFromError,
 } from '../gate.js';
 import { ApprovalDispatcher } from '../engine.js';
 import { ApprovalEngine, ApprovalContext, ApprovalDecision } from '../types.js';
@@ -47,6 +48,30 @@ describe('gateApproval', () => {
     await expect(gateApproval(ctx)).rejects.toThrow(McpError);
     await expect(gateApproval(ctx)).rejects.toThrow(/approval denied/);
     await expect(gateApproval(ctx)).rejects.toThrow(/destructive command/);
+  });
+
+  it('attaches the deny decision to the thrown McpError for audit logging', async () => {
+    const decision: ApprovalDecision = {
+      decision: 'deny',
+      reason: 'manual rejection',
+      decided_by: 'webui:alice',
+      decided_at: new Date().toISOString(),
+      mode: 'manual',
+    };
+    const denyingEngine: ApprovalEngine = {
+      async decide(): Promise<ApprovalDecision> {
+        return decision;
+      },
+    };
+    setApprovalEngine(denyingEngine);
+
+    try {
+      await gateApproval(ctx);
+      throw new Error('expected gateApproval to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpError);
+      expect(getApprovalDecisionFromError(err)).toBe(decision);
+    }
   });
 
   it('passes allow decision through on smart-allow stub', async () => {

--- a/src/approval/__tests__/gate.test.ts
+++ b/src/approval/__tests__/gate.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import {
+  gateApproval,
+  setApprovalEngine,
+  getApprovalEngine,
+} from '../gate.js';
+import { ApprovalDispatcher } from '../engine.js';
+import { ApprovalEngine, ApprovalContext, ApprovalDecision } from '../types.js';
+
+const ctx: ApprovalContext = {
+  profile: { id: 'prod' },
+  tool: 'exec',
+  command: 'ls /',
+};
+
+afterEach(() => setApprovalEngine(null));
+
+describe('gateApproval', () => {
+  it('returns synthetic allow when no engine is configured (legacy path)', async () => {
+    setApprovalEngine(null);
+    const d = await gateApproval(ctx);
+    expect(d.decision).toBe('allow');
+    expect(d.decided_by).toBe('legacy:no-engine');
+  });
+
+  it('allows under yolo dispatcher', async () => {
+    setApprovalEngine(new ApprovalDispatcher({ defaultMode: 'yolo' }));
+    const d = await gateApproval(ctx);
+    expect(d.decision).toBe('allow');
+    expect(d.mode).toBe('yolo');
+  });
+
+  it('throws McpError on deny', async () => {
+    const denyingEngine: ApprovalEngine = {
+      async decide(): Promise<ApprovalDecision> {
+        return {
+          decision: 'deny',
+          reason: 'destructive command',
+          decided_by: 'test-stub',
+          decided_at: new Date().toISOString(),
+          mode: 'smart',
+        };
+      },
+    };
+    setApprovalEngine(denyingEngine);
+    await expect(gateApproval(ctx)).rejects.toThrow(McpError);
+    await expect(gateApproval(ctx)).rejects.toThrow(/approval denied/);
+    await expect(gateApproval(ctx)).rejects.toThrow(/destructive command/);
+  });
+
+  it('passes allow decision through on smart-allow stub', async () => {
+    const allowingEngine: ApprovalEngine = {
+      async decide(): Promise<ApprovalDecision> {
+        return {
+          decision: 'allow',
+          reason: 'safe',
+          decided_by: 'smart-llm',
+          decided_at: new Date().toISOString(),
+          mode: 'smart',
+        };
+      },
+    };
+    setApprovalEngine(allowingEngine);
+    const d = await gateApproval(ctx);
+    expect(d.decision).toBe('allow');
+    expect(d.mode).toBe('smart');
+  });
+
+  it('set/get round-trip', () => {
+    const e = new ApprovalDispatcher({ defaultMode: 'yolo' });
+    setApprovalEngine(e);
+    expect(getApprovalEngine()).toBe(e);
+    setApprovalEngine(null);
+    expect(getApprovalEngine()).toBeNull();
+  });
+});

--- a/src/approval/__tests__/manual-without-resolver-warning.test.ts
+++ b/src/approval/__tests__/manual-without-resolver-warning.test.ts
@@ -1,0 +1,88 @@
+/**
+ * manualWithoutResolverWarning — non-fatal boot advisory.
+ *
+ * The approval-engine lane ships the manual-approval queue primitive but no
+ * driver that settles it (the WebUI manual-approval server lands in the child
+ * lane pr/webui-manual-approval). When this build boots `manual` mode with the
+ * WebUI enabled but no resolver present, every command queues until it times
+ * out and is denied. That is a legitimate stacked-PR state, NOT fatal — boot
+ * still succeeds — so the warning is the only signal. These tests pin exactly
+ * when it fires and when it stays silent.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { manualWithoutResolverWarning } from '../engine.js';
+
+describe('manualWithoutResolverWarning', () => {
+  it('fires: default manual + WebUI enabled + no resolver wired', () => {
+    const w = manualWithoutResolverWarning({
+      webuiEnabled: true,
+      defaultMode: 'manual',
+      resolverWired: false,
+    });
+    expect(w).toContain('manual');
+    expect(w).toContain('pr/webui-manual-approval');
+    expect(w).toMatch(/no approval resolver is wired/);
+  });
+
+  it('fires: omitted default mode (documented manual) + WebUI + no resolver', () => {
+    // defaultMode omitted resolves to manual (mirrors buildApprovalEngineFromConfig).
+    const w = manualWithoutResolverWarning({
+      webuiEnabled: true,
+      resolverWired: false,
+    });
+    expect(w).not.toBeNull();
+    expect(w).toContain('manual');
+  });
+
+  it('fires: manual only via a per-source override, global default yolo', () => {
+    const w = manualWithoutResolverWarning({
+      webuiEnabled: true,
+      defaultMode: 'yolo',
+      perSourceModes: ['manual'],
+      resolverWired: false,
+    });
+    expect(w).not.toBeNull();
+  });
+
+  it('silent: resolver IS wired (child WebUI lane present)', () => {
+    expect(
+      manualWithoutResolverWarning({
+        webuiEnabled: true,
+        defaultMode: 'manual',
+        resolverWired: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('silent: WebUI disabled (manual mode is already fatal-at-boot, gate-12)', () => {
+    expect(
+      manualWithoutResolverWarning({
+        webuiEnabled: false,
+        defaultMode: 'manual',
+        resolverWired: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('silent: manual mode not in use (yolo default, no manual override)', () => {
+    expect(
+      manualWithoutResolverWarning({
+        webuiEnabled: true,
+        defaultMode: 'yolo',
+        perSourceModes: ['smart'],
+        resolverWired: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('silent: smart-only deployment with WebUI enabled', () => {
+    expect(
+      manualWithoutResolverWarning({
+        webuiEnabled: true,
+        defaultMode: 'smart',
+        resolverWired: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/approval/__tests__/manual.test.ts
+++ b/src/approval/__tests__/manual.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ManualApproval,
+  ManualApprovalDisabledError,
+} from '../manual.js';
+import { ApprovalContext } from '../types.js';
+
+const ctx: ApprovalContext = {
+  profile: { id: 'prod' },
+  tool: 'exec',
+  command: 'uptime',
+};
+
+describe('ManualApproval — boot guard', () => {
+  it('throws when WebUI is disabled', () => {
+    expect(() => new ManualApproval({ webuiEnabled: false })).toThrow(
+      ManualApprovalDisabledError,
+    );
+  });
+
+  it('constructs when WebUI is enabled', () => {
+    const m = new ManualApproval({ webuiEnabled: true });
+    expect(m.listPending()).toEqual([]);
+  });
+});
+
+describe('ManualApproval — external resolve', () => {
+  it('allows when resolved with `allow`', async () => {
+    const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 5000 });
+    const p = m.decide(ctx);
+
+    // Tick the microtask queue so the queue entry is registered before we
+    // attempt to resolve it.
+    await Promise.resolve();
+    const pending = m.listPending();
+    expect(pending).toHaveLength(1);
+    const id = pending[0].id;
+    expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+
+    const ok = m.resolvePending(id, 'allow', 'looks good', 'webui:alice');
+    expect(ok).toBe(true);
+
+    const decision = await p;
+    expect(decision.decision).toBe('allow');
+    expect(decision.reason).toBe('looks good');
+    expect(decision.decided_by).toBe('webui:alice');
+    expect(decision.mode).toBe('manual');
+    expect(m.listPending()).toHaveLength(0);
+  });
+
+  it('denies when resolved with `deny`', async () => {
+    const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 5000 });
+    const p = m.decide(ctx);
+    await Promise.resolve();
+    const id = m.listPending()[0].id;
+    expect(m.resolvePending(id, 'deny', 'not now')).toBe(true);
+    const d = await p;
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toBe('not now');
+  });
+
+  it('resolvePending on unknown id returns false', () => {
+    const m = new ManualApproval({ webuiEnabled: true });
+    expect(m.resolvePending('does-not-exist', 'allow')).toBe(false);
+  });
+
+  it('keeps multiple pending entries independent', async () => {
+    const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 5000 });
+    const p1 = m.decide(ctx);
+    const p2 = m.decide({ ...ctx, command: 'whoami' });
+    await Promise.resolve();
+    const pending = m.listPending();
+    expect(pending).toHaveLength(2);
+    m.resolvePending(pending[0].id, 'allow');
+    m.resolvePending(pending[1].id, 'deny');
+    const [d1, d2] = await Promise.all([p1, p2]);
+    expect(d1.decision).toBe('allow');
+    expect(d2.decision).toBe('deny');
+  });
+});
+
+describe('ManualApproval — timeout', () => {
+  it('times out and denies with "approval timed out"', async () => {
+    vi.useFakeTimers();
+    try {
+      const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 100 });
+      const p = m.decide(ctx);
+      // Let the constructor enqueue
+      await Promise.resolve();
+      expect(m.listPending()).toHaveLength(1);
+
+      vi.advanceTimersByTime(150);
+      const d = await p;
+      expect(d.decision).toBe('deny');
+      expect(d.reason).toBe('approval timed out');
+      expect(d.decided_by).toBe('manual:timeout');
+      expect(m.listPending()).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolve after timeout is a no-op', async () => {
+    vi.useFakeTimers();
+    try {
+      const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 50 });
+      const p = m.decide(ctx);
+      await Promise.resolve();
+      const id = m.listPending()[0].id;
+      vi.advanceTimersByTime(100);
+      await p;
+      expect(m.resolvePending(id, 'allow')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/approval/__tests__/manual.test.ts
+++ b/src/approval/__tests__/manual.test.ts
@@ -64,6 +64,29 @@ describe('ManualApproval — external resolve', () => {
     expect(m.resolvePending('does-not-exist', 'allow')).toBe(false);
   });
 
+  it('rejects a runtime decision outside allow/deny without settling', async () => {
+    const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 5000 });
+    const p = m.decide(ctx);
+    await Promise.resolve();
+    const id = m.listPending()[0].id;
+    expect((m.resolvePending as any)(id, 'approve')).toBe(false);
+    expect(m.listPending()).toHaveLength(1);
+    expect(m.resolvePending(id, 'deny')).toBe(true);
+    await expect(p).resolves.toMatchObject({ decision: 'deny' });
+  });
+
+  it('includes the public resolve callback in enqueue events', async () => {
+    const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 5000 });
+    let enqueued: any;
+    m.once('enqueue', (entry) => { enqueued = entry; });
+    const p = m.decide(ctx);
+    await Promise.resolve();
+    expect(enqueued).toMatchObject({ context: ctx });
+    expect(enqueued.resolve).toBeTypeOf('function');
+    expect(enqueued.resolve('allow', 'from event')).toBe(true);
+    await expect(p).resolves.toMatchObject({ decision: 'allow', reason: 'from event' });
+  });
+
   it('keeps multiple pending entries independent', async () => {
     const m = new ManualApproval({ webuiEnabled: true, timeout_ms: 5000 });
     const p1 = m.decide(ctx);

--- a/src/approval/__tests__/smart.test.ts
+++ b/src/approval/__tests__/smart.test.ts
@@ -74,9 +74,54 @@ describe('SmartApproval — happy paths', () => {
     expect(call[1].headers['Authorization']).toBe('Bearer test-key');
     expect(call[1].headers['Content-Type']).toBe('application/json');
   });
+
+  it('redacts command and intent secrets before sending them to the external LLM', async () => {
+    const fetchImpl = vi.fn(() =>
+      makeOkResponse(JSON.stringify({ allow: true, reason: 'ok' })),
+    );
+    const command = [
+      "curl -H 'Authorization: Bearer bearer-secret' https://example.invalid",
+      'mysql -uroot -pdatabase-secret',
+      'API_TOKEN=environment-secret deploy',
+      'git clone https://alice:url-secret@example.invalid/repo.git',
+    ].join(' && ');
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+
+    await s.decide({ ...ctx, command, description: 'password intent-secret' });
+
+    const call: any = (fetchImpl as any).mock.calls[0];
+    const userPrompt = JSON.parse(call[1].body).messages
+      .find((message: any) => message.role === 'user').content as string;
+    expect(userPrompt).toContain('<redacted>');
+    for (const secret of [
+      'bearer-secret',
+      'database-secret',
+      'environment-secret',
+      'url-secret',
+      'intent-secret',
+    ]) {
+      expect(userPrompt).not.toContain(secret);
+    }
+    expect(command).toContain('database-secret');
+  });
 });
 
 describe('SmartApproval — fail-closed (default)', () => {
+  it('does not schedule an abort timer when no fetch implementation exists', async () => {
+    vi.stubGlobal('fetch', undefined);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    try {
+      const s = new SmartApproval(makeOpts());
+      const d = await s.decide(ctx);
+      expect(d.decision).toBe('deny');
+      expect(d.decided_by).toBe('smart-llm:no-fetch');
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('denies on non-200 HTTP', async () => {
     const fetchImpl = vi.fn(() =>
       Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('') }),

--- a/src/approval/__tests__/smart.test.ts
+++ b/src/approval/__tests__/smart.test.ts
@@ -136,6 +136,40 @@ describe('SmartApproval — fail-closed (default)', () => {
     expect(d.reason).toMatch(/timed out/);
   });
 
+  it('keeps the timeout armed while reading the response body', async () => {
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(
+      (_url: string, init: any) => {
+        signal = init.signal;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => new Promise<string>((_resolve, reject) => {
+            signal?.addEventListener('abort', () => {
+              const err: any = new Error('aborted while reading body');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }),
+        });
+      },
+    );
+    const s = new SmartApproval(makeOpts({
+      llm: {
+        endpoint: 'https://example.invalid/v1/chat/completions',
+        api_key: 'test-key',
+        model: 'gpt-4o-mini',
+        timeout_ms: 20,
+      },
+      fetchImpl: fetchImpl as any,
+    }));
+
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toMatch(/timed out/);
+    expect(d.decided_by).toBe('smart-llm:timeout');
+  });
+
   it('denies on transport (network) error', async () => {
     const fetchImpl = vi.fn(() => Promise.reject(new Error('ECONNRESET')));
     const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));

--- a/src/approval/__tests__/smart.test.ts
+++ b/src/approval/__tests__/smart.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SmartApproval } from '../smart.js';
+import { ApprovalContext, SmartApprovalOptions } from '../types.js';
+
+const ctx: ApprovalContext = {
+  profile: { id: 'prod', description: 'production host (read-only)' },
+  tool: 'exec',
+  command: 'ls /tmp',
+  description: 'list temp',
+};
+
+function makeOkResponse(content: string) {
+  const body = JSON.stringify({
+    choices: [{ message: { content } }],
+  });
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(body),
+  });
+}
+
+function makeOpts(overrides: Partial<SmartApprovalOptions> = {}): SmartApprovalOptions {
+  return {
+    llm: {
+      endpoint: 'https://example.invalid/v1/chat/completions',
+      api_key: 'test-key',
+      model: 'gpt-4o-mini',
+      timeout_ms: 50,
+    },
+    fail_closed: true,
+    ...overrides,
+  };
+}
+
+describe('SmartApproval — happy paths', () => {
+  it('allows when LLM returns {allow:true}', async () => {
+    const fetchImpl = vi.fn(() =>
+      makeOkResponse(JSON.stringify({ allow: true, reason: 'looks safe' })),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('allow');
+    expect(d.reason).toBe('looks safe');
+    expect(d.decided_by).toBe('smart-llm');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies when LLM returns {allow:false}', async () => {
+    const fetchImpl = vi.fn(() =>
+      makeOkResponse(JSON.stringify({ allow: false, reason: 'rm -rf detected' })),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toBe('rm -rf detected');
+  });
+
+  it('tolerates fenced JSON inside content', async () => {
+    const fenced = '```json\n{"allow": true, "reason": "ok"}\n```';
+    const fetchImpl = vi.fn(() => makeOkResponse(fenced));
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('allow');
+  });
+
+  it('sends Authorization header when api_key is set', async () => {
+    const fetchImpl = vi.fn(() =>
+      makeOkResponse(JSON.stringify({ allow: true, reason: 'ok' })),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    await s.decide(ctx);
+    const call: any = (fetchImpl as any).mock.calls[0];
+    expect(call[1].headers['Authorization']).toBe('Bearer test-key');
+    expect(call[1].headers['Content-Type']).toBe('application/json');
+  });
+});
+
+describe('SmartApproval — fail-closed (default)', () => {
+  it('denies on non-200 HTTP', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('') }),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toMatch(/HTTP 500/);
+    expect(d.decided_by).toBe('smart-llm:http-500');
+  });
+
+  it('denies on malformed JSON body', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('not json at all'),
+      }),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toMatch(/malformed/);
+  });
+
+  it('denies when content is missing the JSON object', async () => {
+    const fetchImpl = vi.fn(() => makeOkResponse('I refuse to respond as JSON.'));
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toMatch(/no JSON object|malformed/);
+  });
+
+  it('denies when JSON lacks boolean `allow`', async () => {
+    const fetchImpl = vi.fn(() =>
+      makeOkResponse(JSON.stringify({ reason: 'oops, no allow field' })),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+  });
+
+  it('denies on timeout (AbortError)', async () => {
+    const fetchImpl = vi.fn(
+      (_url: string, init: any) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err: any = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toMatch(/timed out/);
+  });
+
+  it('denies on transport (network) error', async () => {
+    const fetchImpl = vi.fn(() => Promise.reject(new Error('ECONNRESET')));
+    const s = new SmartApproval(makeOpts({ fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('deny');
+    expect(d.reason).toMatch(/ECONNRESET/);
+  });
+});
+
+describe('SmartApproval — fail-open (fail_closed=false)', () => {
+  it('allows on non-200 with warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({ ok: false, status: 502, text: () => Promise.resolve('') }),
+    );
+    const s = new SmartApproval(makeOpts({ fail_closed: false, fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('allow');
+    expect(d.reason).toMatch(/fail_closed=false/);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('allows on malformed JSON with warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('garbage') }),
+    );
+    const s = new SmartApproval(makeOpts({ fail_closed: false, fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('allow');
+    warn.mockRestore();
+  });
+
+  it('allows on timeout with warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchImpl = vi.fn(
+      (_url: string, init: any) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            const err: any = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+    const s = new SmartApproval(makeOpts({ fail_closed: false, fetchImpl: fetchImpl as any }));
+    const d = await s.decide(ctx);
+    expect(d.decision).toBe('allow');
+    expect(d.reason).toMatch(/timed out/);
+    warn.mockRestore();
+  });
+});
+
+describe('SmartApproval — constructor validation', () => {
+  it('throws when endpoint missing', () => {
+    expect(
+      () =>
+        new SmartApproval({
+          llm: { endpoint: '', model: 'gpt-4o-mini' } as any,
+        }),
+    ).toThrow(/endpoint/);
+  });
+
+  it('throws when model missing', () => {
+    expect(
+      () =>
+        new SmartApproval({
+          llm: { endpoint: 'https://x', model: '' } as any,
+        }),
+    ).toThrow(/model/);
+  });
+});

--- a/src/approval/__tests__/smart.test.ts
+++ b/src/approval/__tests__/smart.test.ts
@@ -242,4 +242,14 @@ describe('SmartApproval — constructor validation', () => {
         }),
     ).toThrow(/model/);
   });
+
+  it('rejects providers whose request/response schema is not implemented', () => {
+    expect(() => new SmartApproval(makeOpts({
+      llm: {
+        endpoint: 'https://anthropic.example/v1/messages',
+        model: 'claude',
+        provider: 'anthropic',
+      },
+    }))).toThrow(/provider "anthropic" is not supported/);
+  });
 });

--- a/src/approval/audit-seam.ts
+++ b/src/approval/audit-seam.ts
@@ -1,0 +1,149 @@
+/**
+ * OPTIONAL audit-truth seam.
+ *
+ * The approval engine returns a real `ApprovalDecision` from `gateApproval()`.
+ * When the audit module (`src/audit/`) is part of THIS build, the seam threads
+ * that decision into a JSONL audit record so the log reflects the TRUTH of why
+ * a command ran (mode / decided_by / reason), not a placeholder. When
+ * `src/audit/` is ABSENT — as it is on `pr/toml-config`, the base of this lane,
+ * where the engine ships before PR-A merges — the seam degrades to a no-op and
+ * the engine still builds and unit-passes.
+ *
+ * Decision D2 (P1 plan §6): audit is an OPTIONAL seam, not a hard build
+ * prerequisite. We load the audit module via a *computed* (non-literal)
+ * specifier so the TypeScript compiler does not statically resolve it — no
+ * TS2307 when `src/audit/` is missing — and a runtime `ERR_MODULE_NOT_FOUND`
+ * is caught and turned into the no-op sink.
+ */
+import type { ApprovalDecision } from './types.js';
+import type { ExecResult } from '../transports/types.js';
+
+export type AuditToolName = 'exec' | 'sudo-exec';
+
+/** What an exec/sudo-exec handler hands the seam after (attempting) a command. */
+export interface AuditExecInput {
+  tool: AuditToolName;
+  /** Connection / profile name; `default` for the implicit single host. */
+  profile: string;
+  /** The command actually sent to the transport (already sanitized). */
+  command: string;
+  description?: string;
+  /** `Date.now()` captured before the transport call, for duration math. */
+  startedAt: number;
+  /** Present on success. */
+  result?: ExecResult;
+  /** Present on failure (transport error, timeout, or approval deny). */
+  error?: unknown;
+  /** The real decision from `gateApproval`, when one was produced. */
+  approval?: ApprovalDecision;
+}
+
+/** The seam surface the rest of the server depends on. Always safe to call. */
+export interface AuditSink {
+  record(input: AuditExecInput): void;
+}
+
+export interface AuditSeamConfig {
+  /** TOML `[server].audit_dir`. Falls back to env / `~/.ssh-mcp` inside audit. */
+  auditDir?: string;
+  /** TOML `[server].audit_max_bytes`. */
+  auditMaxBytes?: number;
+}
+
+/**
+ * Minimal structural view of the audit module's public surface this seam uses.
+ * Kept local so this file never statically imports `src/audit/` (which may be
+ * absent). The real module satisfies this shape structurally.
+ */
+interface AuditModuleLike {
+  AuditStore: new (cfg: { auditDir: string; auditMaxBytes: number }) => {
+    append(record: unknown): unknown;
+  };
+  resolveAuditDir(override?: string | null): string;
+  yoloApproval(now?: Date): unknown;
+}
+
+/** Shared no-op sink for the audit-absent path. */
+const NO_OP_SINK: AuditSink = {
+  record(): void {
+    /* src/audit/ not present in this build — Decision D2 optional seam */
+  },
+};
+
+function toApprovalSection(decision: ApprovalDecision) {
+  return {
+    mode: decision.mode,
+    decision: decision.decision,
+    reason: decision.reason,
+    decided_at: decision.decided_at,
+    decided_by: decision.decided_by,
+  };
+}
+
+/**
+ * Try to wire a truth-logging audit sink. Returns a no-op sink (never throws)
+ * when `src/audit/` is not part of this build, so callers can wire the seam
+ * unconditionally at boot and treat the result as always-present.
+ */
+export async function loadAuditSink(config: AuditSeamConfig = {}): Promise<AuditSink> {
+  // Non-literal specifier: tsc does NOT resolve this, so the build succeeds
+  // even though `src/audit/store.js` does not exist on `pr/toml-config`.
+  const specifier = '../audit/' + 'store.js';
+
+  let mod: AuditModuleLike;
+  try {
+    mod = (await import(specifier)) as unknown as AuditModuleLike;
+  } catch {
+    return NO_OP_SINK; // ERR_MODULE_NOT_FOUND → audit module absent → no-op
+  }
+  if (!mod || typeof mod.AuditStore !== 'function') {
+    return NO_OP_SINK;
+  }
+
+  const auditDir = mod.resolveAuditDir(config.auditDir);
+  const store = new mod.AuditStore({
+    auditDir,
+    auditMaxBytes: config.auditMaxBytes ?? 10_000,
+  });
+
+  return {
+    record(input: AuditExecInput): void {
+      try {
+        const now = new Date();
+        const durationMs = Math.max(0, Date.now() - input.startedAt);
+        // Truth: prefer the real decision; fall back to the yolo placeholder
+        // only when the gate never produced one (error before the gate ran).
+        const approval = input.approval
+          ? toApprovalSection(input.approval)
+          : mod.yoloApproval(now);
+        store.append({
+          profile: input.profile,
+          tool: input.tool,
+          command: input.command,
+          description: input.description,
+          approval,
+          exec: input.result
+            ? {
+                stdout: input.result.stdout ?? '',
+                stderr: input.result.stderr ?? '',
+                exitCode: input.result.exitCode ?? null,
+                durationMs,
+              }
+            : {
+                stdout: '',
+                stderr:
+                  input.error instanceof Error
+                    ? input.error.message
+                    : String(input.error ?? 'unknown error'),
+                exitCode: null,
+                durationMs,
+              },
+          now,
+        });
+      } catch (auditErr: any) {
+        // Audit failure must be visible but must not hide the real SSH result.
+        console.error(`audit log append failed: ${auditErr?.message || auditErr}`);
+      }
+    },
+  };
+}

--- a/src/approval/audit-seam.ts
+++ b/src/approval/audit-seam.ts
@@ -17,6 +17,7 @@
  */
 import type { ApprovalDecision } from './types.js';
 import type { ExecResult } from '../transports/types.js';
+import { fileURLToPath } from 'node:url';
 
 export type AuditToolName = 'exec' | 'sudo-exec';
 
@@ -63,6 +64,28 @@ interface AuditModuleLike {
   yoloApproval(now?: Date): unknown;
 }
 
+export type AuditModuleImporter = (specifier: string) => Promise<unknown>;
+
+const defaultAuditImporter: AuditModuleImporter = (specifier) => import(specifier);
+
+export function isOptionalAuditStoreMissing(
+  err: unknown,
+  expectedStoreUrl = new URL('../audit/store.js', import.meta.url).href,
+): boolean {
+  const code = (err as { code?: string })?.code;
+  if (code !== 'ERR_MODULE_NOT_FOUND') return false;
+
+  const actualUrl = (err as { url?: string })?.url;
+  if (actualUrl) return actualUrl === expectedStoreUrl;
+
+  const expectedStorePath = fileURLToPath(expectedStoreUrl);
+  const message = (err as { message?: string })?.message ?? String(err);
+  return message.includes(`Cannot find module '${expectedStorePath}'`)
+    || message.includes(`Cannot find module "${expectedStorePath}"`)
+    || message.includes("Cannot find module '../audit/store.js'")
+    || message.includes('Cannot find module "../audit/store.js"');
+}
+
 /** Shared no-op sink for the audit-absent path. */
 const NO_OP_SINK: AuditSink = {
   record(): void {
@@ -85,26 +108,29 @@ function toApprovalSection(decision: ApprovalDecision) {
  * when `src/audit/` is not part of this build, so callers can wire the seam
  * unconditionally at boot and treat the result as always-present.
  */
-export async function loadAuditSink(config: AuditSeamConfig = {}): Promise<AuditSink> {
+export async function loadAuditSink(
+  config: AuditSeamConfig = {},
+  importer: AuditModuleImporter = defaultAuditImporter,
+): Promise<AuditSink> {
   // Non-literal specifier: tsc does NOT resolve this, so the build succeeds
   // even though `src/audit/store.js` does not exist on `pr/toml-config`.
   const specifier = '../audit/' + 'store.js';
+  const expectedStoreUrl = new URL(specifier, import.meta.url).href;
 
   let mod: AuditModuleLike;
   try {
-    mod = (await import(specifier)) as unknown as AuditModuleLike;
+    mod = (await importer(specifier)) as unknown as AuditModuleLike;
   } catch (err) {
-    // Only ERR_MODULE_NOT_FOUND is the expected "audit module absent" case
-    // (Decision D2 optional seam). Any other import failure — a syntax or
-    // runtime error inside a *present* audit module — is a real
-    // misconfiguration that would otherwise be silently indistinguishable
-    // from "not installed". Surface it before degrading to the no-op sink.
-    const code = (err as { code?: string })?.code;
-    if (code !== 'ERR_MODULE_NOT_FOUND') {
-      const message = (err as { message?: string })?.message ?? String(err);
-      console.error(`[ssh-mcp][audit-seam] audit module present but failed to load; auditing disabled: ${message}`);
+    // Only a missing ../audit/store.js is the expected "audit module absent"
+    // case (Decision D2 optional seam). A present audit module whose own import
+    // is missing also reports ERR_MODULE_NOT_FOUND; do not misclassify that as
+    // optional absence, or the broken module is silently suppressed.
+    if (isOptionalAuditStoreMissing(err, expectedStoreUrl)) {
+      return NO_OP_SINK;
     }
-    return NO_OP_SINK; // audit module absent (or unusable) → no-op
+    const message = (err as { message?: string })?.message ?? String(err);
+    console.error(`[ssh-mcp][audit-seam] audit module present but failed to load; auditing disabled: ${message}`);
+    return NO_OP_SINK; // audit module unusable → visible warning + no-op
   }
   if (!mod || typeof mod.AuditStore !== 'function') {
     return NO_OP_SINK;

--- a/src/approval/audit-seam.ts
+++ b/src/approval/audit-seam.ts
@@ -37,6 +37,8 @@ export interface AuditExecInput {
   error?: unknown;
   /** The real decision from `gateApproval`, when one was produced. */
   approval?: ApprovalDecision;
+  /** Effective configured mode, retained when a failure occurs before the gate decides. */
+  approvalMode?: ApprovalDecision['mode'];
 }
 
 /** The seam surface the rest of the server depends on. Always safe to call. */
@@ -106,10 +108,14 @@ function errorMessageFromUnknown(error: unknown): string {
   return error instanceof Error ? error.message : String(error ?? 'unknown error');
 }
 
-function approvalNotReachedSection(now: Date, error: unknown) {
+function approvalNotReachedSection(
+  now: Date,
+  error: unknown,
+  mode: ApprovalDecision['mode'],
+) {
   const message = errorMessageFromUnknown(error);
   return {
-    mode: 'manual',
+    mode,
     decision: 'deny',
     reason: `approval gate was not reached: ${message}`,
     decided_at: now.toISOString(),
@@ -157,15 +163,29 @@ export async function loadAuditSink(
     console.error(`[ssh-mcp][audit-seam] audit module present but failed to load; auditing disabled: ${message}`);
     return NO_OP_SINK; // audit module unusable → visible warning + no-op
   }
-  if (!mod || typeof mod.AuditStore !== 'function') {
+  let store: { append(record: unknown): unknown };
+  try {
+    if (
+      !mod
+      || typeof mod.AuditStore !== 'function'
+      || typeof mod.resolveAuditDir !== 'function'
+    ) {
+      throw new TypeError('expected callable AuditStore and resolveAuditDir exports');
+    }
+
+    const auditDir = mod.resolveAuditDir(config.auditDir);
+    store = new mod.AuditStore({
+      auditDir,
+      auditMaxBytes: config.auditMaxBytes ?? 10_000,
+    });
+    if (!store || typeof store.append !== 'function') {
+      throw new TypeError('AuditStore instance must expose append(record)');
+    }
+  } catch (err) {
+    const message = (err as { message?: string })?.message ?? String(err);
+    console.error(`[ssh-mcp][audit-seam] audit module present but failed to initialize; auditing disabled: ${message}`);
     return NO_OP_SINK;
   }
-
-  const auditDir = mod.resolveAuditDir(config.auditDir);
-  const store = new mod.AuditStore({
-    auditDir,
-    auditMaxBytes: config.auditMaxBytes ?? 10_000,
-  });
 
   return {
     record(input: AuditExecInput): void {
@@ -177,7 +197,7 @@ export async function loadAuditSink(
         // decision: record an explicit not-run denial marker instead.
         const approval = input.approval
           ? toApprovalSection(input.approval)
-          : approvalNotReachedSection(now, input.error);
+          : approvalNotReachedSection(now, input.error, input.approvalMode ?? 'yolo');
         store.append({
           profile: input.profile,
           tool: input.tool,

--- a/src/approval/audit-seam.ts
+++ b/src/approval/audit-seam.ts
@@ -102,8 +102,12 @@ function toApprovalSection(decision: ApprovalDecision) {
   };
 }
 
+function errorMessageFromUnknown(error: unknown): string {
+  return error instanceof Error ? error.message : String(error ?? 'unknown error');
+}
+
 function approvalNotReachedSection(now: Date, error: unknown) {
-  const message = error instanceof Error ? error.message : String(error ?? 'unknown error');
+  const message = errorMessageFromUnknown(error);
   return {
     mode: 'manual',
     decision: 'deny',
@@ -111,6 +115,17 @@ function approvalNotReachedSection(now: Date, error: unknown) {
     decided_at: now.toISOString(),
     decided_by: 'approval:not-run',
   };
+}
+
+function stderrWithExecutionError(stderr: string | undefined, error: unknown): string {
+  const base = stderr ?? '';
+  if (error === undefined) return base;
+
+  const message = errorMessageFromUnknown(error);
+  if (base.includes(message)) return base;
+
+  const executionError = `execution error: ${message}`;
+  return base ? `${base}\n${executionError}` : executionError;
 }
 
 /**
@@ -172,16 +187,18 @@ export async function loadAuditSink(
           exec: input.result
             ? {
                 stdout: input.result.stdout ?? '',
-                stderr: input.result.stderr ?? '',
+                // When resultToMcpContent rejects after the transport already
+                // returned an ExecResult, keep both the raw transport stderr and
+                // the mapped MCP error. Otherwise timeout/auth/host-key/
+                // transport/non-zero results become audit records that only say
+                // "a result existed" and lose the execution failure context.
+                stderr: stderrWithExecutionError(input.result.stderr, input.error),
                 exitCode: input.result.exitCode ?? null,
                 durationMs,
               }
             : {
                 stdout: '',
-                stderr:
-                  input.error instanceof Error
-                    ? input.error.message
-                    : String(input.error ?? 'unknown error'),
+                stderr: errorMessageFromUnknown(input.error),
                 exitCode: null,
                 durationMs,
               },

--- a/src/approval/audit-seam.ts
+++ b/src/approval/audit-seam.ts
@@ -93,8 +93,18 @@ export async function loadAuditSink(config: AuditSeamConfig = {}): Promise<Audit
   let mod: AuditModuleLike;
   try {
     mod = (await import(specifier)) as unknown as AuditModuleLike;
-  } catch {
-    return NO_OP_SINK; // ERR_MODULE_NOT_FOUND → audit module absent → no-op
+  } catch (err) {
+    // Only ERR_MODULE_NOT_FOUND is the expected "audit module absent" case
+    // (Decision D2 optional seam). Any other import failure — a syntax or
+    // runtime error inside a *present* audit module — is a real
+    // misconfiguration that would otherwise be silently indistinguishable
+    // from "not installed". Surface it before degrading to the no-op sink.
+    const code = (err as { code?: string })?.code;
+    if (code !== 'ERR_MODULE_NOT_FOUND') {
+      const message = (err as { message?: string })?.message ?? String(err);
+      console.error(`[ssh-mcp][audit-seam] audit module present but failed to load; auditing disabled: ${message}`);
+    }
+    return NO_OP_SINK; // audit module absent (or unusable) → no-op
   }
   if (!mod || typeof mod.AuditStore !== 'function') {
     return NO_OP_SINK;

--- a/src/approval/engine.ts
+++ b/src/approval/engine.ts
@@ -1,0 +1,168 @@
+/**
+ * Approval engine entry point.
+ *
+ * Resolves the effective mode (per-source override > global default) and
+ * dispatches to yolo / smart / manual. Returned ApprovalDecision is meant to
+ * be appended verbatim into the audit record's `approval` block.
+ */
+
+import { EventEmitter } from 'node:events';
+import {
+  ApprovalContext,
+  ApprovalDecision,
+  ApprovalEngine,
+  ApprovalMode,
+  ManualApprovalOptions,
+  PendingApproval,
+  SmartApprovalOptions,
+} from './types.js';
+import { YoloApproval } from './yolo.js';
+import { SmartApproval } from './smart.js';
+import { ManualApproval } from './manual.js';
+
+export interface BuildApprovalEngineOptions {
+  /** Default approval mode when a source has no [sources.approval] override. */
+  defaultMode: ApprovalMode;
+  /** Smart-mode config; required when defaultMode or any per-source override uses smart. */
+  smart?: SmartApprovalOptions;
+  /** Manual-mode config; required when defaultMode or any per-source override uses manual. */
+  manual?: ManualApprovalOptions;
+}
+
+/**
+ * Dispatch engine that owns one instance per mode. Lazy-builds per-mode
+ * engines so a yolo-only deployment never has to configure smart or manual.
+ */
+export class ApprovalDispatcher extends EventEmitter implements ApprovalEngine {
+  private readonly yolo = new YoloApproval();
+  private readonly smart?: SmartApproval;
+  private readonly manual?: ManualApproval;
+
+  constructor(private readonly opts: BuildApprovalEngineOptions) {
+    super();
+    if (opts.smart) {
+      this.smart = new SmartApproval(opts.smart);
+    }
+    if (opts.manual) {
+      // Construction itself enforces the WebUI-required invariant.
+      this.manual = new ManualApproval(opts.manual);
+      // Forward manual queue events through the dispatcher so the WebUI
+      // adapter can subscribe to one place regardless of effective mode.
+      this.manual.on('enqueue', (p: PendingApproval) => this.emit('enqueue', p));
+      this.manual.on('resolve', (p: PendingApproval, d: ApprovalDecision) =>
+        this.emit('resolve', p, d),
+      );
+    }
+    // Eager validate: default mode must have its engine wired.
+    this.requireEngineFor(opts.defaultMode);
+  }
+
+  private requireEngineFor(mode: ApprovalMode): ApprovalEngine {
+    switch (mode) {
+      case 'yolo':
+        return this.yolo;
+      case 'smart':
+        if (!this.smart) {
+          throw new Error(`approval mode "smart" requested but [approval.llm] is not configured`);
+        }
+        return this.smart;
+      case 'manual':
+        if (!this.manual) {
+          throw new Error(`approval mode "manual" requested but WebUI/manual options are not configured`);
+        }
+        return this.manual;
+      default: {
+        const exhaustive: never = mode;
+        throw new Error(`unknown approval mode: ${exhaustive}`);
+      }
+    }
+  }
+
+  async decide(ctx: ApprovalContext): Promise<ApprovalDecision> {
+    const effective = ctx.profile.approval?.mode ?? this.opts.defaultMode;
+    const engine = this.requireEngineFor(effective);
+    return engine.decide(ctx);
+  }
+
+  listPending(): PendingApproval[] {
+    return this.manual?.listPending() ?? [];
+  }
+
+  resolvePending(id: string, decision: 'allow' | 'deny', note?: string, decided_by?: string): boolean {
+    if (!this.manual) return false;
+    return this.manual.resolvePending(id, decision, note, decided_by);
+  }
+}
+
+/** Convenience builder mirroring dbhub's factory style. */
+export function buildApprovalEngine(opts: BuildApprovalEngineOptions): ApprovalDispatcher {
+  return new ApprovalDispatcher(opts);
+}
+
+/**
+ * Resolve TOML [approval] config into a concrete dispatcher.
+ *
+ * `manualOpts.webuiEnabled` carries the boot-time decision about whether the
+ * WebUI is going to be started — when manual mode is selected (default or per-
+ * source) and WebUI is off, ManualApproval's constructor will throw
+ * `ManualApprovalDisabledError`. That is the structural gate-12 invariant: do
+ * not loosen.
+ */
+export interface BuildEngineFromConfigInput {
+  defaultMode?: ApprovalMode;
+  fail_closed?: boolean;
+  llm?: {
+    endpoint?: string;
+    api_key?: string;
+    model?: string;
+    timeout_ms?: number;
+    provider?: 'openai' | string;
+  };
+  /** Used to decide whether to also construct a manual sub-engine for per-source overrides. */
+  perSourceModes?: ApprovalMode[];
+}
+
+export interface BuildEngineFromConfigOptions {
+  manualOpts: { webuiEnabled: boolean; timeout_ms?: number };
+  /** Test seam for SmartApproval. */
+  smartFetchImpl?: SmartApprovalOptions['fetchImpl'];
+}
+
+export function buildApprovalEngineFromConfig(
+  approval: BuildEngineFromConfigInput | undefined,
+  options: BuildEngineFromConfigOptions,
+): ApprovalDispatcher {
+  // Default mode mirrors TOML default ('manual' per ApprovalSection comment).
+  const defaultMode: ApprovalMode = approval?.defaultMode ?? 'yolo';
+  const perSource = approval?.perSourceModes ?? [];
+  const usedModes = new Set<ApprovalMode>([defaultMode, ...perSource]);
+
+  const built: BuildApprovalEngineOptions = { defaultMode };
+
+  if (usedModes.has('smart')) {
+    const llm = approval?.llm;
+    if (!llm?.endpoint || !llm?.model) {
+      throw new Error('approval mode "smart" requires [approval.llm].endpoint and .model');
+    }
+    built.smart = {
+      llm: {
+        endpoint: llm.endpoint,
+        api_key: llm.api_key,
+        model: llm.model,
+        timeout_ms: llm.timeout_ms,
+        provider: (llm.provider as 'openai' | 'anthropic' | 'azure' | undefined) ?? 'openai',
+      },
+      fail_closed: approval?.fail_closed !== false,
+      fetchImpl: options.smartFetchImpl,
+    };
+  }
+
+  if (usedModes.has('manual')) {
+    built.manual = {
+      webuiEnabled: options.manualOpts.webuiEnabled,
+      timeout_ms: options.manualOpts.timeout_ms,
+    };
+  }
+
+  return new ApprovalDispatcher(built);
+}

--- a/src/approval/engine.ts
+++ b/src/approval/engine.ts
@@ -133,7 +133,7 @@ export function buildApprovalEngineFromConfig(
   options: BuildEngineFromConfigOptions,
 ): ApprovalDispatcher {
   // Default mode mirrors TOML default ('manual' per ApprovalSection comment).
-  const defaultMode: ApprovalMode = approval?.defaultMode ?? 'yolo';
+  const defaultMode: ApprovalMode = approval?.defaultMode ?? 'manual';
   const perSource = approval?.perSourceModes ?? [];
   const usedModes = new Set<ApprovalMode>([defaultMode, ...perSource]);
 

--- a/src/approval/engine.ts
+++ b/src/approval/engine.ts
@@ -166,3 +166,44 @@ export function buildApprovalEngineFromConfig(
 
   return new ApprovalDispatcher(built);
 }
+
+/**
+ * Boot-time advisory for the manual-mode-without-a-resolver case.
+ *
+ * `manual` mode enqueues each command and waits for something to settle the
+ * queue (`resolvePending`) — in practice the WebUI manual-approval server. That
+ * server lands in the child lane `pr/webui-manual-approval`; the approval-engine
+ * lane ships the engine + queue primitive but wires no resolver. When this build
+ * boots `manual` mode with the WebUI enabled but no resolver present (i.e. the
+ * approval-engine lane merged standalone, ahead of its child lane), every
+ * pending approval sits in the queue until it times out and is denied.
+ *
+ * That is a legitimate stacked-PR state, NOT a fatal error (keep boot
+ * succeeding — do not throw). But it is otherwise silent, so surface a
+ * non-fatal warning. Returns the warning text when it should fire, or `null`
+ * when it should not:
+ *   - WebUI disabled: `manual` mode is already fatal-at-boot (gate-12
+ *     invariant, ManualApprovalDisabledError) — no warning needed here.
+ *   - resolver wired (child lane present): the queue is driven — no warning.
+ *   - `manual` mode not in use (yolo/smart only): nothing enqueues — no warning.
+ *
+ * `defaultMode` mirrors buildApprovalEngineFromConfig: an omitted default
+ * resolves to `manual`, so the bare-[approval] case is covered.
+ */
+export function manualWithoutResolverWarning(params: {
+  webuiEnabled: boolean;
+  defaultMode?: ApprovalMode;
+  perSourceModes?: ApprovalMode[];
+  resolverWired: boolean;
+}): string | null {
+  if (!params.webuiEnabled || params.resolverWired) return null;
+  const defaultMode: ApprovalMode = params.defaultMode ?? 'manual';
+  const usedModes = new Set<ApprovalMode>([defaultMode, ...(params.perSourceModes ?? [])]);
+  if (!usedModes.has('manual')) return null;
+  return (
+    'approval mode "manual" is active but no approval resolver is wired in this ' +
+    'build; pending approvals will time out until the WebUI manual-approval ' +
+    'server (pr/webui-manual-approval) is present. This is expected when the ' +
+    'approval-engine lane is used standalone ahead of its child lane.'
+  );
+}

--- a/src/approval/gate.ts
+++ b/src/approval/gate.ts
@@ -1,0 +1,72 @@
+/**
+ * Tool-handler integration glue.
+ *
+ * The exec / sudo-exec MCP tool handlers call `gateApproval` BEFORE
+ * transport.exec. If no engine has been set (legacy boot path that lands
+ * before toml-config wires this up), gateApproval is a no-op allow — keeping
+ * existing tests green.
+ *
+ * Once toml-config + audit-log cards land, the boot code will call
+ * `setApprovalEngine(engine)` and the audit store will read the decision
+ * via the returned ApprovalDecision passed back from `gateApproval`.
+ */
+
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ApprovalContext,
+  ApprovalDecision,
+  ApprovalEngine,
+  PendingApproval,
+} from './types.js';
+
+let activeEngine: ApprovalEngine | null = null;
+
+export function setApprovalEngine(engine: ApprovalEngine | null): void {
+  activeEngine = engine;
+}
+
+export function getApprovalEngine(): ApprovalEngine | null {
+  return activeEngine;
+}
+
+/**
+ * Run the engine for `ctx`. On deny, throws McpError(InvalidRequest) so the
+ * MCP client surfaces a clear refusal. On allow, returns the decision so the
+ * caller can stuff it into the audit record.
+ *
+ * If no engine is configured, returns a synthetic allow decision tagged
+ * `legacy:no-engine`. This keeps the legacy CLI boot path working.
+ */
+export async function gateApproval(ctx: ApprovalContext): Promise<ApprovalDecision> {
+  if (!activeEngine) {
+    return {
+      decision: 'allow',
+      reason: 'no approval engine configured (legacy boot path)',
+      decided_by: 'legacy:no-engine',
+      decided_at: new Date().toISOString(),
+      mode: 'yolo',
+    };
+  }
+  const decision = await activeEngine.decide(ctx);
+  if (decision.decision === 'deny') {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      `approval denied (${decision.mode}/${decision.decided_by}): ${decision.reason}`,
+    );
+  }
+  return decision;
+}
+
+/** Surface for the WebUI card. */
+export function listPendingApprovals(): PendingApproval[] {
+  return activeEngine?.listPending?.() ?? [];
+}
+
+export function resolvePendingApproval(
+  id: string,
+  decision: 'allow' | 'deny',
+  note?: string,
+  decided_by?: string,
+): boolean {
+  return activeEngine?.resolvePending?.(id, decision, note, decided_by) ?? false;
+}

--- a/src/approval/gate.ts
+++ b/src/approval/gate.ts
@@ -19,6 +19,10 @@ import {
   PendingApproval,
 } from './types.js';
 
+export interface ApprovalDeniedMcpError extends McpError {
+  approval?: ApprovalDecision;
+}
+
 let activeEngine: ApprovalEngine | null = null;
 
 export function setApprovalEngine(engine: ApprovalEngine | null): void {
@@ -27,6 +31,10 @@ export function setApprovalEngine(engine: ApprovalEngine | null): void {
 
 export function getApprovalEngine(): ApprovalEngine | null {
   return activeEngine;
+}
+
+export function getApprovalDecisionFromError(err: unknown): ApprovalDecision | undefined {
+  return (err as ApprovalDeniedMcpError | undefined)?.approval;
 }
 
 /**
@@ -49,10 +57,12 @@ export async function gateApproval(ctx: ApprovalContext): Promise<ApprovalDecisi
   }
   const decision = await activeEngine.decide(ctx);
   if (decision.decision === 'deny') {
-    throw new McpError(
+    const err = new McpError(
       ErrorCode.InvalidRequest,
       `approval denied (${decision.mode}/${decision.decided_by}): ${decision.reason}`,
-    );
+    ) as ApprovalDeniedMcpError;
+    err.approval = decision;
+    throw err;
   }
   return decision;
 }

--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -22,6 +22,7 @@ export {
   ApprovalDispatcher,
   buildApprovalEngine,
   buildApprovalEngineFromConfig,
+  manualWithoutResolverWarning,
   type BuildApprovalEngineOptions,
   type BuildEngineFromConfigInput,
   type BuildEngineFromConfigOptions,

--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Public barrel for the approval module. Tool handlers should import from
+ * here so the internal layout (yolo/smart/manual) can evolve without
+ * touching call sites.
+ */
+
+export type {
+  ApprovalMode,
+  ApprovalDecision,
+  ApprovalContext,
+  ApprovalEngine,
+  ResolvedSource,
+  SmartLlmConfig,
+  SmartApprovalOptions,
+  ManualApprovalOptions,
+  PendingApproval,
+} from './types.js';
+export { YoloApproval } from './yolo.js';
+export { SmartApproval } from './smart.js';
+export { ManualApproval, ManualApprovalDisabledError } from './manual.js';
+export {
+  ApprovalDispatcher,
+  buildApprovalEngine,
+  buildApprovalEngineFromConfig,
+  type BuildApprovalEngineOptions,
+  type BuildEngineFromConfigInput,
+  type BuildEngineFromConfigOptions,
+} from './engine.js';
+export {
+  setApprovalEngine,
+  getApprovalEngine,
+  gateApproval,
+  listPendingApprovals,
+  resolvePendingApproval,
+} from './gate.js';

--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -29,6 +29,7 @@ export {
 export {
   setApprovalEngine,
   getApprovalEngine,
+  getApprovalDecisionFromError,
   gateApproval,
   listPendingApprovals,
   resolvePendingApproval,

--- a/src/approval/manual.ts
+++ b/src/approval/manual.ts
@@ -108,6 +108,7 @@ export class ManualApproval extends EventEmitter implements ApprovalEngine {
         settle,
         timer,
         resolve: (decision, note, decided_by) => {
+          if (decision !== 'allow' && decision !== 'deny') return false;
           const live = this.pending.get(id);
           if (!live) return false;
           live.settle({
@@ -122,7 +123,12 @@ export class ManualApproval extends EventEmitter implements ApprovalEngine {
       };
       this.pending.set(id, entry);
       try {
-        this.emit('enqueue', { id, enqueued_at, context: ctx });
+        this.emit('enqueue', {
+          id,
+          enqueued_at,
+          context: ctx,
+          resolve: entry.resolve,
+        } satisfies PendingApproval);
       } catch { /* listener errors must not affect the gate */ }
     });
   }

--- a/src/approval/manual.ts
+++ b/src/approval/manual.ts
@@ -1,0 +1,141 @@
+/**
+ * manual mode: enqueue PendingApproval, await external resolve (typically a
+ * WebUI POST). The WebUI surface lives in a separate card; this module only
+ * cares about the queue and the resolve callback.
+ *
+ * Fatal-at-boot when WebUI is disabled — there's no UI to resolve the queue.
+ *
+ * The default timeout is 5 minutes; on timeout the queued entry is dropped
+ * and the decide() promise resolves with `decision: 'deny', reason: "approval
+ * timed out"`.
+ */
+
+import { EventEmitter } from 'node:events';
+import {
+  ApprovalContext,
+  ApprovalDecision,
+  ApprovalEngine,
+  ManualApprovalOptions,
+  PendingApproval,
+} from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
+
+// Crockford base32 alphabet (no I L O U) — ULID-compatible character set.
+const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/**
+ * Generate a 26-character ULID-like identifier without pulling in a dep.
+ * The 10-char timestamp prefix is genuine ULID; the 16-char random tail uses
+ * Math.random which is fine for in-process uniqueness (these ids only need
+ * to be unique within one server lifetime).
+ */
+function generateUlid(): string {
+  let now = Date.now();
+  let ts = '';
+  for (let i = 9; i >= 0; i--) {
+    ts = ULID_ALPHABET[now % 32] + ts;
+    now = Math.floor(now / 32);
+  }
+  let rand = '';
+  for (let i = 0; i < 16; i++) {
+    rand += ULID_ALPHABET[Math.floor(Math.random() * 32)];
+  }
+  return ts + rand;
+}
+
+interface QueueEntry extends PendingApproval {
+  settle: (decision: ApprovalDecision) => void;
+  timer: NodeJS.Timeout;
+}
+
+export class ManualApprovalDisabledError extends Error {
+  constructor(message = 'manual approval mode requires WebUI to be enabled — set [webui].enabled = true or pass --webui') {
+    super(message);
+    this.name = 'ManualApprovalDisabledError';
+  }
+}
+
+export class ManualApproval extends EventEmitter implements ApprovalEngine {
+  private readonly timeoutMs: number;
+  private readonly pending = new Map<string, QueueEntry>();
+
+  constructor(opts: ManualApprovalOptions) {
+    super();
+    if (!opts.webuiEnabled) {
+      throw new ManualApprovalDisabledError();
+    }
+    this.timeoutMs = opts.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  async decide(ctx: ApprovalContext): Promise<ApprovalDecision> {
+    return new Promise<ApprovalDecision>((resolve) => {
+      const id = generateUlid();
+      const enqueued_at = new Date().toISOString();
+
+      const settle = (decision: ApprovalDecision) => {
+        const entry = this.pending.get(id);
+        if (!entry) return;
+        clearTimeout(entry.timer);
+        this.pending.delete(id);
+        // Emit resolve event before settling the promise so SSE clients see
+        // the resolution before the caller's next tick observes the result.
+        try {
+          this.emit('resolve', { id, enqueued_at, context: ctx }, decision);
+        } catch { /* listener errors must not affect the gate */ }
+        resolve(decision);
+      };
+
+      const timer = setTimeout(() => {
+        settle({
+          decision: 'deny',
+          reason: 'approval timed out',
+          decided_by: 'manual:timeout',
+          decided_at: new Date().toISOString(),
+          mode: 'manual',
+        });
+      }, this.timeoutMs);
+      // Don't keep the event loop alive solely waiting on this timer.
+      if (typeof (timer as any).unref === 'function') (timer as any).unref();
+
+      const entry: QueueEntry = {
+        id,
+        enqueued_at,
+        context: ctx,
+        settle,
+        timer,
+        resolve: (decision, note, decided_by) => {
+          const live = this.pending.get(id);
+          if (!live) return false;
+          live.settle({
+            decision,
+            reason: note ?? (decision === 'allow' ? 'manually approved' : 'manually denied'),
+            decided_by: decided_by ?? 'manual:webui',
+            decided_at: new Date().toISOString(),
+            mode: 'manual',
+          });
+          return true;
+        },
+      };
+      this.pending.set(id, entry);
+      try {
+        this.emit('enqueue', { id, enqueued_at, context: ctx });
+      } catch { /* listener errors must not affect the gate */ }
+    });
+  }
+
+  listPending(): PendingApproval[] {
+    return Array.from(this.pending.values()).map(({ id, enqueued_at, context, resolve }) => ({
+      id,
+      enqueued_at,
+      context,
+      resolve,
+    }));
+  }
+
+  resolvePending(id: string, decision: 'allow' | 'deny', note?: string, decided_by?: string): boolean {
+    const entry = this.pending.get(id);
+    if (!entry) return false;
+    return entry.resolve(decision, note, decided_by);
+  }
+}

--- a/src/approval/manual.ts
+++ b/src/approval/manual.ts
@@ -11,6 +11,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { randomInt } from 'node:crypto';
 import {
   ApprovalContext,
   ApprovalDecision,
@@ -27,8 +28,10 @@ const ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 /**
  * Generate a 26-character ULID-like identifier without pulling in a dep.
  * The 10-char timestamp prefix is genuine ULID; the 16-char random tail uses
- * Math.random which is fine for in-process uniqueness (these ids only need
- * to be unique within one server lifetime).
+ * a cryptographically strong CSPRNG (node:crypto randomInt). These ids gate
+ * the WebUI resolve endpoint, so a predictable tail (e.g. Math.random) would
+ * let an attacker who can reach that endpoint guess pending ids and
+ * approve/deny commands — hence CSPRNG rather than Math.random.
  */
 function generateUlid(): string {
   let now = Date.now();
@@ -39,7 +42,7 @@ function generateUlid(): string {
   }
   let rand = '';
   for (let i = 0; i < 16; i++) {
-    rand += ULID_ALPHABET[Math.floor(Math.random() * 32)];
+    rand += ULID_ALPHABET[randomInt(32)];
   }
   return ts + rand;
 }

--- a/src/approval/redactor.ts
+++ b/src/approval/redactor.ts
@@ -1,0 +1,132 @@
+/**
+ * Provider-bound approval context redactor.
+ *
+ * Smart approval can call an operator-configured external LLM, so command and
+ * intent text must be scrubbed before either value leaves the process. Rules
+ * are deliberately conservative: losing a little context is safer than
+ * transmitting a credential. This does not mutate the command that is later
+ * executed after approval.
+ */
+
+const REDACTED = '<redacted>';
+const SECRET_FLAG = String.raw`(?:password|passwd|passphrase|pass|secret|token|api[-_]?key|access[-_]?key|client[-_]?secret|auth[-_]?token|bearer)`;
+const SECRET_KEY = String.raw`[A-Za-z0-9_.-]*(?:password|passwd|passphrase|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[A-Za-z0-9_.-]*`;
+const SHELL_SECRET_KEY = String.raw`[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|PASSPHRASE|SECRET|TOKEN|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET)[A-Z0-9_]*`;
+const DQ_VALUE = String.raw`"(?:[^"\\]|\\.)*"`;
+const SQ_VALUE = String.raw`'(?:[^'\\]|\\.)*'`;
+const OPEN_DQ_VALUE = String.raw`"(?:[^"\\]|\\.)*$`;
+const OPEN_SQ_VALUE = String.raw`'(?:[^'\\]|\\.)*$`;
+
+interface RedactionRule {
+  re: RegExp;
+  replace: string | ((substring: string, ...groups: string[]) => string);
+}
+
+const RULES: RedactionRule[] = [
+  // Long CLI flags, both --token=value and --token value. Open-quoted rules
+  // run first so malformed/truncated commands cannot leak the quoted suffix.
+  {
+    re: new RegExp(String.raw`(--${SECRET_FLAG}\s*=)\s*(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`, 'gi'),
+    replace: (_match, key) => `${key}${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`(--${SECRET_FLAG}\s*=)\s*(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`, 'gi'),
+    replace: (_match, key) => `${key}${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`(--${SECRET_FLAG})\s+(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`, 'gi'),
+    replace: (_match, key) => `${key} ${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`(--${SECRET_FLAG})\s+(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`, 'gi'),
+    replace: (_match, key) => `${key} ${REDACTED}`,
+  },
+
+  // MySQL/MariaDB -p password forms (space-separated, attached, and quoted).
+  {
+    re: new RegExp(String.raw`(^|\s)(-p)\s+(?:${DQ_VALUE}|${SQ_VALUE}|[^\s]+)`, 'g'),
+    replace: (_match, lead, flag) => `${lead}${flag} ${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`(^|\s)-p(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`, 'g'),
+    replace: (_match, lead) => `${lead}-p${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`(^|\s)-p(${DQ_VALUE}|${SQ_VALUE})`, 'g'),
+    replace: (_match, lead, value) => `${lead}-p${value[0]}${REDACTED}${value[0]}`,
+  },
+  {
+    re: /(^|\s)("-p(?:[^"\\]|\\.)*"|'-p(?:[^'\\]|\\.)*')/g,
+    replace: (_match, lead, argument) => `${lead}${argument[0]}-p${REDACTED}${argument[0]}`,
+  },
+  {
+    re: /(^|\s)(["']?)-p([^\s"']+)(\2)/g,
+    replace: (_match, lead, quote) => `${lead}${quote}-p${REDACTED}${quote}`,
+  },
+
+  // HTTP authorization headers and URL userinfo credentials.
+  {
+    re: /(Authorization\s*:\s*)(Bearer|Basic|Token)\s+([A-Za-z0-9_~\-.=+\/]+)/gi,
+    replace: (_match, header, scheme) => `${header}${scheme} ${REDACTED}`,
+  },
+  {
+    re: /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s:/@]+:)([^\s/@]+)(@)/g,
+    replace: (_match, prefix, _password, at) => `${prefix}${REDACTED}${at}`,
+  },
+
+  // Shell env assignments, JSON/TOML key-value fields, and simple prose.
+  {
+    re: new RegExp(String.raw`\b(${SHELL_SECRET_KEY}=)\s*(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`, 'g'),
+    replace: (_match, key) => `${key}${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`\b(${SHELL_SECRET_KEY}=)(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`, 'g'),
+    replace: (_match, key) => `${key}${REDACTED}`,
+  },
+  {
+    re: /("[^"\\]*(?:password|passwd|passphrase|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*$/gi,
+    replace: (_match, prefix) => `${prefix}"${REDACTED}"`,
+  },
+  {
+    re: /("[^"\\]*(?:password|passwd|passphrase|secret|token|api[-_]?key|access[-_]?key|private[-_]?key|client[-_]?secret|auth[-_]?token)[^"\\]*"\s*[:=]\s*)"(?:[^"\\]|\\.)*"/gi,
+    replace: (_match, prefix) => `${prefix}"${REDACTED}"`,
+  },
+  {
+    re: new RegExp(String.raw`\b(${SECRET_KEY}\s*[:=]\s*)(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`, 'gi'),
+    replace: (_match, prefix) => `${prefix}${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`\b(${SECRET_KEY}\s*[:=]\s*)(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`, 'gi'),
+    replace: (_match, prefix) => `${prefix}${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`\b(password|passwd|passphrase|secret|token)\s+(?:${OPEN_DQ_VALUE}|${OPEN_SQ_VALUE})`, 'gi'),
+    replace: (_match, word) => `${word} ${REDACTED}`,
+  },
+  {
+    re: new RegExp(String.raw`\b(password|passwd|passphrase|secret|token)\s+(?:${DQ_VALUE}|${SQ_VALUE}|\S+)`, 'gi'),
+    replace: (_match, word) => `${word} ${REDACTED}`,
+  },
+
+  // Standalone high-confidence credential shapes and private keys.
+  { re: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----/g, replace: REDACTED },
+  { re: /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*$/g, replace: REDACTED },
+  { re: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, replace: REDACTED },
+  {
+    re: /(aws[_-]?secret[_-]?access[_-]?key\s*[:=]?\s*["']?)([A-Za-z0-9/+]{40})(["']?)/gi,
+    replace: (_match, prefix, _value, suffix) => `${prefix}${REDACTED}${suffix}`,
+  },
+  { re: /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, replace: REDACTED },
+  { re: /\b(?:gh[opusr]_[A-Za-z0-9]{20,255}|github_pat_[A-Za-z0-9_]{40,255})\b/g, replace: REDACTED },
+  { re: /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/g, replace: REDACTED },
+  { re: /\bAIza[0-9A-Za-z_-]{35}\b/g, replace: REDACTED },
+];
+
+export function redactApprovalText(input: string | undefined): string {
+  if (!input) return '';
+  let output = input;
+  for (const rule of RULES) {
+    output = output.replace(rule.re, rule.replace as any);
+  }
+  return output;
+}

--- a/src/approval/smart.ts
+++ b/src/approval/smart.ts
@@ -1,0 +1,193 @@
+/**
+ * smart mode: ask a configured LLM endpoint whether a command should be
+ * allowed. Default schema follows OpenAI chat-completions; alternative
+ * providers can be added behind the `provider` field on SmartLlmConfig.
+ *
+ * Fail-closed semantics:
+ *   - HTTP non-200, timeout, malformed JSON, or missing `allow` field
+ *     -> deny when fail_closed=true (default), else allow with warning.
+ *
+ * The fetch implementation is dependency-injected via SmartApprovalOptions so
+ * tests can stub it without monkey-patching the global.
+ */
+
+import {
+  ApprovalContext,
+  ApprovalDecision,
+  ApprovalEngine,
+  SmartApprovalOptions,
+} from './types.js';
+
+interface LlmJudgement {
+  allow: boolean;
+  reason: string;
+}
+
+/**
+ * Parse the LLM response body and extract a {allow, reason} judgement.
+ * Throws when the structure is unusable; the caller maps that to a
+ * fail-closed deny (or fail-open allow with warning).
+ */
+function parseOpenAiResponse(raw: string): LlmJudgement {
+  const root = JSON.parse(raw);
+  const content: unknown = root?.choices?.[0]?.message?.content;
+  if (typeof content !== 'string') {
+    throw new Error('LLM response missing choices[0].message.content string');
+  }
+
+  // The content itself should be JSON {allow, reason}. We tolerate fenced
+  // code blocks (``` ... ```) and stray whitespace by grabbing the first
+  // {...} block in the string.
+  const match = content.match(/\{[\s\S]*\}/);
+  if (!match) {
+    throw new Error('LLM content has no JSON object');
+  }
+  const judgement = JSON.parse(match[0]);
+  if (typeof judgement.allow !== 'boolean') {
+    throw new Error('LLM JSON missing boolean `allow`');
+  }
+  const reason = typeof judgement.reason === 'string' ? judgement.reason : '';
+  return { allow: judgement.allow, reason };
+}
+
+const SYSTEM_PROMPT = [
+  'You are a security gatekeeper for an SSH command executor.',
+  'Decide whether the proposed command is safe to run on the described host.',
+  'Reply with ONLY a single JSON object of the shape {"allow": true|false, "reason": "..."}.',
+  'Deny destructive operations (rm -rf, dd, mkfs, shutdown, user/credential changes) unless the host description explicitly authorises them.',
+].join(' ');
+
+function buildUserPrompt(ctx: ApprovalContext): string {
+  const profileBlock = ctx.profile.description
+    ? `Profile: ${ctx.profile.id}\nDescription: ${ctx.profile.description}`
+    : `Profile: ${ctx.profile.id}`;
+  const descBlock = ctx.description ? `\nCommand intent: ${ctx.description}` : '';
+  return [
+    profileBlock,
+    `Tool: ${ctx.tool}`,
+    `Command:\n${ctx.command}${descBlock}`,
+    'Respond with the JSON object only.',
+  ].join('\n\n');
+}
+
+export class SmartApproval implements ApprovalEngine {
+  constructor(private readonly opts: SmartApprovalOptions) {
+    if (!opts.llm?.endpoint) {
+      throw new Error('smart approval mode requires [approval.llm].endpoint');
+    }
+    if (!opts.llm?.model) {
+      throw new Error('smart approval mode requires [approval.llm].model');
+    }
+  }
+
+  async decide(ctx: ApprovalContext): Promise<ApprovalDecision> {
+    const fail_closed = this.opts.fail_closed !== false; // default true
+    const timeoutMs = this.opts.llm.timeout_ms ?? 8000;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    const body = JSON.stringify({
+      model: this.opts.llm.model,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: buildUserPrompt(ctx) },
+      ],
+      temperature: 0,
+      response_format: { type: 'json_object' },
+    });
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.opts.llm.api_key) {
+      headers['Authorization'] = `Bearer ${this.opts.llm.api_key}`;
+    }
+
+    const fetchImpl = this.opts.fetchImpl ?? (globalThis.fetch as any);
+    if (!fetchImpl) {
+      return this.failClosedDecision(
+        fail_closed,
+        'smart approval: no fetch implementation available',
+        'smart-llm:no-fetch',
+      );
+    }
+
+    let response: { ok: boolean; status: number; text: () => Promise<string> };
+    try {
+      response = await fetchImpl(this.opts.llm.endpoint, {
+        method: 'POST',
+        headers,
+        body,
+        signal: controller.signal,
+      });
+    } catch (err: any) {
+      clearTimeout(timer);
+      const aborted = err?.name === 'AbortError' || /aborted/i.test(String(err?.message ?? ''));
+      const reason = aborted
+        ? `smart approval: LLM request timed out after ${timeoutMs}ms`
+        : `smart approval: LLM request failed: ${err?.message ?? err}`;
+      return this.failClosedDecision(fail_closed, reason, 'smart-llm:transport-error');
+    }
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const reason = `smart approval: LLM returned HTTP ${response.status}`;
+      return this.failClosedDecision(fail_closed, reason, `smart-llm:http-${response.status}`);
+    }
+
+    let raw: string;
+    try {
+      raw = await response.text();
+    } catch (err: any) {
+      return this.failClosedDecision(
+        fail_closed,
+        `smart approval: failed to read LLM body: ${err?.message ?? err}`,
+        'smart-llm:read-error',
+      );
+    }
+
+    let judgement: LlmJudgement;
+    try {
+      judgement = parseOpenAiResponse(raw);
+    } catch (err: any) {
+      return this.failClosedDecision(
+        fail_closed,
+        `smart approval: malformed LLM JSON: ${err?.message ?? err}`,
+        'smart-llm:malformed-json',
+      );
+    }
+
+    return {
+      decision: judgement.allow ? 'allow' : 'deny',
+      reason: judgement.reason || (judgement.allow ? 'LLM allowed' : 'LLM denied'),
+      decided_by: 'smart-llm',
+      decided_at: new Date().toISOString(),
+      mode: 'smart',
+    };
+  }
+
+  private failClosedDecision(
+    fail_closed: boolean,
+    reason: string,
+    decided_by: string,
+  ): ApprovalDecision {
+    if (fail_closed) {
+      return {
+        decision: 'deny',
+        reason,
+        decided_by,
+        decided_at: new Date().toISOString(),
+        mode: 'smart',
+      };
+    }
+    // fail-open: warn loudly so operators see this in stderr, then allow.
+    console.warn(`[ssh-mcp][smart-approval] fail-open allow: ${reason}`);
+    return {
+      decision: 'allow',
+      reason: `${reason} (fail_closed=false; allowed with warning)`,
+      decided_by,
+      decided_at: new Date().toISOString(),
+      mode: 'smart',
+    };
+  }
+}

--- a/src/approval/smart.ts
+++ b/src/approval/smart.ts
@@ -17,6 +17,7 @@ import {
   ApprovalEngine,
   SmartApprovalOptions,
 } from './types.js';
+import { redactApprovalText } from './redactor.js';
 
 interface LlmJudgement {
   allow: boolean;
@@ -61,11 +62,13 @@ function buildUserPrompt(ctx: ApprovalContext): string {
   const profileBlock = ctx.profile.description
     ? `Profile: ${ctx.profile.id}\nDescription: ${ctx.profile.description}`
     : `Profile: ${ctx.profile.id}`;
-  const descBlock = ctx.description ? `\nCommand intent: ${ctx.description}` : '';
+  const command = redactApprovalText(ctx.command);
+  const description = redactApprovalText(ctx.description);
+  const descBlock = description ? `\nCommand intent: ${description}` : '';
   return [
     profileBlock,
     `Tool: ${ctx.tool}`,
-    `Command:\n${ctx.command}${descBlock}`,
+    `Command:\n${command}${descBlock}`,
     'Respond with the JSON object only.',
   ].join('\n\n');
 }
@@ -86,6 +89,15 @@ export class SmartApproval implements ApprovalEngine {
 
   async decide(ctx: ApprovalContext): Promise<ApprovalDecision> {
     const fail_closed = this.opts.fail_closed !== false; // default true
+    const fetchImpl = this.opts.fetchImpl ?? (globalThis.fetch as any);
+    if (!fetchImpl) {
+      return this.failClosedDecision(
+        fail_closed,
+        'smart approval: no fetch implementation available',
+        'smart-llm:no-fetch',
+      );
+    }
+
     const timeoutMs = this.opts.llm.timeout_ms ?? 8000;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -105,15 +117,6 @@ export class SmartApproval implements ApprovalEngine {
     };
     if (this.opts.llm.api_key) {
       headers['Authorization'] = `Bearer ${this.opts.llm.api_key}`;
-    }
-
-    const fetchImpl = this.opts.fetchImpl ?? (globalThis.fetch as any);
-    if (!fetchImpl) {
-      return this.failClosedDecision(
-        fail_closed,
-        'smart approval: no fetch implementation available',
-        'smart-llm:no-fetch',
-      );
     }
 
     let phase: 'request' | 'body' = 'request';

--- a/src/approval/smart.ts
+++ b/src/approval/smart.ts
@@ -72,6 +72,10 @@ function buildUserPrompt(ctx: ApprovalContext): string {
 
 export class SmartApproval implements ApprovalEngine {
   constructor(private readonly opts: SmartApprovalOptions) {
+    const provider = opts.llm?.provider ?? 'openai';
+    if (provider !== 'openai') {
+      throw new Error(`smart approval provider "${provider}" is not supported; use "openai"`);
+    }
     if (!opts.llm?.endpoint) {
       throw new Error('smart approval mode requires [approval.llm].endpoint');
     }

--- a/src/approval/smart.ts
+++ b/src/approval/smart.ts
@@ -112,38 +112,46 @@ export class SmartApproval implements ApprovalEngine {
       );
     }
 
-    let response: { ok: boolean; status: number; text: () => Promise<string> };
+    let phase: 'request' | 'body' = 'request';
+    let raw: string;
     try {
-      response = await fetchImpl(this.opts.llm.endpoint, {
+      const response: { ok: boolean; status: number; text: () => Promise<string> } = await fetchImpl(this.opts.llm.endpoint, {
         method: 'POST',
         headers,
         body,
         signal: controller.signal,
       });
-    } catch (err: any) {
-      clearTimeout(timer);
-      const aborted = err?.name === 'AbortError' || /aborted/i.test(String(err?.message ?? ''));
-      const reason = aborted
-        ? `smart approval: LLM request timed out after ${timeoutMs}ms`
-        : `smart approval: LLM request failed: ${err?.message ?? err}`;
-      return this.failClosedDecision(fail_closed, reason, 'smart-llm:transport-error');
-    }
-    clearTimeout(timer);
 
-    if (!response.ok) {
-      const reason = `smart approval: LLM returned HTTP ${response.status}`;
-      return this.failClosedDecision(fail_closed, reason, `smart-llm:http-${response.status}`);
-    }
+      if (!response.ok) {
+        const reason = `smart approval: LLM returned HTTP ${response.status}`;
+        return this.failClosedDecision(fail_closed, reason, `smart-llm:http-${response.status}`);
+      }
 
-    let raw: string;
-    try {
+      phase = 'body';
       raw = await response.text();
     } catch (err: any) {
+      const aborted = err?.name === 'AbortError' || /aborted/i.test(String(err?.message ?? ''));
+      if (aborted) {
+        return this.failClosedDecision(
+          fail_closed,
+          `smart approval: LLM request timed out after ${timeoutMs}ms`,
+          'smart-llm:timeout',
+        );
+      }
+      if (phase === 'request') {
+        return this.failClosedDecision(
+          fail_closed,
+          `smart approval: LLM request failed: ${err?.message ?? err}`,
+          'smart-llm:transport-error',
+        );
+      }
       return this.failClosedDecision(
         fail_closed,
         `smart approval: failed to read LLM body: ${err?.message ?? err}`,
         'smart-llm:read-error',
       );
+    } finally {
+      clearTimeout(timer);
     }
 
     let judgement: LlmJudgement;

--- a/src/approval/types.ts
+++ b/src/approval/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Approval engine types — mode dispatch, decisions, and per-source overrides.
+ *
+ * This module is intentionally self-contained so the approval-engine card can
+ * land before toml-config / audit-log. The reviewer will reconcile
+ * ResolvedSource / AuditRecord shapes once those cards merge.
+ */
+
+export type ApprovalMode = 'yolo' | 'smart' | 'manual';
+
+export type ApprovalDecision =
+  | { decision: 'allow'; reason: string; decided_by: string; decided_at: string; mode: ApprovalMode }
+  | { decision: 'deny'; reason: string; decided_by: string; decided_at: string; mode: ApprovalMode };
+
+/**
+ * Minimal shape of a resolved SSH source/profile used by the approval engine.
+ * Once toml-config lands, this should be re-exported from src/config/types.ts.
+ */
+export interface ResolvedSource {
+  id: string;
+  description?: string;
+  approval?: {
+    mode?: ApprovalMode;
+  };
+}
+
+/**
+ * Context handed to ApprovalEngine.decide() for every exec / sudo-exec call.
+ */
+export interface ApprovalContext {
+  profile: ResolvedSource;
+  tool: 'exec' | 'sudo-exec';
+  command: string;       // sanitized, post-redact for visible value
+  description?: string;  // verbatim from MCP arg
+}
+
+/**
+ * LLM endpoint configuration for `smart` mode.
+ * Defaults to the OpenAI chat-completions schema; provider is reserved for
+ * future Anthropic / Azure shapes.
+ */
+export interface SmartLlmConfig {
+  provider?: 'openai' | 'anthropic' | 'azure';
+  endpoint: string;
+  api_key?: string;
+  model: string;
+  timeout_ms?: number;   // default 8000
+}
+
+export interface SmartApprovalOptions {
+  llm: SmartLlmConfig;
+  fail_closed?: boolean;  // default true
+  /**
+   * Test seam: dependency-injectable fetch implementation. Defaults to the
+   * global `fetch`. The signature is intentionally narrowed to the bits we use
+   * so test stubs don't need to satisfy the full DOM Fetch type.
+   */
+  fetchImpl?: (input: string, init: { method: string; headers: Record<string, string>; body: string; signal?: AbortSignal }) => Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>;
+}
+
+export interface ManualApprovalOptions {
+  timeout_ms?: number;   // default 5 minutes
+  webuiEnabled: boolean; // when false, manual mode throws at construction time
+}
+
+/**
+ * A pending manual approval request. WebUI surface (separate card) lists these
+ * and posts allow/deny back via `resolve()`.
+ */
+export interface PendingApproval {
+  id: string;
+  enqueued_at: string;
+  context: ApprovalContext;
+  /** Resolve from outside (WebUI POST handler). Returns true if the resolve
+   * was applied; false if the request had already timed out or been resolved. */
+  resolve: (decision: 'allow' | 'deny', note?: string, decided_by?: string) => boolean;
+}
+
+export interface ApprovalEngine {
+  /** Decide whether to allow the command. Never throws on policy decisions;
+   * the caller throws McpError on `deny`. Throws on misconfiguration. */
+  decide(ctx: ApprovalContext): Promise<ApprovalDecision>;
+  /** Snapshot of pending manual approvals (empty for yolo/smart). */
+  listPending?(): PendingApproval[];
+  /** External resolve hook for manual mode (used by WebUI). */
+  resolvePending?(id: string, decision: 'allow' | 'deny', note?: string, decided_by?: string): boolean;
+}

--- a/src/approval/yolo.ts
+++ b/src/approval/yolo.ts
@@ -1,0 +1,17 @@
+/**
+ * yolo mode: always allow. Useful for local dev or trusted hosts.
+ */
+
+import { ApprovalContext, ApprovalDecision, ApprovalEngine } from './types.js';
+
+export class YoloApproval implements ApprovalEngine {
+  async decide(_ctx: ApprovalContext): Promise<ApprovalDecision> {
+    return {
+      decision: 'allow',
+      reason: 'yolo mode: all commands auto-approved',
+      decided_by: 'yolo',
+      decided_at: new Date().toISOString(),
+      mode: 'yolo',
+    };
+  }
+}

--- a/src/config/__tests__/resolver.test.ts
+++ b/src/config/__tests__/resolver.test.ts
@@ -86,6 +86,40 @@ auth = "kerberos"
     expect(cfg.configPath).toBe(p);
   });
 
+  it('CLI source + a TOML with ONLY top-level sections (no [[sources]]) resolves', () => {
+    // R1 finding 1: the resolver doc-comment promises "legacy flags AND a TOML
+    // just for [webui]". A --config TOML carrying no [[sources]] must not throw
+    // when CLI sources are present; it should keep the CLI source and expose
+    // the top-level sections.
+    const p = writeToml(tmp, 'webui-only.toml', `
+[webui]
+enabled = true
+host = "127.0.0.1"
+port = 9099
+
+[server]
+audit_dir = "~/audit-only"
+`);
+    const cfg = resolveConfig({ cliSources: [cliSource('cli')], cliConfigPath: p, env: {} });
+    expect(cfg.sources.map(s => s.name)).toEqual(['cli']);
+    expect(cfg.defaultName).toBe('cli');
+    expect(cfg.webui?.enabled).toBe(true);
+    expect(cfg.webui?.port).toBe(9099);
+    expect(cfg.server?.audit_dir).toContain('audit-only');
+    expect(cfg.configPath).toBe(p);
+  });
+
+  it('still rejects a TOML with no [[sources]] when there are NO CLI sources', () => {
+    // Without CLI sources the empty-sources tolerance must NOT apply — an
+    // otherwise-empty config is a user error.
+    const p = writeToml(tmp, 'empty.toml', `
+[webui]
+enabled = true
+`);
+    expect(() => resolveConfig({ cliSources: [], cliConfigPath: p, env: {} }))
+      .toThrow(/at least one \[\[sources\]\]/);
+  });
+
   it('--config wins over SSH_MCP_CONFIG when no CLI sources exist', () => {
     const explicit = writeToml(tmp, 'explicit.toml', `
 [[sources]]

--- a/src/config/__tests__/resolver.test.ts
+++ b/src/config/__tests__/resolver.test.ts
@@ -164,6 +164,57 @@ auth = "kerberos"
     expect(cfg.configPath).toBe(envPath);
   });
 
+  it('a set-but-missing SSH_MCP_CONFIG falls through to XDG discovery instead of hard-failing', () => {
+    // R2 Copilot finding: resolveConfig must honor the discovery contract from
+    // toml-loader (SSH_MCP_CONFIG is the highest-precedence *candidate*, and a
+    // missing candidate falls through). Reading env.SSH_MCP_CONFIG directly
+    // made a missing path throw in loadTomlFile; the fix routes env handling
+    // through discoverConfigPath so a missing SSH_MCP_CONFIG cleanly falls back.
+    const xdgRoot = path.join(tmp, 'xdg');
+    const xdgPath = writeToml(xdgRoot, 'ssh-mcp/config.toml', `
+[[sources]]
+id = "xdg"
+host = "xdg.example"
+user = "u"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({
+      cliSources: [],
+      env: {
+        SSH_MCP_CONFIG: path.join(tmp, 'does-not-exist.toml'),
+        XDG_CONFIG_HOME: xdgRoot,
+      },
+    });
+    expect(cfg.sources[0].name).toBe('xdg');
+    expect(cfg.configPath).toBe(xdgPath);
+  });
+
+  it('SSH_MCP_CONFIG still wins over XDG when the env path exists', () => {
+    // Precedence within discovery is preserved: an existing SSH_MCP_CONFIG is
+    // probed before the XDG/home candidates.
+    const envPath = writeToml(tmp, 'env-win.toml', `
+[[sources]]
+id = "env"
+host = "env.example"
+user = "u"
+auth = "kerberos"
+`);
+    const xdgRoot = path.join(tmp, 'xdg-lose');
+    writeToml(xdgRoot, 'ssh-mcp/config.toml', `
+[[sources]]
+id = "xdg"
+host = "xdg.example"
+user = "u"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({
+      cliSources: [],
+      env: { SSH_MCP_CONFIG: envPath, XDG_CONFIG_HOME: xdgRoot },
+    });
+    expect(cfg.sources[0].name).toBe('env');
+    expect(cfg.configPath).toBe(envPath);
+  });
+
   it('discovers $XDG_CONFIG_HOME/ssh-mcp/config.toml before ~/.ssh-mcp/config.toml', () => {
     const xdgRoot = path.join(tmp, 'xdg');
     const xdgPath = writeToml(xdgRoot, 'ssh-mcp/config.toml', `

--- a/src/config/__tests__/resolver.test.ts
+++ b/src/config/__tests__/resolver.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveConfig } from '../resolver.js';
+import type { ServerConfig } from '../../transports/types.js';
+
+function cliSource(name = 'cli'): ServerConfig {
+  return {
+    name,
+    host: `${name}.example`,
+    port: 22,
+    username: 'cli-user',
+    authMode: 'kerberos',
+    kerberos: true,
+    transport: 'openssh',
+  };
+}
+
+function writeToml(dir: string, name: string, body: string): string {
+  const file = path.join(dir, name);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, body);
+  return file;
+}
+
+const basicToml = `
+[[sources]]
+id = "toml"
+host = "toml.example"
+user = "toml-user"
+auth = "kerberos"
+default = true
+`;
+
+describe('resolveConfig precedence', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-resolver-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns CLI sources when provided and no TOML exists', () => {
+    const cfg = resolveConfig({ cliSources: [cliSource('a'), cliSource('b')], env: {} });
+    expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
+    expect(cfg.defaultName).toBe('a');
+    expect(cfg.configPath).toBeUndefined();
+  });
+
+  it('loads --config TOML when no CLI sources exist', () => {
+    const p = writeToml(tmp, 'explicit.toml', basicToml);
+    const cfg = resolveConfig({ cliSources: [], cliConfigPath: p, env: {} });
+    expect(cfg.sources).toHaveLength(1);
+    expect(cfg.sources[0]).toMatchObject({
+      name: 'toml',
+      host: 'toml.example',
+      username: 'toml-user',
+      transport: 'openssh',
+    });
+    expect(cfg.defaultName).toBe('toml');
+    expect(cfg.configPath).toBe(p);
+  });
+
+  it('CLI > TOML: CLI sources suppress TOML sources but keep top-level TOML sections', () => {
+    const p = writeToml(tmp, 'explicit.toml', `
+[server]
+audit_dir = "~/audit-test"
+
+[[sources]]
+id = "toml"
+host = "toml.example"
+user = "toml-user"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({ cliSources: [cliSource('cli')], cliConfigPath: p, env: {} });
+    expect(cfg.sources).toHaveLength(1);
+    expect(cfg.sources[0].name).toBe('cli');
+    expect(cfg.sources[0].host).toBe('cli.example');
+    expect(cfg.defaultName).toBe('cli');
+    expect(cfg.server?.audit_dir).toContain('audit-test');
+    expect(cfg.configPath).toBe(p);
+  });
+
+  it('--config wins over SSH_MCP_CONFIG when no CLI sources exist', () => {
+    const explicit = writeToml(tmp, 'explicit.toml', `
+[[sources]]
+id = "explicit"
+host = "explicit.example"
+user = "u"
+auth = "kerberos"
+`);
+    const envPath = writeToml(tmp, 'from-env.toml', `
+[[sources]]
+id = "env"
+host = "env.example"
+user = "u"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({ cliSources: [], cliConfigPath: explicit, env: { SSH_MCP_CONFIG: envPath } });
+    expect(cfg.sources[0].name).toBe('explicit');
+    expect(cfg.configPath).toBe(explicit);
+  });
+
+  it('SSH_MCP_CONFIG is used when --config is absent', () => {
+    const envPath = writeToml(tmp, 'from-env.toml', `
+[[sources]]
+id = "env"
+host = "env.example"
+user = "u"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({ cliSources: [], env: { SSH_MCP_CONFIG: envPath } });
+    expect(cfg.sources[0].name).toBe('env');
+    expect(cfg.configPath).toBe(envPath);
+  });
+
+  it('discovers $XDG_CONFIG_HOME/ssh-mcp/config.toml before ~/.ssh-mcp/config.toml', () => {
+    const xdgRoot = path.join(tmp, 'xdg');
+    const xdgPath = writeToml(xdgRoot, 'ssh-mcp/config.toml', `
+[[sources]]
+id = "xdg"
+host = "xdg.example"
+user = "u"
+auth = "kerberos"
+`);
+
+    // We cannot safely fake os.homedir() here, but setting XDG_CONFIG_HOME
+    // exercises the documented discovery path and avoids touching real home.
+    const cfg = resolveConfig({ cliSources: [], env: { XDG_CONFIG_HOME: xdgRoot } });
+    expect(cfg.sources[0].name).toBe('xdg');
+    expect(cfg.configPath).toBe(xdgPath);
+  });
+
+  it('returns an empty source list when neither CLI nor TOML exists', () => {
+    const cfg = resolveConfig({ cliSources: [], env: { XDG_CONFIG_HOME: path.join(tmp, 'none') } });
+    expect(cfg.sources).toEqual([]);
+    expect(cfg.defaultName).toBeUndefined();
+    expect(cfg.configPath).toBeUndefined();
+  });
+
+  it('propagates TOML validation errors', () => {
+    const bad = writeToml(tmp, 'bad.toml', `not valid =`);
+    expect(() => resolveConfig({ cliSources: [], cliConfigPath: bad, env: {} })).toThrow(/parse failed/);
+  });
+});

--- a/src/config/__tests__/resolver.test.ts
+++ b/src/config/__tests__/resolver.test.ts
@@ -244,6 +244,42 @@ auth = "kerberos"
     const bad = writeToml(tmp, 'bad.toml', `not valid =`);
     expect(() => resolveConfig({ cliSources: [], cliConfigPath: bad, env: {} })).toThrow(/parse failed/);
   });
+
+  it('CLI sources suppress a TOML [[sources]] whose secret env ref is unset, without aborting startup (R2)', () => {
+    // R2 Codex finding: when CLI sources win, the resolver discards
+    // fromToml.sources downstream, so it must NOT fully validate/resolve the
+    // suppressed [[sources]]. A suppressed source with an unset
+    // `password = "env:PROD_PASS"` must not fail startup — only the top-level
+    // sections survive.
+    const p = writeToml(tmp, 'suppressed-secret.toml', `
+[[sources]]
+id = "prod"
+host = "prod.example"
+user = "u"
+auth = "password"
+password = "env:PROD_PASS_UNSET"
+
+[server]
+audit_dir = "~/audit-suppressed"
+`);
+    const cfg = resolveConfig({ cliSources: [cliSource('cli')], cliConfigPath: p, env: {} });
+    expect(cfg.sources.map(s => s.name)).toEqual(['cli']);
+    expect(cfg.server?.audit_dir).toContain('audit-suppressed');
+    expect(cfg.configPath).toBe(p);
+  });
+
+  it('still validates TOML [[sources]] secrets when there are NO CLI sources (R2 negative)', () => {
+    const p = writeToml(tmp, 'active-secret.toml', `
+[[sources]]
+id = "prod"
+host = "prod.example"
+user = "u"
+auth = "password"
+password = "env:PROD_PASS_UNSET"
+`);
+    expect(() => resolveConfig({ cliSources: [], cliConfigPath: p, env: {} }))
+      .toThrow(/PROD_PASS_UNSET|not set or empty/);
+  });
 });
 
 describe('resolveConfig: defaultExplicit (explicit-default vs first-registered fallback)', () => {

--- a/src/config/__tests__/resolver.test.ts
+++ b/src/config/__tests__/resolver.test.ts
@@ -49,6 +49,10 @@ describe('resolveConfig precedence', () => {
     const cfg = resolveConfig({ cliSources: [cliSource('a'), cliSource('b')], env: {} });
     expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
     expect(cfg.defaultName).toBe('a');
+    // The first --ssh source is a positional fallback, NOT a user-chosen
+    // default: defaultExplicit must be false so the multi-source omit-name
+    // guard still fires (the security fix).
+    expect(cfg.defaultExplicit).toBe(false);
     expect(cfg.configPath).toBeUndefined();
   });
 
@@ -63,6 +67,8 @@ describe('resolveConfig precedence', () => {
       transport: 'openssh',
     });
     expect(cfg.defaultName).toBe('toml');
+    // basicToml marks the source `default = true` → an explicit user choice.
+    expect(cfg.defaultExplicit).toBe(true);
     expect(cfg.configPath).toBe(p);
   });
 
@@ -82,6 +88,10 @@ auth = "kerberos"
     expect(cfg.sources[0].name).toBe('cli');
     expect(cfg.sources[0].host).toBe('cli.example');
     expect(cfg.defaultName).toBe('cli');
+    // CLI sources suppress the TOML source list; the surviving default is a
+    // positional CLI fallback, so the explicit-default marker (even if the
+    // suppressed TOML had `default = true`) does NOT carry over.
+    expect(cfg.defaultExplicit).toBe(false);
     expect(cfg.server?.audit_dir).toContain('audit-test');
     expect(cfg.configPath).toBe(p);
   });
@@ -103,6 +113,7 @@ audit_dir = "~/audit-only"
     const cfg = resolveConfig({ cliSources: [cliSource('cli')], cliConfigPath: p, env: {} });
     expect(cfg.sources.map(s => s.name)).toEqual(['cli']);
     expect(cfg.defaultName).toBe('cli');
+    expect(cfg.defaultExplicit).toBe(false);
     expect(cfg.webui?.enabled).toBe(true);
     expect(cfg.webui?.port).toBe(9099);
     expect(cfg.server?.audit_dir).toContain('audit-only');
@@ -174,11 +185,87 @@ auth = "kerberos"
     const cfg = resolveConfig({ cliSources: [], env: { XDG_CONFIG_HOME: path.join(tmp, 'none') } });
     expect(cfg.sources).toEqual([]);
     expect(cfg.defaultName).toBeUndefined();
+    expect(cfg.defaultExplicit).toBe(false);
     expect(cfg.configPath).toBeUndefined();
   });
 
   it('propagates TOML validation errors', () => {
     const bad = writeToml(tmp, 'bad.toml', `not valid =`);
     expect(() => resolveConfig({ cliSources: [], cliConfigPath: bad, env: {} })).toThrow(/parse failed/);
+  });
+});
+
+describe('resolveConfig: defaultExplicit (explicit-default vs first-registered fallback)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-resolver-de-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  const multiNoDefault = `
+[[sources]]
+id = "a"
+host = "a.example"
+user = "u"
+auth = "kerberos"
+
+[[sources]]
+id = "b"
+host = "b.example"
+user = "u"
+auth = "kerberos"
+`;
+
+  const multiWithDefault = `
+[[sources]]
+id = "a"
+host = "a.example"
+user = "u"
+auth = "kerberos"
+
+[[sources]]
+id = "b"
+host = "b.example"
+user = "u"
+auth = "kerberos"
+default = true
+`;
+
+  it('multi-source TOML with NO `default = true`: defaultName falls back to the first source but defaultExplicit is FALSE', () => {
+    // This is the security-critical case. Pre-fix the resolver collapsed an
+    // explicit default with this positional fallback, so the registry was
+    // always told it had an explicit default and the omit-name guard never
+    // fired. The fix keeps routing-fallback defaultName but reports
+    // defaultExplicit=false so bootstrapRegistry does NOT call setDefault().
+    const p = writeToml(tmp, 'multi-nodefault.toml', multiNoDefault);
+    const cfg = resolveConfig({ cliSources: [], cliConfigPath: p, env: {} });
+    expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
+    expect(cfg.defaultName).toBe('a');
+    expect(cfg.defaultExplicit).toBe(false);
+  });
+
+  it('multi-source TOML WITH `default = true`: defaultName is the chosen source and defaultExplicit is TRUE', () => {
+    const p = writeToml(tmp, 'multi-default.toml', multiWithDefault);
+    const cfg = resolveConfig({ cliSources: [], cliConfigPath: p, env: {} });
+    expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
+    expect(cfg.defaultName).toBe('b');
+    expect(cfg.defaultExplicit).toBe(true);
+  });
+
+  it('single-source TOML with no `default = true`: defaultName falls back but defaultExplicit is FALSE', () => {
+    const p = writeToml(tmp, 'single.toml', `
+[[sources]]
+id = "solo"
+host = "solo.example"
+user = "u"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({ cliSources: [], cliConfigPath: p, env: {} });
+    expect(cfg.defaultName).toBe('solo');
+    expect(cfg.defaultExplicit).toBe(false);
   });
 });

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -313,6 +313,190 @@ mode = "yolo"
   });
 });
 
+describe('parseTomlConfig: transport/host-key/secret guards (R1 findings 3-6)', () => {
+  // Finding 3: kerberos requires openssh; explicit ssh2 must be rejected at parse.
+  it('rejects auth="kerberos" with explicit transport="ssh2"', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "kerberos"
+transport = "ssh2"
+`)).toThrow(/kerberos.*openssh|openssh.*kerberos/i);
+  });
+
+  it('still defaults a kerberos source (no transport) to openssh', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "kerberos"
+`);
+    expect(cfg.sources[0].transport).toBe('openssh');
+  });
+
+  // Finding 4: host-key fields require openssh (ssh2 silently ignores them).
+  it('rejects known_hosts_file on an ssh2 (default) key source', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+key_path = "/k"
+known_hosts_file = "/tmp/known"
+`)).toThrow(/known_hosts_file.*openssh|strict_host_key_checking.*openssh/i);
+  });
+
+  it('rejects strict_host_key_checking on an ssh2 (default) password source', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = "pw"
+strict_host_key_checking = "yes"
+`)).toThrow(/openssh/i);
+  });
+
+  it('accepts known_hosts_file / strict_host_key_checking on transport="openssh"', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+key_path = "/k"
+transport = "openssh"
+known_hosts_file = "/tmp/known"
+strict_host_key_checking = "accept-new"
+`);
+    expect(cfg.sources[0].knownHostsFile).toBe('/tmp/known');
+    expect(cfg.sources[0].strictHostKeyChecking).toBe('accept-new');
+  });
+
+  it('accepts host-key fields on a kerberos source (implies openssh)', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u@EX"
+auth = "kerberos"
+known_hosts_file = "/tmp/known"
+`);
+    expect(cfg.sources[0].transport).toBe('openssh');
+    expect(cfg.sources[0].knownHostsFile).toBe('/tmp/known');
+  });
+
+  // Finding 5: openssh key sources need an on-disk key_path (inline key unused).
+  it('rejects auth="key" transport="openssh" with only private_key', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+transport = "openssh"
+private_key = "-----BEGIN KEY-----"
+`)).toThrow(/key_path/);
+  });
+
+  it('accepts auth="key" transport="openssh" with key_path', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+transport = "openssh"
+key_path = "/k"
+`);
+    expect(cfg.sources[0].keyPath).toBe('/k');
+    expect(cfg.sources[0].transport).toBe('openssh');
+  });
+
+  it('still accepts inline private_key on the ssh2 transport', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+private_key = "-----BEGIN KEY-----"
+`);
+    expect(cfg.sources[0].transport).toBe('ssh2');
+    expect(cfg.sources[0].privateKey).toBe('-----BEGIN KEY-----');
+  });
+
+  // Finding 6: secret fields must be quoted strings (a TOML number is rejected).
+  it('rejects an unquoted numeric password', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = 123456
+`)).toThrow(/password must be a quoted string/);
+  });
+
+  it('rejects an unquoted numeric sudo_password', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = "pw"
+sudo_password = 123456
+`)).toThrow(/sudo_password must be a quoted string/);
+  });
+
+  it('rejects an unquoted numeric su_password', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = "pw"
+su_password = 42
+`)).toThrow(/su_password must be a quoted string/);
+  });
+
+  it('does not echo the secret value in the type-guard error', () => {
+    try {
+      parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = 987654
+`);
+      throw new Error('should have thrown');
+    } catch (e: any) {
+      expect(e.message).toContain('sources.p.password');
+      expect(e.message).not.toContain('987654');
+    }
+  });
+
+  it('allowEmptySources tolerates a TOML with only top-level sections', () => {
+    const cfg = parseTomlConfig(`
+[webui]
+enabled = true
+host = "127.0.0.1"
+port = 8088
+`, { allowEmptySources: true });
+    expect(cfg.sources).toEqual([]);
+    expect(cfg.webui?.enabled).toBe(true);
+    expect(cfg.webui?.port).toBe(8088);
+  });
+});
+
 describe('loadTomlFile', () => {
   it('reads from disk and stamps configPath', () => {
     const tmp = path.join(os.tmpdir(), `ssh-mcp-test-${process.pid}-${Date.now()}.toml`);

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -561,3 +561,152 @@ auth = "kerberos"
     expect(() => loadTomlFile('/nonexistent/ssh-mcp-test.toml')).toThrow(/cannot read/);
   });
 });
+
+describe('parseTomlConfig: R2 Codex findings (port range, gssapi-delegate scope, deferred LLM key, ignored sources)', () => {
+  const kerbSource = (extra = '') => `
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "kerberos"
+${extra}`;
+
+  // Finding: TOML ports must be usable TCP ports (integer 1..65535).
+  it('rejects a non-integer port (22.5)', () => {
+    expect(() => parseTomlConfig(kerbSource('port = 22.5')))
+      .toThrow(/port must be an integer between 1 and 65535/);
+  });
+
+  it('rejects a negative port (-1)', () => {
+    expect(() => parseTomlConfig(kerbSource('port = -1')))
+      .toThrow(/port must be an integer between 1 and 65535/);
+  });
+
+  it('rejects an out-of-range port (70000)', () => {
+    expect(() => parseTomlConfig(kerbSource('port = 70000')))
+      .toThrow(/port must be an integer between 1 and 65535/);
+  });
+
+  it('rejects port 0 (not a usable TCP port)', () => {
+    expect(() => parseTomlConfig(kerbSource('port = 0')))
+      .toThrow(/port must be an integer between 1 and 65535/);
+  });
+
+  it('accepts a valid integer port and the boundary values 1 and 65535', () => {
+    expect(parseTomlConfig(kerbSource('port = 2222')).sources[0].port).toBe(2222);
+    expect(parseTomlConfig(kerbSource('port = 1')).sources[0].port).toBe(1);
+    expect(parseTomlConfig(kerbSource('port = 65535')).sources[0].port).toBe(65535);
+  });
+
+  // Finding: gssapi_delegate_credentials is only wired for kerberos auth.
+  it('rejects gssapi_delegate_credentials on a password source', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = "pw"
+gssapi_delegate_credentials = "yes"
+`)).toThrow(/gssapi_delegate_credentials requires auth="kerberos"/);
+  });
+
+  it('rejects gssapi_delegate_credentials on a key source', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "kk"
+host = "h"
+user = "u"
+auth = "key"
+key_path = "/tmp/id"
+gssapi_delegate_credentials = "yes"
+`)).toThrow(/gssapi_delegate_credentials requires auth="kerberos"/);
+  });
+
+  it('still accepts gssapi_delegate_credentials on a kerberos source', () => {
+    const cfg = parseTomlConfig(kerbSource('gssapi_delegate_credentials = "yes"'));
+    expect(cfg.sources[0].gssapiDelegateCredentials).toBe('yes');
+  });
+
+  // Finding: [approval.llm].api_key resolution is deferred unless smart mode.
+  it('does NOT resolve api_key when approval mode is manual/default (avoids startup failure on missing env)', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[approval]
+mode = "manual"
+
+[approval.llm]
+api_key = "env:MISSING_KEY"
+`, { env: {} });
+    // No throw despite MISSING_KEY being unset, and api_key stays unresolved.
+    expect(cfg.approval?.llm?.api_key).toBeUndefined();
+  });
+
+  it('does NOT resolve api_key when [approval] omits mode entirely', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[approval.llm]
+api_key = "env:MISSING_KEY"
+`, { env: {} });
+    expect(cfg.approval?.llm?.api_key).toBeUndefined();
+  });
+
+  it('still resolves api_key when smart mode is enabled', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[approval]
+mode = "smart"
+
+[approval.llm]
+api_key = "env:KEY"
+`, { env: { KEY: 'sk-xyz' } });
+    expect(cfg.approval?.llm?.api_key).toBe('sk-xyz');
+  });
+
+  // Finding: ignoreSources skips validating suppressed [[sources]] entirely.
+  it('ignoreSources skips validation + secret resolution of [[sources]] and keeps top-level sections', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "prod"
+host = "prod.example"
+user = "u"
+auth = "password"
+password = "env:PROD_PASS_UNSET"
+
+[webui]
+enabled = true
+host = "127.0.0.1"
+port = 8099
+`, { ignoreSources: true, env: {} });
+    // The suppressed source's unset env: secret must NOT abort parsing.
+    expect(cfg.sources).toEqual([]);
+    expect(cfg.webui?.enabled).toBe(true);
+    expect(cfg.webui?.port).toBe(8099);
+  });
+
+  it('without ignoreSources, the same unset-secret source still throws', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "prod"
+host = "prod.example"
+user = "u"
+auth = "password"
+password = "env:PROD_PASS_UNSET"
+`, { env: {} })).toThrow(/PROD_PASS_UNSET|not set or empty/);
+  });
+});

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -661,6 +661,40 @@ api_key = "env:MISSING_KEY"
     expect(cfg.approval?.llm?.api_key).toBeUndefined();
   });
 
+  it('resolves api_key when smart mode is only enabled by a per-source override', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+approval = { mode = "smart" }
+
+[approval.llm]
+endpoint = "https://api.example/v1/c"
+api_key = "env:KEY"
+model = "m-1"
+`, { env: { KEY: 'sk-xyz' } });
+    expect(cfg.perSourceApproval).toEqual({ x: 'smart' });
+    expect(cfg.approval?.llm?.api_key).toBe('sk-xyz');
+  });
+
+  it('requires api_key env when a per-source smart override uses [approval.llm]', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+approval = { mode = "smart" }
+
+[approval.llm]
+endpoint = "https://api.example/v1/c"
+api_key = "env:MISSING_KEY"
+model = "m-1"
+`, { env: {} })).toThrow(/MISSING_KEY|not set or empty/);
+  });
+
   it('still resolves api_key when smart mode is enabled', () => {
     const cfg = parseTomlConfig(`
 [[sources]]

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -305,11 +305,52 @@ auth = "kerberos"
 [sources.approval]
 mode = "yolo"
 `);
-    // @iarna/toml flattens `[sources.approval]` as a sibling key; this
-    // assertion encodes the actual TOML semantics we expect.
-    // (When users want per-source overrides they use the inline-table form
-    // shown in the example file.)
-    expect(cfg.perSourceApproval).toBeDefined();
+    // @iarna/toml attaches `[sources.approval]` to the immediately preceding
+    // `[[sources]]` entry (verified: identical to the inline `approval = { ...
+    // }` form documented in ssh-mcp.toml.example). Assert on the resolved
+    // record so this guards the intended semantics — the override actually
+    // lands on source "x" with the captured mode — not merely that the map
+    // object exists (it is always initialized to `{}`).
+    expect(cfg.perSourceApproval).toEqual({ x: 'yolo' });
+  });
+});
+
+describe('parseTomlConfig: [server].require_connection wiring', () => {
+  const oneSource = `
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+`;
+
+  it('projects require_connection = false onto ResolvedConfig.requireConnection', () => {
+    const cfg = parseTomlConfig(`
+[server]
+require_connection = false
+${oneSource}`);
+    expect(cfg.requireConnection).toBe(false);
+    expect(cfg.server?.require_connection).toBe(false);
+  });
+
+  it('projects require_connection = true onto ResolvedConfig.requireConnection', () => {
+    const cfg = parseTomlConfig(`
+[server]
+require_connection = true
+${oneSource}`);
+    expect(cfg.requireConnection).toBe(true);
+  });
+
+  it('leaves requireConnection undefined when the field is absent (safe default applied downstream)', () => {
+    const cfg = parseTomlConfig(oneSource);
+    expect(cfg.requireConnection).toBeUndefined();
+  });
+
+  it('rejects a non-boolean require_connection', () => {
+    expect(() => parseTomlConfig(`
+[server]
+require_connection = "no"
+${oneSource}`)).toThrow(/require_connection.*boolean/);
   });
 });
 

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import {
+  parseTomlConfig,
+  loadTomlFile,
+  expandHome,
+  resolveEnvRef,
+  defaultDiscoveryPaths,
+} from '../toml-loader.js';
+
+describe('expandHome', () => {
+  it('expands a leading ~ alone', () => {
+    expect(expandHome('~')).toBe(os.homedir());
+  });
+  it('expands ~/foo', () => {
+    expect(expandHome('~/foo')).toBe(path.join(os.homedir(), 'foo'));
+  });
+  it('passes through paths without ~', () => {
+    expect(expandHome('/etc/ssh/known_hosts')).toBe('/etc/ssh/known_hosts');
+  });
+  it('returns undefined for undefined', () => {
+    expect(expandHome(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveEnvRef', () => {
+  it('returns the plain string when no env: prefix', () => {
+    expect(resolveEnvRef('hello', 'x', {})).toBe('hello');
+  });
+  it('resolves env:NAME against the env map', () => {
+    expect(resolveEnvRef('env:FOO', 'x', { FOO: 'bar' })).toBe('bar');
+  });
+  it('throws when env var is missing', () => {
+    expect(() => resolveEnvRef('env:MISSING', 'field.x', {})).toThrow(/MISSING/);
+  });
+  it('throws when env var is empty', () => {
+    expect(() => resolveEnvRef('env:EMPTY', 'field.x', { EMPTY: '' })).toThrow(/EMPTY/);
+  });
+  it('throws when env: prefix has no name', () => {
+    expect(() => resolveEnvRef('env:', 'field.x', {})).toThrow(/no variable name/);
+  });
+  it('never echoes the env value in the error message', () => {
+    try {
+      resolveEnvRef('env:NOT_SET', 'sources.x.password', {});
+      throw new Error('should have thrown');
+    } catch (e: any) {
+      // The error mentions the env name and the field, but never the value.
+      expect(e.message).toContain('NOT_SET');
+      expect(e.message).toContain('sources.x.password');
+    }
+  });
+});
+
+describe('defaultDiscoveryPaths', () => {
+  it('includes SSH_MCP_CONFIG first when set', () => {
+    const paths = defaultDiscoveryPaths({ SSH_MCP_CONFIG: '/tmp/from-env.toml' });
+    expect(paths[0]).toBe('/tmp/from-env.toml');
+  });
+  it('falls back to XDG then ~/.ssh-mcp', () => {
+    const paths = defaultDiscoveryPaths({ XDG_CONFIG_HOME: '/x/conf' });
+    expect(paths).toContain('/x/conf/ssh-mcp/config.toml');
+    expect(paths[paths.length - 1].endsWith(path.join('.ssh-mcp', 'config.toml'))).toBe(true);
+  });
+});
+
+describe('parseTomlConfig: minimum viable', () => {
+  it('parses a single password source', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "lab"
+host = "lab.example"
+user = "root"
+auth = "password"
+password = "literal-pw"
+`);
+    expect(cfg.sources).toHaveLength(1);
+    expect(cfg.sources[0]).toMatchObject({
+      name: 'lab',
+      host: 'lab.example',
+      port: 22,
+      username: 'root',
+      authMode: 'password',
+      transport: 'ssh2',
+      password: 'literal-pw',
+    });
+    expect(cfg.defaultName).toBeUndefined();
+  });
+
+  it('parses a key source and reads key_path verbatim (no FS read)', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "lab"
+host = "lab.example"
+user = "root"
+auth = "key"
+key_path = "~/.ssh/lab_ed25519"
+`);
+    expect(cfg.sources[0].keyPath).toBe(path.join(os.homedir(), '.ssh/lab_ed25519'));
+    expect(cfg.sources[0].privateKey).toBeUndefined();
+  });
+
+  it('kerberos defaults transport to openssh', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "bastion"
+host = "b.example"
+user = "x@EXAMPLE"
+auth = "kerberos"
+`);
+    expect(cfg.sources[0].transport).toBe('openssh');
+    expect(cfg.sources[0].kerberos).toBe(true);
+  });
+
+  it('two [[sources]] register identically to two --ssh=<JSON> calls', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "a"
+host = "a.example"
+user = "ua"
+auth = "kerberos"
+default = true
+
+[[sources]]
+id = "b"
+host = "b.example"
+user = "ub"
+auth = "key"
+key_path = "/k"
+`);
+    expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
+    expect(cfg.defaultName).toBe('a');
+    expect(cfg.sources[0].authMode).toBe('kerberos');
+    expect(cfg.sources[1].authMode).toBe('key');
+    expect(cfg.sources[1].keyPath).toBe('/k');
+  });
+});
+
+describe('parseTomlConfig: env interpolation', () => {
+  it('resolves env:NAME for password fields', () => {
+    const cfg = parseTomlConfig(
+      `
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "password"
+password = "env:LAB_PW"
+sudo_password = "env:LAB_SUDO"
+`,
+      { env: { LAB_PW: 'secret-pw', LAB_SUDO: 'secret-sudo' } },
+    );
+    expect(cfg.sources[0].password).toBe('secret-pw');
+    expect(cfg.sources[0].sudoPassword).toBe('secret-sudo');
+  });
+
+  it('errors when env var missing', () => {
+    expect(() => parseTomlConfig(
+      `
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "password"
+password = "env:NOT_SET"
+`,
+      { env: {} },
+    )).toThrow(/NOT_SET/);
+  });
+});
+
+describe('parseTomlConfig: validation', () => {
+  it('rejects empty source list', () => {
+    expect(() => parseTomlConfig(`[server]\naudit_dir = "/tmp"`)).toThrow(/sources/);
+  });
+
+  it('rejects duplicate ids', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h1"
+user = "u"
+auth = "kerberos"
+
+[[sources]]
+id = "x"
+host = "h2"
+user = "u"
+auth = "kerberos"
+`)).toThrow(/duplicate/i);
+  });
+
+  it('rejects invalid auth', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "bogus"
+`)).toThrow(/auth/);
+  });
+
+  it('rejects key auth with no key_path or private_key', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "key"
+`)).toThrow(/key_path|private_key/);
+  });
+
+  it('rejects password auth with no password', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "password"
+`)).toThrow(/password/);
+  });
+
+  it('rejects multiple sources marked default', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "a"
+host = "h"
+user = "u"
+auth = "kerberos"
+default = true
+
+[[sources]]
+id = "b"
+host = "h"
+user = "u"
+auth = "kerberos"
+default = true
+`)).toThrow(/default/);
+  });
+
+  it('rejects non-loopback webui without auth_token', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[webui]
+host = "0.0.0.0"
+port = 8080
+`)).toThrow(/auth_token/);
+  });
+
+  it('accepts non-loopback webui when auth_token is set', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[webui]
+host = "0.0.0.0"
+port = 8080
+auth_token = "env:TKN"
+`, { env: { TKN: 'tok' } });
+    expect(cfg.webui?.auth_token).toBe('tok');
+  });
+
+  it('parses [approval] and [approval.llm]', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[approval]
+mode = "smart"
+fail_closed = false
+
+[approval.llm]
+endpoint = "https://api.example/v1/c"
+api_key = "env:KEY"
+model = "m-1"
+timeout_ms = 1234
+`, { env: { KEY: 'sk-xyz' } });
+    expect(cfg.approval?.mode).toBe('smart');
+    expect(cfg.approval?.fail_closed).toBe(false);
+    expect(cfg.approval?.llm?.api_key).toBe('sk-xyz');
+    expect(cfg.approval?.llm?.timeout_ms).toBe(1234);
+  });
+
+  it('parses per-source approval override', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[sources.approval]
+mode = "yolo"
+`);
+    // @iarna/toml flattens `[sources.approval]` as a sibling key; this
+    // assertion encodes the actual TOML semantics we expect.
+    // (When users want per-source overrides they use the inline-table form
+    // shown in the example file.)
+    expect(cfg.perSourceApproval).toBeDefined();
+  });
+});
+
+describe('loadTomlFile', () => {
+  it('reads from disk and stamps configPath', () => {
+    const tmp = path.join(os.tmpdir(), `ssh-mcp-test-${process.pid}-${Date.now()}.toml`);
+    fs.writeFileSync(tmp, `
+[[sources]]
+id = "lab"
+host = "lab.example"
+user = "root"
+auth = "kerberos"
+`);
+    try {
+      const cfg = loadTomlFile(tmp);
+      expect(cfg.configPath).toBe(tmp);
+      expect(cfg.sources[0].name).toBe('lab');
+    } finally {
+      fs.unlinkSync(tmp);
+    }
+  });
+
+  it('throws a redact-safe error on missing file', () => {
+    expect(() => loadTomlFile('/nonexistent/ssh-mcp-test.toml')).toThrow(/cannot read/);
+  });
+});

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -298,8 +298,8 @@ timeout_ms = 1234
     const cfg = parseTomlConfig(`
 [[sources]]
 id = "dc03"
-host = "dc03.css.com.tw"
-user = "css\\\\c19087"
+host = "dc03.example.com"
+user = "corp\\\\svcuser"
 auth = "kerberos"
 description = '''allow only NTDS\\My thumbprint 8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE certificate-object writes; deny PFX, private key reads, restart, reboot'''
 approval = { mode = "smart" }

--- a/src/config/__tests__/toml-loader.test.ts
+++ b/src/config/__tests__/toml-loader.test.ts
@@ -294,6 +294,22 @@ timeout_ms = 1234
     expect(cfg.approval?.llm?.timeout_ms).toBe(1234);
   });
 
+  it('propagates per-source description and approval override to the server config', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "dc03"
+host = "dc03.css.com.tw"
+user = "css\\\\c19087"
+auth = "kerberos"
+description = '''allow only NTDS\\My thumbprint 8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE certificate-object writes; deny PFX, private key reads, restart, reboot'''
+approval = { mode = "smart" }
+`);
+    expect(cfg.sources[0].description).toContain('NTDS\\My');
+    expect(cfg.sources[0].description).toContain('8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE');
+    expect(cfg.sources[0].approval?.mode).toBe('smart');
+    expect(cfg.perSourceApproval?.dc03).toBe('smart');
+  });
+
   it('parses per-source approval override', () => {
     const cfg = parseTomlConfig(`
 [[sources]]

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -1,0 +1,77 @@
+/**
+ * Precedence resolver for ssh-mcp-kerberos boot-time configuration.
+ *
+ * Order (high -> low):
+ *   1. CLI flags (legacy single-host flags, OR repeated --ssh=<JSON>)
+ *   2. --config=<path> TOML
+ *   3. SSH_MCP_CONFIG env -> TOML
+ *   4. $XDG_CONFIG_HOME/ssh-mcp/config.toml or ~/.ssh-mcp/config.toml
+ *
+ * The resolver is pure: it accepts pre-parsed CLI inputs and an env map,
+ * walks the four candidate sources in order, and returns a single
+ * `ResolvedConfig`. The src/index.ts boot path stays in charge of parsing
+ * argv (the `parseArgv` / `collectSshJsonArgs` helpers already exist).
+ *
+ * "CLI wins" semantics:
+ *   - Any CLI source provided (legacy single-host OR --ssh=<JSON>) suppresses
+ *     the entire TOML sources list. Mixing modes is rejected upstream by
+ *     `validateConfig` in src/index.ts. This keeps existing CLI tests untouched.
+ *   - Top-level TOML sections (server/webui/approval) survive even when CLI
+ *     sources are present, so a future user can use legacy flags AND a TOML
+ *     just for [webui]. (Source-level overrides land in later tasks.)
+ */
+
+import { discoverConfigPath, loadTomlFile } from './toml-loader.js';
+import type { ResolvedConfig } from './types.js';
+import type { ServerConfig } from '../transports/types.js';
+
+export interface ResolverInputs {
+  /** Parsed CLI ServerConfig entries (from --ssh=<JSON> or legacy single-host). */
+  cliSources: ServerConfig[];
+  /** Explicit --config=<path>, if the user supplied one. */
+  cliConfigPath?: string;
+  /** Override env for tests; defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
+export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
+  const env = inputs.env ?? process.env;
+
+  // --- locate a TOML, if any ---------------------------------------------
+  let tomlPath: string | undefined = inputs.cliConfigPath;
+  if (!tomlPath && env.SSH_MCP_CONFIG) tomlPath = env.SSH_MCP_CONFIG;
+  if (!tomlPath) tomlPath = discoverConfigPath(env);
+
+  const fromToml: ResolvedConfig | undefined = tomlPath
+    ? loadTomlFile(tomlPath, { env })
+    : undefined;
+
+  // --- assemble final ResolvedConfig -------------------------------------
+  const hasCliSources = inputs.cliSources.length > 0;
+
+  // Per spec: CLI sources win and SUPPRESS the TOML source list (avoid
+  // confusing union semantics + double-registration). Top-level TOML
+  // sections still apply so e.g. [webui] from disk is respected.
+  const sources: ServerConfig[] = hasCliSources
+    ? inputs.cliSources
+    : (fromToml?.sources ?? []);
+
+  // defaultName: when CLI is in charge, first registered wins (matches
+  // existing TransportRegistry behavior).
+  let defaultName: string | undefined;
+  if (hasCliSources) {
+    defaultName = inputs.cliSources[0]?.name;
+  } else {
+    defaultName = fromToml?.defaultName ?? fromToml?.sources?.[0]?.name;
+  }
+
+  return {
+    sources,
+    defaultName,
+    perSourceApproval: hasCliSources ? {} : (fromToml?.perSourceApproval ?? {}),
+    server: fromToml?.server,
+    webui: fromToml?.webui,
+    approval: fromToml?.approval,
+    configPath: tomlPath,
+  };
+}

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -56,6 +56,7 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
   // or another source-only error would otherwise abort startup even though only
   // the top-level sections survive. ignoreSources handles both.
   const hasCliSources = inputs.cliSources.length > 0;
+  const hasExplicitCliConfig = inputs.cliConfigPath !== undefined;
 
   const fromToml: ResolvedConfig | undefined = tomlPath
     ? loadTomlFile(tomlPath, {
@@ -103,9 +104,14 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
     defaultName,
     defaultExplicit,
     perSourceApproval: hasCliSources ? {} : (fromToml?.perSourceApproval ?? {}),
-    // require_connection is a top-level [server] knob, so it survives even when
-    // CLI sources suppress the TOML source list (like server/webui/approval).
-    requireConnection: fromToml?.requireConnection,
+    // An auto-discovered TOML must not weaken the connectionName guard for
+    // explicit CLI sources. In particular, a stale default config containing
+    // require_connection=false must not make a multi-`--ssh` invocation silently
+    // route omitted connectionName calls to its first CLI host. The opt-out is
+    // honored with CLI sources only when the user explicitly supplied --config.
+    requireConnection: hasCliSources && !hasExplicitCliConfig
+      ? undefined
+      : fromToml?.requireConnection,
     server: fromToml?.server,
     webui: fromToml?.webui,
     approval: fromToml?.approval,

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -50,11 +50,19 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
   // When CLI sources are present they win and suppress the TOML source list
   // (see "CLI wins" semantics above). In that case a TOML that exists only to
   // supply top-level sections (e.g. just [webui]) is legitimate and must not be
-  // rejected for having zero [[sources]]. Tolerate empty sources accordingly.
+  // rejected for having zero [[sources]]. Beyond tolerating empty sources, we
+  // must also SKIP parsing/validating any [[sources]] that ARE present but
+  // suppressed: a suppressed source with an unset `password = "env:PROD_PASS"`
+  // or another source-only error would otherwise abort startup even though only
+  // the top-level sections survive. ignoreSources handles both.
   const hasCliSources = inputs.cliSources.length > 0;
 
   const fromToml: ResolvedConfig | undefined = tomlPath
-    ? loadTomlFile(tomlPath, { env, allowEmptySources: hasCliSources })
+    ? loadTomlFile(tomlPath, {
+        env,
+        allowEmptySources: hasCliSources,
+        ignoreSources: hasCliSources,
+      })
     : undefined;
 
   // --- assemble final ResolvedConfig -------------------------------------

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -62,17 +62,33 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
     : (fromToml?.sources ?? []);
 
   // defaultName: when CLI is in charge, first registered wins (matches
-  // existing TransportRegistry behavior).
+  // existing TransportRegistry behavior). defaultExplicit tracks whether that
+  // default was a deliberate user choice (TOML `default = true`) versus a mere
+  // positional fallback — the boot path only calls registry.setDefault() for an
+  // explicit default, so a multi-source config without one keeps the omit-name
+  // guard armed instead of silently routing to the first host.
   let defaultName: string | undefined;
+  let defaultExplicit: boolean;
   if (hasCliSources) {
+    // A CLI invocation never carries an explicit-default marker; the first
+    // --ssh source is a positional fallback only.
     defaultName = inputs.cliSources[0]?.name;
+    defaultExplicit = false;
+  } else if (fromToml?.defaultName !== undefined) {
+    // The TOML loader sets defaultName ONLY from an explicit `default = true`.
+    defaultName = fromToml.defaultName;
+    defaultExplicit = true;
   } else {
-    defaultName = fromToml?.defaultName ?? fromToml?.sources?.[0]?.name;
+    // No explicit default anywhere: fall back to the first source positionally
+    // for routing, but mark it non-explicit so the guard still fires.
+    defaultName = fromToml?.sources?.[0]?.name;
+    defaultExplicit = false;
   }
 
   return {
     sources,
     defaultName,
+    defaultExplicit,
     perSourceApproval: hasCliSources ? {} : (fromToml?.perSourceApproval ?? {}),
     server: fromToml?.server,
     webui: fromToml?.webui,

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -42,12 +42,17 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
   if (!tomlPath && env.SSH_MCP_CONFIG) tomlPath = env.SSH_MCP_CONFIG;
   if (!tomlPath) tomlPath = discoverConfigPath(env);
 
+  // When CLI sources are present they win and suppress the TOML source list
+  // (see "CLI wins" semantics above). In that case a TOML that exists only to
+  // supply top-level sections (e.g. just [webui]) is legitimate and must not be
+  // rejected for having zero [[sources]]. Tolerate empty sources accordingly.
+  const hasCliSources = inputs.cliSources.length > 0;
+
   const fromToml: ResolvedConfig | undefined = tomlPath
-    ? loadTomlFile(tomlPath, { env })
+    ? loadTomlFile(tomlPath, { env, allowEmptySources: hasCliSources })
     : undefined;
 
   // --- assemble final ResolvedConfig -------------------------------------
-  const hasCliSources = inputs.cliSources.length > 0;
 
   // Per spec: CLI sources win and SUPPRESS the TOML source list (avoid
   // confusing union semantics + double-registration). Top-level TOML

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -42,8 +42,8 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
   // discoverConfigPath(env), which probes SSH_MCP_CONFIG first and then the
   // XDG/home candidates, returning the first that actually EXISTS. Reading
   // env.SSH_MCP_CONFIG directly here would diverge from that discovery
-  // contract: a set-but-missing SSH_MCP_CONFIG would hard-fail in loadTomlFile
-  // instead of falling through to the XDG/home paths the way an unset var does.
+  // contract: a set-but-missing SSH_MCP_CONFIG falls through to XDG/home,
+  // while an inaccessible SSH_MCP_CONFIG fails closed in discovery.
   const tomlPath: string | undefined =
     inputs.cliConfigPath ?? discoverConfigPath(env);
 

--- a/src/config/resolver.ts
+++ b/src/config/resolver.ts
@@ -38,9 +38,14 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
   const env = inputs.env ?? process.env;
 
   // --- locate a TOML, if any ---------------------------------------------
-  let tomlPath: string | undefined = inputs.cliConfigPath;
-  if (!tomlPath && env.SSH_MCP_CONFIG) tomlPath = env.SSH_MCP_CONFIG;
-  if (!tomlPath) tomlPath = discoverConfigPath(env);
+  // Precedence: explicit --config wins outright. Otherwise defer to
+  // discoverConfigPath(env), which probes SSH_MCP_CONFIG first and then the
+  // XDG/home candidates, returning the first that actually EXISTS. Reading
+  // env.SSH_MCP_CONFIG directly here would diverge from that discovery
+  // contract: a set-but-missing SSH_MCP_CONFIG would hard-fail in loadTomlFile
+  // instead of falling through to the XDG/home paths the way an unset var does.
+  const tomlPath: string | undefined =
+    inputs.cliConfigPath ?? discoverConfigPath(env);
 
   // When CLI sources are present they win and suppress the TOML source list
   // (see "CLI wins" semantics above). In that case a TOML that exists only to
@@ -90,6 +95,9 @@ export function resolveConfig(inputs: ResolverInputs): ResolvedConfig {
     defaultName,
     defaultExplicit,
     perSourceApproval: hasCliSources ? {} : (fromToml?.perSourceApproval ?? {}),
+    // require_connection is a top-level [server] knob, so it survives even when
+    // CLI sources suppress the TOML source list (like server/webui/approval).
+    requireConnection: fromToml?.requireConnection,
     server: fromToml?.server,
     webui: fromToml?.webui,
     approval: fromToml?.approval,

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -100,6 +100,13 @@ export function discoverConfigPath(env: NodeJS.ProcessEnv = process.env): string
 
 interface LoadOptions {
   env?: NodeJS.ProcessEnv;
+  /**
+   * Tolerate a TOML with zero [[sources]] entries. Used by the resolver when
+   * CLI sources are present and suppress the TOML source list, so a TOML that
+   * only supplies top-level sections (e.g. just [webui]) is a valid, supported
+   * combination instead of a hard error.
+   */
+  allowEmptySources?: boolean;
 }
 
 /**
@@ -118,7 +125,7 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
   }
 
   const sources = Array.isArray(parsed?.sources) ? parsed.sources : [];
-  if (sources.length === 0) {
+  if (sources.length === 0 && !opts.allowEmptySources) {
     throw new Error('Config: at least one [[sources]] entry is required');
   }
 
@@ -186,9 +193,48 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     const resolvedTransport: 'ssh2' | 'openssh' = src.transport
       ?? (src.auth === 'kerberos' ? 'openssh' : 'ssh2');
 
-    const password = resolveEnvRef(src.password, `sources.${src.id}.password`, env);
-    const sudoPassword = resolveEnvRef(src.sudo_password, `sources.${src.id}.sudo_password`, env);
-    const suPassword = resolveEnvRef(src.su_password, `sources.${src.id}.su_password`, env);
+    // Kerberos requires the openssh transport (GSSAPI is only wired there).
+    // An explicit transport="ssh2" on a kerberos source would start up and then
+    // fail authentication at runtime — mirror the legacy CLI rule and reject it
+    // at parse time. (index.ts validateConfig: "--kerberos requires
+    // --transport=openssh".)
+    if (src.auth === 'kerberos' && src.transport === 'ssh2') {
+      throw new Error(
+        `Config: sources.${src.id} auth="kerberos" requires transport="openssh" (remove transport="ssh2")`,
+      );
+    }
+
+    // Secret fields must be quoted strings. An unquoted numeric value (e.g.
+    // `password = 123456`) parses as a TOML number; resolveEnvRef returns
+    // non-strings unchanged, so a number would reach the SSH/sudo password
+    // paths and fail with an opaque runtime type error. Reject it here with a
+    // clear, redact-safe config error that names the field but not the value.
+    const requireSecretString = (
+      value: unknown,
+      field: string,
+    ): string | undefined => {
+      if (value === undefined) return undefined;
+      if (typeof value !== 'string') {
+        throw new Error(`Config: sources.${src.id}.${field} must be a quoted string`);
+      }
+      return value;
+    };
+
+    const password = resolveEnvRef(
+      requireSecretString(src.password, 'password'),
+      `sources.${src.id}.password`,
+      env,
+    );
+    const sudoPassword = resolveEnvRef(
+      requireSecretString(src.sudo_password, 'sudo_password'),
+      `sources.${src.id}.sudo_password`,
+      env,
+    );
+    const suPassword = resolveEnvRef(
+      requireSecretString(src.su_password, 'su_password'),
+      `sources.${src.id}.su_password`,
+      env,
+    );
 
     const out: ServerConfig = {
       name: src.id,
@@ -214,6 +260,18 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
             `Config: sources.${src.id} auth="key" requires key_path or private_key`,
           );
         }
+        // The openssh transport authenticates with `-i <keyPath>` and never
+        // materializes an inline private_key — supplying only private_key on
+        // openssh silently falls back to default-identity pubkey auth. Require
+        // an on-disk key_path for openssh key sources so the configured key is
+        // actually used. (ssh2 reads inline key contents in memory, so inline
+        // private_key remains valid there.)
+        if (resolvedTransport === 'openssh' && !out.keyPath) {
+          throw new Error(
+            `Config: sources.${src.id} auth="key" with transport="openssh" requires key_path ` +
+            `(inline private_key is not supported on the openssh transport)`,
+          );
+        }
         break;
       case 'password':
         if (!password) {
@@ -227,6 +285,20 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
 
     if (sudoPassword !== undefined) out.sudoPassword = sudoPassword;
     if (suPassword !== undefined) out.suPassword = suPassword;
+    // known_hosts_file / strict_host_key_checking are honored only by the
+    // openssh transport (openssh.ts). On ssh2 they are silently dropped, which
+    // would disable the requested host-key enforcement — a security downgrade.
+    // Mirror the legacy CLI rule ("--knownHostsFile and --strictHostKeyChecking
+    // require --transport=openssh") and reject the combination at parse time.
+    if (
+      resolvedTransport === 'ssh2' &&
+      (src.known_hosts_file || src.strict_host_key_checking)
+    ) {
+      throw new Error(
+        `Config: sources.${src.id} known_hosts_file/strict_host_key_checking require transport="openssh" ` +
+        `(the ssh2 transport does not enforce host keys)`,
+      );
+    }
     if (src.known_hosts_file) out.knownHostsFile = expandHome(src.known_hosts_file);
     if (src.strict_host_key_checking) out.strictHostKeyChecking = src.strict_host_key_checking;
 

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -317,6 +317,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       ? requireConfigString(src.private_key, 'private_key')
       : undefined;
     const knownHostsFile = requireConfigString(src.known_hosts_file, 'known_hosts_file');
+    if (knownHostsFile !== undefined && knownHostsFile.length === 0) {
+      throw new Error(`Config: sources.${src.id}.known_hosts_file must be a non-empty string`);
+    }
 
     const out: ServerConfig = {
       name: src.id,

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -443,9 +443,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     }
   }
 
-  const server = parsed.server ? validateServerSection(parsed.server) : undefined;
-  const webui = parsed.webui ? validateWebUI(parsed.webui, env) : undefined;
-  const approval = parsed.approval
+  const server = parsed.server !== undefined ? validateServerSection(parsed.server) : undefined;
+  const webui = parsed.webui !== undefined ? validateWebUI(parsed.webui, env) : undefined;
+  const approval = parsed.approval !== undefined
     ? validateApproval(parsed.approval, env, Object.values(perSourceApproval).includes('smart'))
     : undefined;
 
@@ -467,6 +467,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
 }
 
 function validateServerSection(raw: any) {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Config: [server] must be a table');
+  }
   const out: TomlConfig['server'] = {};
   if (raw.audit_dir !== undefined) {
     if (typeof raw.audit_dir !== 'string') throw new Error('Config: [server].audit_dir must be a string');
@@ -488,6 +491,9 @@ function validateServerSection(raw: any) {
 }
 
 function validateWebUI(raw: any, env: NodeJS.ProcessEnv) {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Config: [webui] must be a table');
+  }
   const out: TomlConfig['webui'] = {};
   if (raw.enabled !== undefined) {
     if (typeof raw.enabled !== 'boolean') throw new Error('Config: [webui].enabled must be a boolean');
@@ -527,6 +533,9 @@ function validateApproval(
   env: NodeJS.ProcessEnv,
   resolveLlmApiKeyForPerSourceSmart = false,
 ): ApprovalSection {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Config: [approval] must be a table');
+  }
   const out: ApprovalSection = {};
   if (raw.mode !== undefined) {
     if (!VALID_APPROVAL_MODE.includes(raw.mode)) {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -317,6 +317,7 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       ? requireConfigString(src.private_key, 'private_key')
       : undefined;
     const knownHostsFile = requireConfigString(src.known_hosts_file, 'known_hosts_file');
+    const description = requireConfigString(src.description, 'description');
 
     const out: ServerConfig = {
       name: src.id,
@@ -326,8 +327,8 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       authMode: src.auth,
       transport: resolvedTransport,
     };
-    if (typeof src.description === 'string' && src.description.length > 0) {
-      out.description = src.description;
+    if (description && description.length > 0) {
+      out.description = description;
     }
 
     switch (src.auth) {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -335,6 +335,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     // defaultName here is, by construction, a user-chosen explicit default.
     defaultExplicit: defaultName !== undefined,
     perSourceApproval,
+    // Surface [server].require_connection so the boot path can wire the
+    // omit-name guard opt-out. Undefined (field absent) keeps the guard ON.
+    requireConnection: server?.require_connection,
     server,
     webui,
     approval,
@@ -352,6 +355,12 @@ function validateServerSection(raw: any) {
       throw new Error('Config: [server].audit_max_bytes must be a positive number');
     }
     out.audit_max_bytes = raw.audit_max_bytes;
+  }
+  if (raw.require_connection !== undefined) {
+    if (typeof raw.require_connection !== 'boolean') {
+      throw new Error('Config: [server].require_connection must be a boolean');
+    }
+    out.require_connection = raw.require_connection;
   }
   return out;
 }

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -33,6 +33,29 @@ import type {
 
 const VALID_AUTH: AuthMode[] = ['kerberos', 'key', 'password'];
 const VALID_APPROVAL_MODE: ApprovalMode[] = ['yolo', 'smart', 'manual'];
+const SECRET_TOML_KEYS = [
+  'password',
+  'sudo_password',
+  'su_password',
+  'private_key',
+  'auth_token',
+  'api_key',
+];
+
+function redactTomlParseMessage(message: string): string {
+  const secretAssignment = new RegExp(
+    `(\\b(?:${SECRET_TOML_KEYS.join('|')})\\s*=\\s*).*$`,
+    'i',
+  );
+  return message
+    .split(/\r?\n/)
+    .map(line => line.replace(secretAssignment, '$1[REDACTED]'))
+    .join('\n');
+}
+
+function isMissingPathError(e: any): boolean {
+  return e?.code === 'ENOENT' || e?.code === 'ENOTDIR';
+}
 
 /** Replace a leading `~` with $HOME (POSIX + Windows). No-op for non-string. */
 export function expandHome(p: string | undefined): string | undefined {
@@ -91,8 +114,15 @@ export function discoverConfigPath(env: NodeJS.ProcessEnv = process.env): string
   for (const candidate of defaultDiscoveryPaths(env)) {
     try {
       if (fs.statSync(candidate).isFile()) return candidate;
-    } catch {
-      // not found / permission denied — fall through
+    } catch (e: any) {
+      // SSH_MCP_CONFIG is an explicit user/env selection. A missing env path
+      // still falls through to XDG/home discovery for compatibility, but an
+      // unreadable/inaccessible env path must fail closed rather than silently
+      // booting from a lower-precedence config.
+      if (candidate === env.SSH_MCP_CONFIG && !isMissingPathError(e)) {
+        throw new Error(`Config: cannot access ${candidate}: ${e?.message || e}`);
+      }
+      // not found — fall through
     }
   }
   return undefined;
@@ -131,7 +161,8 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
   try {
     parsed = TOML.parse(raw);
   } catch (e: any) {
-    throw new Error(`Config: TOML parse failed: ${e?.message || e}`);
+    const message = redactTomlParseMessage(e?.message || String(e));
+    throw new Error(`Config: TOML parse failed: ${message}`);
   }
 
   const rawSources = Array.isArray(parsed?.sources) ? parsed.sources : [];
@@ -247,7 +278,7 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     // non-strings unchanged, so a number would reach the SSH/sudo password
     // paths and fail with an opaque runtime type error. Reject it here with a
     // clear, redact-safe config error that names the field but not the value.
-    const requireSecretString = (
+    const requireConfigString = (
       value: unknown,
       field: string,
     ): string | undefined => {
@@ -259,20 +290,22 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     };
 
     const password = resolveEnvRef(
-      requireSecretString(src.password, 'password'),
+      requireConfigString(src.password, 'password'),
       `sources.${src.id}.password`,
       env,
     );
     const sudoPassword = resolveEnvRef(
-      requireSecretString(src.sudo_password, 'sudo_password'),
+      requireConfigString(src.sudo_password, 'sudo_password'),
       `sources.${src.id}.sudo_password`,
       env,
     );
     const suPassword = resolveEnvRef(
-      requireSecretString(src.su_password, 'su_password'),
+      requireConfigString(src.su_password, 'su_password'),
       `sources.${src.id}.su_password`,
       env,
     );
+    const keyPath = requireConfigString(src.key_path, 'key_path');
+    const privateKey = requireConfigString(src.private_key, 'private_key');
 
     const out: ServerConfig = {
       name: src.id,
@@ -291,15 +324,15 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
         }
         break;
       case 'key':
-        if (src.key_path) out.keyPath = expandHome(src.key_path);
+        if (keyPath) out.keyPath = expandHome(keyPath);
         // Resolve `env:NAME` for inline private_key the same way password/
         // sudo_password/su_password are resolved. Without this the literal
         // "env:SSH_KEY" placeholder would be copied into ServerConfig.privateKey
         // and the ssh2 transport would try to parse it as key material, failing
         // auth even when the env var is set (Codex 3541772408).
-        if (src.private_key) {
+        if (privateKey !== undefined) {
           out.privateKey = resolveEnvRef(
-            requireSecretString(src.private_key, 'private_key'),
+            privateKey,
             `sources.${src.id}.private_key`,
             env,
           );
@@ -371,13 +404,14 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       defaultName = src.id;
     }
 
-    if (src.approval && src.approval.mode) {
-      if (!VALID_APPROVAL_MODE.includes(src.approval.mode)) {
+    if (src.approval?.mode !== undefined) {
+      const mode = src.approval.mode;
+      if (typeof mode !== 'string' || !VALID_APPROVAL_MODE.includes(mode as ApprovalMode)) {
         throw new Error(
           `Config: sources.${src.id}.approval.mode must be one of: ${VALID_APPROVAL_MODE.join(', ')}`,
         );
       }
-      perSourceApproval[src.id] = src.approval.mode;
+      perSourceApproval[src.id] = mode as ApprovalMode;
     }
   }
 

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -244,6 +244,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       authMode: src.auth,
       transport: resolvedTransport,
     };
+    if (typeof src.description === 'string' && src.description.length > 0) {
+      out.description = src.description;
+    }
 
     switch (src.auth) {
       case 'kerberos':

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -1,0 +1,368 @@
+/**
+ * TOML config loader for ssh-mcp-kerberos.
+ *
+ * Responsibilities:
+ *  - Read file from disk.
+ *  - Parse via @iarna/toml.
+ *  - Resolve `env:NAME` strings against process.env (missing -> validation error).
+ *  - Expand leading `~` and `~/` to the user's home directory.
+ *  - Validate required fields and known enum values.
+ *  - Project the validated TOML into the runtime shape (`ResolvedConfig`)
+ *    that wires straight into TransportRegistry.register().
+ *  - Never echo secret material in error messages.
+ *
+ * Discovery (when no explicit path is provided):
+ *   1. $SSH_MCP_CONFIG
+ *   2. $XDG_CONFIG_HOME/ssh-mcp/config.toml  (or ~/.config/ssh-mcp/config.toml when XDG unset)
+ *   3. ~/.ssh-mcp/config.toml
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import TOML from '@iarna/toml';
+
+import type { AuthMode, ServerConfig } from '../transports/types.js';
+import type {
+  ApprovalMode,
+  ApprovalSection,
+  ResolvedConfig,
+  TomlConfig,
+  TomlSource,
+} from './types.js';
+
+const VALID_AUTH: AuthMode[] = ['kerberos', 'key', 'password'];
+const VALID_APPROVAL_MODE: ApprovalMode[] = ['yolo', 'smart', 'manual'];
+
+/** Replace a leading `~` with $HOME (POSIX + Windows). No-op for non-string. */
+export function expandHome(p: string | undefined): string | undefined {
+  if (!p) return p;
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Resolve `env:NAME` references against process.env. Returns the value
+ * unchanged when the prefix is absent. Throws a redact-safe error when
+ * the referenced env var is missing or empty so secrets are never logged.
+ */
+export function resolveEnvRef(
+  value: string | undefined,
+  fieldLabel: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') return value;
+  if (!value.startsWith('env:')) return value;
+  const name = value.slice(4).trim();
+  if (!name) {
+    throw new Error(`Config: ${fieldLabel} uses "env:" but no variable name was provided`);
+  }
+  const resolved = env[name];
+  if (resolved === undefined || resolved === '') {
+    throw new Error(
+      `Config: ${fieldLabel} references env var ${name}, but it is not set or empty`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Default discovery paths (in precedence order, highest first). Path is
+ * returned even when the file does not exist; the caller decides whether
+ * to require the discovered path.
+ */
+export function defaultDiscoveryPaths(env: NodeJS.ProcessEnv = process.env): string[] {
+  const paths: string[] = [];
+  if (env.SSH_MCP_CONFIG) paths.push(env.SSH_MCP_CONFIG);
+  const xdg = env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.trim()
+    ? env.XDG_CONFIG_HOME
+    : path.join(os.homedir(), '.config');
+  paths.push(path.join(xdg, 'ssh-mcp', 'config.toml'));
+  paths.push(path.join(os.homedir(), '.ssh-mcp', 'config.toml'));
+  return paths;
+}
+
+/** Locate the first existing discovery path, if any. */
+export function discoverConfigPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  for (const candidate of defaultDiscoveryPaths(env)) {
+    try {
+      if (fs.statSync(candidate).isFile()) return candidate;
+    } catch {
+      // not found / permission denied — fall through
+    }
+  }
+  return undefined;
+}
+
+interface LoadOptions {
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Parse a raw TOML string into the runtime `ResolvedConfig` shape.
+ * Used directly by tests; the file-system entry point `loadTomlFile`
+ * delegates here after reading the file.
+ */
+export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedConfig {
+  const env = opts.env ?? process.env;
+
+  let parsed: any;
+  try {
+    parsed = TOML.parse(raw);
+  } catch (e: any) {
+    throw new Error(`Config: TOML parse failed: ${e?.message || e}`);
+  }
+
+  const sources = Array.isArray(parsed?.sources) ? parsed.sources : [];
+  if (sources.length === 0) {
+    throw new Error('Config: at least one [[sources]] entry is required');
+  }
+
+  const resolvedSources: ServerConfig[] = [];
+  const perSourceApproval: Record<string, ApprovalMode> = {};
+  const seenNames = new Set<string>();
+  let defaultName: string | undefined;
+
+  for (let i = 0; i < sources.length; i++) {
+    const src = sources[i] as TomlSource;
+    const label = `[[sources]][${i}]`;
+
+    if (!src || typeof src !== 'object') {
+      throw new Error(`Config: ${label} must be a TOML table`);
+    }
+    if (!src.id || typeof src.id !== 'string') {
+      throw new Error(`Config: ${label} missing required string "id"`);
+    }
+    if (seenNames.has(src.id)) {
+      throw new Error(`Config: duplicate source id "${src.id}"`);
+    }
+    seenNames.add(src.id);
+
+    if (!src.host || typeof src.host !== 'string') {
+      throw new Error(`Config: sources.${src.id} missing required "host"`);
+    }
+    if (!src.user || typeof src.user !== 'string') {
+      throw new Error(`Config: sources.${src.id} missing required "user"`);
+    }
+    if (!src.auth || !VALID_AUTH.includes(src.auth)) {
+      throw new Error(
+        `Config: sources.${src.id}.auth must be one of: ${VALID_AUTH.join(', ')}`,
+      );
+    }
+    if (src.port !== undefined && (typeof src.port !== 'number' || !Number.isFinite(src.port))) {
+      throw new Error(`Config: sources.${src.id}.port must be a number`);
+    }
+    if (
+      src.transport !== undefined &&
+      src.transport !== 'ssh2' &&
+      src.transport !== 'openssh'
+    ) {
+      throw new Error(
+        `Config: sources.${src.id}.transport must be "ssh2" or "openssh"`,
+      );
+    }
+    if (
+      src.strict_host_key_checking !== undefined &&
+      !['yes', 'no', 'accept-new'].includes(src.strict_host_key_checking)
+    ) {
+      throw new Error(
+        `Config: sources.${src.id}.strict_host_key_checking must be yes|no|accept-new`,
+      );
+    }
+    if (
+      src.gssapi_delegate_credentials !== undefined &&
+      !['yes', 'no'].includes(src.gssapi_delegate_credentials)
+    ) {
+      throw new Error(
+        `Config: sources.${src.id}.gssapi_delegate_credentials must be yes|no`,
+      );
+    }
+
+    // Default transport mirrors index.ts logic: kerberos -> openssh, else explicit, else ssh2.
+    const resolvedTransport: 'ssh2' | 'openssh' = src.transport
+      ?? (src.auth === 'kerberos' ? 'openssh' : 'ssh2');
+
+    const password = resolveEnvRef(src.password, `sources.${src.id}.password`, env);
+    const sudoPassword = resolveEnvRef(src.sudo_password, `sources.${src.id}.sudo_password`, env);
+    const suPassword = resolveEnvRef(src.su_password, `sources.${src.id}.su_password`, env);
+
+    const out: ServerConfig = {
+      name: src.id,
+      host: src.host,
+      port: src.port ?? 22,
+      username: src.user,
+      authMode: src.auth,
+      transport: resolvedTransport,
+    };
+
+    switch (src.auth) {
+      case 'kerberos':
+        out.kerberos = true;
+        if (src.gssapi_delegate_credentials) {
+          out.gssapiDelegateCredentials = src.gssapi_delegate_credentials;
+        }
+        break;
+      case 'key':
+        if (src.key_path) out.keyPath = expandHome(src.key_path);
+        if (src.private_key) out.privateKey = src.private_key;
+        if (!out.keyPath && !out.privateKey) {
+          throw new Error(
+            `Config: sources.${src.id} auth="key" requires key_path or private_key`,
+          );
+        }
+        break;
+      case 'password':
+        if (!password) {
+          throw new Error(
+            `Config: sources.${src.id} auth="password" requires "password"`,
+          );
+        }
+        out.password = password;
+        break;
+    }
+
+    if (sudoPassword !== undefined) out.sudoPassword = sudoPassword;
+    if (suPassword !== undefined) out.suPassword = suPassword;
+    if (src.known_hosts_file) out.knownHostsFile = expandHome(src.known_hosts_file);
+    if (src.strict_host_key_checking) out.strictHostKeyChecking = src.strict_host_key_checking;
+
+    resolvedSources.push(out);
+
+    if (src.default === true) {
+      if (defaultName && defaultName !== src.id) {
+        throw new Error(
+          `Config: multiple sources marked default ("${defaultName}" and "${src.id}")`,
+        );
+      }
+      defaultName = src.id;
+    }
+
+    if (src.approval && src.approval.mode) {
+      if (!VALID_APPROVAL_MODE.includes(src.approval.mode)) {
+        throw new Error(
+          `Config: sources.${src.id}.approval.mode must be one of: ${VALID_APPROVAL_MODE.join(', ')}`,
+        );
+      }
+      perSourceApproval[src.id] = src.approval.mode;
+    }
+  }
+
+  const server = parsed.server ? validateServerSection(parsed.server) : undefined;
+  const webui = parsed.webui ? validateWebUI(parsed.webui, env) : undefined;
+  const approval = parsed.approval ? validateApproval(parsed.approval, env) : undefined;
+
+  return {
+    sources: resolvedSources,
+    defaultName,
+    perSourceApproval,
+    server,
+    webui,
+    approval,
+  };
+}
+
+function validateServerSection(raw: any) {
+  const out: TomlConfig['server'] = {};
+  if (raw.audit_dir !== undefined) {
+    if (typeof raw.audit_dir !== 'string') throw new Error('Config: [server].audit_dir must be a string');
+    out.audit_dir = expandHome(raw.audit_dir);
+  }
+  if (raw.audit_max_bytes !== undefined) {
+    if (typeof raw.audit_max_bytes !== 'number' || raw.audit_max_bytes <= 0) {
+      throw new Error('Config: [server].audit_max_bytes must be a positive number');
+    }
+    out.audit_max_bytes = raw.audit_max_bytes;
+  }
+  return out;
+}
+
+function validateWebUI(raw: any, env: NodeJS.ProcessEnv) {
+  const out: TomlConfig['webui'] = {};
+  if (raw.enabled !== undefined) {
+    if (typeof raw.enabled !== 'boolean') throw new Error('Config: [webui].enabled must be a boolean');
+    out.enabled = raw.enabled;
+  }
+  if (raw.host !== undefined) {
+    if (typeof raw.host !== 'string') throw new Error('Config: [webui].host must be a string');
+    out.host = raw.host;
+  }
+  if (raw.port !== undefined) {
+    if (typeof raw.port !== 'number') throw new Error('Config: [webui].port must be a number');
+    out.port = raw.port;
+  }
+  if (raw.auth_token !== undefined) {
+    out.auth_token = resolveEnvRef(String(raw.auth_token), '[webui].auth_token', env);
+  }
+  // Cross-field check: non-loopback bind requires a token.
+  if (out.host && out.host !== '127.0.0.1' && out.host !== 'localhost' && out.host !== '::1') {
+    if (!out.auth_token) {
+      throw new Error(
+        `Config: [webui].host="${out.host}" is non-loopback; auth_token is required`,
+      );
+    }
+  }
+  return out;
+}
+
+function validateApproval(raw: any, env: NodeJS.ProcessEnv): ApprovalSection {
+  const out: ApprovalSection = {};
+  if (raw.mode !== undefined) {
+    if (!VALID_APPROVAL_MODE.includes(raw.mode)) {
+      throw new Error(`Config: [approval].mode must be one of: ${VALID_APPROVAL_MODE.join(', ')}`);
+    }
+    out.mode = raw.mode;
+  }
+  if (raw.fail_closed !== undefined) {
+    if (typeof raw.fail_closed !== 'boolean') {
+      throw new Error('Config: [approval].fail_closed must be a boolean');
+    }
+    out.fail_closed = raw.fail_closed;
+  }
+  if (raw.llm !== undefined) {
+    if (typeof raw.llm !== 'object' || raw.llm === null) {
+      throw new Error('Config: [approval.llm] must be a table');
+    }
+    const llm = raw.llm;
+    const resolved: ApprovalSection['llm'] = {};
+    if (llm.endpoint !== undefined) {
+      if (typeof llm.endpoint !== 'string') throw new Error('Config: [approval.llm].endpoint must be a string');
+      resolved.endpoint = llm.endpoint;
+    }
+    if (llm.api_key !== undefined) {
+      resolved.api_key = resolveEnvRef(String(llm.api_key), '[approval.llm].api_key', env);
+    }
+    if (llm.model !== undefined) {
+      if (typeof llm.model !== 'string') throw new Error('Config: [approval.llm].model must be a string');
+      resolved.model = llm.model;
+    }
+    if (llm.timeout_ms !== undefined) {
+      if (typeof llm.timeout_ms !== 'number' || llm.timeout_ms <= 0) {
+        throw new Error('Config: [approval.llm].timeout_ms must be a positive number');
+      }
+      resolved.timeout_ms = llm.timeout_ms;
+    }
+    if (llm.provider !== undefined) {
+      if (typeof llm.provider !== 'string') throw new Error('Config: [approval.llm].provider must be a string');
+      resolved.provider = llm.provider;
+    }
+    out.llm = resolved;
+  }
+  return out;
+}
+
+/** Load + parse a TOML file from disk. Throws on missing file or any validation error. */
+export function loadTomlFile(filePath: string, opts: LoadOptions = {}): ResolvedConfig {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (e: any) {
+    throw new Error(`Config: cannot read ${filePath}: ${e?.message || e}`);
+  }
+  const parsed = parseTomlConfig(raw, opts);
+  parsed.configPath = filePath;
+  return parsed;
+}

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -296,16 +296,22 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     const passwordValue = src.auth === 'password'
       ? requireConfigString(src.password, 'password')
       : undefined;
-    const sudoPassword = resolveEnvRef(
-      requireConfigString(src.sudo_password, 'sudo_password'),
-      `sources.${src.id}.sudo_password`,
-      env,
-    );
-    const suPassword = resolveEnvRef(
-      requireConfigString(src.su_password, 'su_password'),
-      `sources.${src.id}.su_password`,
-      env,
-    );
+    const resolveOptionalElevationPassword = (
+      value: unknown,
+      field: 'sudo_password' | 'su_password',
+    ): string | undefined => {
+      const resolved = resolveEnvRef(
+        requireConfigString(value, field),
+        `sources.${src.id}.${field}`,
+        env,
+      );
+      // Treat an explicitly empty TOML elevation password as unset. Leaving it
+      // as '' makes the OpenSSH sudo path feed a blank line via sudo -S, which
+      // blocks the intended passwordless-sudo / suPassword fallback behavior.
+      return resolved === '' ? undefined : resolved;
+    };
+    const sudoPassword = resolveOptionalElevationPassword(src.sudo_password, 'sudo_password');
+    const suPassword = resolveOptionalElevationPassword(src.su_password, 'su_password');
     const keyPath = requireConfigString(src.key_path, 'key_path');
     const privateKey = src.auth === 'key'
       ? requireConfigString(src.private_key, 'private_key')
@@ -538,7 +544,10 @@ function validateApproval(raw: any, env: NodeJS.ProcessEnv): ApprovalSection {
       // for a user who copied the example config without enabling smart mode.
       // Defer resolution to smart mode; leave api_key unresolved otherwise.
       if (out.mode === 'smart') {
-        resolved.api_key = resolveEnvRef(String(llm.api_key), '[approval.llm].api_key', env);
+        if (typeof llm.api_key !== 'string') {
+          throw new Error('Config: [approval.llm].api_key must be a string');
+        }
+        resolved.api_key = resolveEnvRef(llm.api_key, '[approval.llm].api_key', env);
       }
     }
     if (llm.model !== undefined) {

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -366,7 +366,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
 
   const server = parsed.server ? validateServerSection(parsed.server) : undefined;
   const webui = parsed.webui ? validateWebUI(parsed.webui, env) : undefined;
-  const approval = parsed.approval ? validateApproval(parsed.approval, env) : undefined;
+  const approval = parsed.approval
+    ? validateApproval(parsed.approval, env, Object.values(perSourceApproval).includes('smart'))
+    : undefined;
 
   return {
     sources: resolvedSources,
@@ -434,7 +436,11 @@ function validateWebUI(raw: any, env: NodeJS.ProcessEnv) {
   return out;
 }
 
-function validateApproval(raw: any, env: NodeJS.ProcessEnv): ApprovalSection {
+function validateApproval(
+  raw: any,
+  env: NodeJS.ProcessEnv,
+  resolveLlmApiKeyForPerSourceSmart = false,
+): ApprovalSection {
   const out: ApprovalSection = {};
   if (raw.mode !== undefined) {
     if (!VALID_APPROVAL_MODE.includes(raw.mode)) {
@@ -459,12 +465,12 @@ function validateApproval(raw: any, env: NodeJS.ProcessEnv): ApprovalSection {
       resolved.endpoint = llm.endpoint;
     }
     if (llm.api_key !== undefined) {
-      // Only resolve the api_key env ref when smart approval is actually
-      // enabled. [approval.llm] settings are irrelevant in the default/manual
+      // Only resolve the api_key env ref when smart approval is actually used:
+      // either by the top-level [approval].mode or by a per-source override.
+      // [approval.llm] settings are otherwise irrelevant in the default/manual
       // mode, so resolving here would fail startup on a missing OPENAI_API_KEY
       // for a user who copied the example config without enabling smart mode.
-      // Defer resolution to smart mode; leave api_key unresolved otherwise.
-      if (out.mode === 'smart') {
+      if (out.mode === 'smart' || resolveLlmApiKeyForPerSourceSmart) {
         resolved.api_key = resolveEnvRef(String(llm.api_key), '[approval.llm].api_key', env);
       }
     }

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -107,6 +107,16 @@ interface LoadOptions {
    * combination instead of a hard error.
    */
   allowEmptySources?: boolean;
+  /**
+   * Skip [[sources]] parsing, validation, and secret env-ref resolution
+   * entirely, projecting only the top-level sections. Used by the resolver
+   * when CLI sources are present and SUPPRESS the TOML source list: the
+   * suppressed [[sources]] are discarded downstream, so validating them here
+   * (and resolving their `env:` secrets) would abort startup on a source-only
+   * error even though only the top-level sections are meant to survive.
+   * Implies allowEmptySources.
+   */
+  ignoreSources?: boolean;
 }
 
 /**
@@ -124,8 +134,12 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     throw new Error(`Config: TOML parse failed: ${e?.message || e}`);
   }
 
-  const sources = Array.isArray(parsed?.sources) ? parsed.sources : [];
-  if (sources.length === 0 && !opts.allowEmptySources) {
+  const rawSources = Array.isArray(parsed?.sources) ? parsed.sources : [];
+  // When ignoreSources is set the CLI sources win and suppress the entire TOML
+  // source list downstream, so skip parsing/validating them here (an env: ref
+  // or other source-only error in a suppressed source must not abort startup).
+  const sources = opts.ignoreSources ? [] : rawSources;
+  if (sources.length === 0 && !opts.allowEmptySources && !opts.ignoreSources) {
     throw new Error('Config: at least one [[sources]] entry is required');
   }
 
@@ -160,8 +174,21 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
         `Config: sources.${src.id}.auth must be one of: ${VALID_AUTH.join(', ')}`,
       );
     }
-    if (src.port !== undefined && (typeof src.port !== 'number' || !Number.isFinite(src.port))) {
-      throw new Error(`Config: sources.${src.id}.port must be a number`);
+    if (src.port !== undefined) {
+      // This loader is the validation boundary for TOML sources, so reject a
+      // port that is not a usable TCP port here rather than letting a value
+      // like 22.5 / -1 / 70000 register and fail later with an opaque
+      // transport-level error from ssh2/OpenSSH.
+      if (
+        typeof src.port !== 'number' ||
+        !Number.isInteger(src.port) ||
+        src.port < 1 ||
+        src.port > 65535
+      ) {
+        throw new Error(
+          `Config: sources.${src.id}.port must be an integer between 1 and 65535`,
+        );
+      }
     }
     if (
       src.transport !== undefined &&
@@ -186,6 +213,17 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     ) {
       throw new Error(
         `Config: sources.${src.id}.gssapi_delegate_credentials must be yes|no`,
+      );
+    }
+    // GSSAPIDelegateCredentials is only wired in the Kerberos auth branch (see
+    // the `case 'kerberos'` below and OpenSshTransport.buildArgs); for key or
+    // password auth the option is silently dropped, so a user requesting
+    // credential delegation would get none with no error. Mirror the legacy CLI
+    // rule ("--gssapiDelegateCredentials requires --kerberos") and reject the
+    // combination at parse time.
+    if (src.gssapi_delegate_credentials !== undefined && src.auth !== 'kerberos') {
+      throw new Error(
+        `Config: sources.${src.id}.gssapi_delegate_credentials requires auth="kerberos"`,
       );
     }
 
@@ -418,7 +456,14 @@ function validateApproval(raw: any, env: NodeJS.ProcessEnv): ApprovalSection {
       resolved.endpoint = llm.endpoint;
     }
     if (llm.api_key !== undefined) {
-      resolved.api_key = resolveEnvRef(String(llm.api_key), '[approval.llm].api_key', env);
+      // Only resolve the api_key env ref when smart approval is actually
+      // enabled. [approval.llm] settings are irrelevant in the default/manual
+      // mode, so resolving here would fail startup on a missing OPENAI_API_KEY
+      // for a user who copied the example config without enabling smart mode.
+      // Defer resolution to smart mode; leave api_key unresolved otherwise.
+      if (out.mode === 'smart') {
+        resolved.api_key = resolveEnvRef(String(llm.api_key), '[approval.llm].api_key', env);
+      }
     }
     if (llm.model !== undefined) {
       if (typeof llm.model !== 'string') throw new Error('Config: [approval.llm].model must be a string');

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -181,6 +181,12 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
         `Config: sources.${src.id}.gssapi_delegate_credentials must be yes|no`,
       );
     }
+    if (src.default !== undefined && typeof src.default !== 'boolean') {
+      throw new Error(`Config: sources.${src.id}.default must be a boolean`);
+    }
+    if (src.description !== undefined && typeof src.description !== 'string') {
+      throw new Error(`Config: sources.${src.id}.description must be a string`);
+    }
 
     // Default transport mirrors index.ts logic: kerberos -> openssh, else explicit, else ssh2.
     const resolvedTransport: 'ssh2' | 'openssh' = src.transport
@@ -227,6 +233,7 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
 
     if (sudoPassword !== undefined) out.sudoPassword = sudoPassword;
     if (suPassword !== undefined) out.suPassword = suPassword;
+    if (src.description !== undefined) out.description = src.description;
     if (src.known_hosts_file) out.knownHostsFile = expandHome(src.known_hosts_file);
     if (src.strict_host_key_checking) out.strictHostKeyChecking = src.strict_host_key_checking;
 
@@ -241,12 +248,13 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       defaultName = src.id;
     }
 
-    if (src.approval && src.approval.mode) {
+    if (src.approval?.mode) {
       if (!VALID_APPROVAL_MODE.includes(src.approval.mode)) {
         throw new Error(
           `Config: sources.${src.id}.approval.mode must be one of: ${VALID_APPROVAL_MODE.join(', ')}`,
         );
       }
+      out.approval = { mode: src.approval.mode };
       perSourceApproval[src.id] = src.approval.mode;
     }
   }

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -113,7 +113,11 @@ export function defaultDiscoveryPaths(env: NodeJS.ProcessEnv = process.env): str
 export function discoverConfigPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
   for (const candidate of defaultDiscoveryPaths(env)) {
     try {
-      if (fs.statSync(candidate).isFile()) return candidate;
+      const st = fs.statSync(candidate);
+      if (st.isFile()) return candidate;
+      if (candidate === env.SSH_MCP_CONFIG) {
+        throw new Error(`Config: cannot access ${candidate}: not a regular file`);
+      }
     } catch (e: any) {
       // SSH_MCP_CONFIG is an explicit user/env selection. A missing env path
       // still falls through to XDG/home discovery for compatibility, but an
@@ -289,11 +293,9 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       return value;
     };
 
-    const password = resolveEnvRef(
-      requireConfigString(src.password, 'password'),
-      `sources.${src.id}.password`,
-      env,
-    );
+    const passwordValue = src.auth === 'password'
+      ? requireConfigString(src.password, 'password')
+      : undefined;
     const sudoPassword = resolveEnvRef(
       requireConfigString(src.sudo_password, 'sudo_password'),
       `sources.${src.id}.sudo_password`,
@@ -305,7 +307,10 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
       env,
     );
     const keyPath = requireConfigString(src.key_path, 'key_path');
-    const privateKey = requireConfigString(src.private_key, 'private_key');
+    const privateKey = src.auth === 'key'
+      ? requireConfigString(src.private_key, 'private_key')
+      : undefined;
+    const knownHostsFile = requireConfigString(src.known_hosts_file, 'known_hosts_file');
 
     const out: ServerConfig = {
       name: src.id,
@@ -325,6 +330,22 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
         break;
       case 'key':
         if (keyPath) out.keyPath = expandHome(keyPath);
+        // The openssh transport authenticates with `-i <keyPath>` and never
+        // materializes an inline private_key — supplying only private_key on
+        // openssh silently falls back to default-identity pubkey auth. Treat
+        // inline private_key as unsupported on openssh: require key_path and do
+        // not resolve an unused private_key env ref that could fail startup.
+        // (ssh2 reads inline key contents in memory, so inline private_key
+        // remains valid there.)
+        if (resolvedTransport === 'openssh') {
+          if (!out.keyPath) {
+            throw new Error(
+              `Config: sources.${src.id} auth="key" with transport="openssh" requires key_path ` +
+              `(inline private_key is not supported on the openssh transport)`,
+            );
+          }
+          break;
+        }
         // Resolve `env:NAME` for inline private_key the same way password/
         // sudo_password/su_password are resolved. Without this the literal
         // "env:SSH_KEY" placeholder would be copied into ServerConfig.privateKey
@@ -342,20 +363,13 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
             `Config: sources.${src.id} auth="key" requires key_path or private_key`,
           );
         }
-        // The openssh transport authenticates with `-i <keyPath>` and never
-        // materializes an inline private_key — supplying only private_key on
-        // openssh silently falls back to default-identity pubkey auth. Require
-        // an on-disk key_path for openssh key sources so the configured key is
-        // actually used. (ssh2 reads inline key contents in memory, so inline
-        // private_key remains valid there.)
-        if (resolvedTransport === 'openssh' && !out.keyPath) {
-          throw new Error(
-            `Config: sources.${src.id} auth="key" with transport="openssh" requires key_path ` +
-            `(inline private_key is not supported on the openssh transport)`,
-          );
-        }
         break;
-      case 'password':
+      case 'password': {
+        const password = resolveEnvRef(
+          passwordValue,
+          `sources.${src.id}.password`,
+          env,
+        );
         if (!password) {
           throw new Error(
             `Config: sources.${src.id} auth="password" requires "password"`,
@@ -363,6 +377,7 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
         }
         out.password = password;
         break;
+      }
     }
 
     if (sudoPassword !== undefined) out.sudoPassword = sudoPassword;
@@ -374,14 +389,14 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
     // require --transport=openssh") and reject the combination at parse time.
     if (
       resolvedTransport === 'ssh2' &&
-      (src.known_hosts_file || src.strict_host_key_checking)
+      (knownHostsFile !== undefined || src.strict_host_key_checking !== undefined)
     ) {
       throw new Error(
         `Config: sources.${src.id} known_hosts_file/strict_host_key_checking require transport="openssh" ` +
         `(the ssh2 transport does not enforce host keys)`,
       );
     }
-    if (src.known_hosts_file) out.knownHostsFile = expandHome(src.known_hosts_file);
+    if (knownHostsFile !== undefined) out.knownHostsFile = expandHome(knownHostsFile);
     if (src.strict_host_key_checking) out.strictHostKeyChecking = src.strict_host_key_checking;
 
     resolvedSources.push(out);
@@ -471,8 +486,10 @@ function validateWebUI(raw: any, env: NodeJS.ProcessEnv) {
     if (typeof raw.port !== 'number') throw new Error('Config: [webui].port must be a number');
     out.port = raw.port;
   }
-  if (raw.auth_token !== undefined) {
-    out.auth_token = resolveEnvRef(String(raw.auth_token), '[webui].auth_token', env);
+  const webuiEnabled = out.enabled === true;
+  if (raw.auth_token !== undefined && webuiEnabled) {
+    if (typeof raw.auth_token !== 'string') throw new Error('Config: [webui].auth_token must be a string');
+    out.auth_token = resolveEnvRef(raw.auth_token, '[webui].auth_token', env);
   }
   // Cross-field check: a non-loopback bind requires a token — but ONLY when the
   // web UI is actually enabled. With `[webui] enabled = false` the section is
@@ -480,7 +497,7 @@ function validateWebUI(raw: any, env: NodeJS.ProcessEnv) {
   // section would let an otherwise-off optional block fail SSH startup (Codex
   // 3541772404). When the eventual CLI enable path turns it on, the same check
   // applies against the resolved enabled=true state.
-  if (out.enabled && out.host && out.host !== '127.0.0.1' && out.host !== 'localhost' && out.host !== '::1') {
+  if (webuiEnabled && out.host && out.host !== '127.0.0.1' && out.host !== 'localhost' && out.host !== '::1') {
     if (!out.auth_token) {
       throw new Error(
         `Config: [webui].host="${out.host}" is non-loopback; auth_token is required when [webui].enabled = true`,

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -330,6 +330,10 @@ export function parseTomlConfig(raw: string, opts: LoadOptions = {}): ResolvedCo
   return {
     sources: resolvedSources,
     defaultName,
+    // In a TOML, defaultName is set ONLY by an explicit `default = true` on a
+    // source (see the loop above) — never a positional fallback. So a defined
+    // defaultName here is, by construction, a user-chosen explicit default.
+    defaultExplicit: defaultName !== undefined,
     perSourceApproval,
     server,
     webui,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -91,6 +91,17 @@ export interface ResolvedConfig {
   sources: ServerConfig[];
   /** Name of the source TransportRegistry should treat as default, if any. */
   defaultName?: string;
+  /**
+   * True ONLY when the user explicitly chose a default (a TOML source with
+   * `default = true`). False when `defaultName` is merely the first-registered
+   * fallback. The boot path keys the multi-source omit-name guard on this:
+   * `setDefault()` (which re-enables the omit-name shortcut) is called only for
+   * an explicit default, so a multi-source config with no explicit default
+   * still rejects an omitted connectionName instead of silently routing to the
+   * first host. Required (not optional) so every construction site states its
+   * intent and the compiler catches omissions.
+   */
+  defaultExplicit: boolean;
   /** Per-source approval override, keyed by source name. */
   perSourceApproval: Record<string, ApprovalMode>;
   server?: ServerSection;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,6 +47,12 @@ export interface ApprovalSection {
 /** A single [[sources]] entry from the TOML. */
 export interface TomlSource {
   id: string;
+  /**
+   * Human-readable label for the source. RESERVED: parsed and type-checked
+   * here but not yet projected into ServerConfig — a downstream task
+   * (webui-description-edit) consumes it. Documented in ssh-mcp.toml.example so
+   * configs can declare it ahead of that consumer landing.
+   */
   description?: string;
   host: string;
   port?: number;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -18,6 +18,13 @@ export interface ServerSection {
   audit_dir?: string;
   /** Per-record stdout/stderr cap. Default 10000. */
   audit_max_bytes?: number;
+  /**
+   * Opt out of the multi-source omit-name connection guard (restore the legacy
+   * silent first-source default). Absent or `true` keeps the guard ON (safe);
+   * `false` disables it. Projected onto ResolvedConfig.requireConnection and
+   * consumed by applyRegistryConnectionPolicy at boot.
+   */
+  require_connection?: boolean;
 }
 
 /** Top-level [webui] block — optional. WebUI is OFF unless enabled or --webui passed. */
@@ -104,6 +111,13 @@ export interface ResolvedConfig {
   defaultExplicit: boolean;
   /** Per-source approval override, keyed by source name. */
   perSourceApproval: Record<string, ApprovalMode>;
+  /**
+   * Boot-time value of [server].require_connection. When `false` the
+   * multi-source omit-name guard is disabled (legacy first-source default);
+   * `undefined`/`true` keeps it ON. applyRegistryConnectionPolicy applies the
+   * safe default, so a config that predates this field stays guarded.
+   */
+  requireConnection?: boolean;
   server?: ServerSection;
   webui?: WebUISection;
   approval?: ApprovalSection;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,95 @@
+/**
+ * TOML config schema for ssh-mcp-kerberos.
+ *
+ * Mirrors dbhub's [[sources]]/[server]/[webui]/[approval] layout. The parsed
+ * representation is intentionally a superset: only `sources` is required.
+ * Other sections are reserved for the audit-log, approval-engine, and
+ * webui-status tasks downstream — this task implements parsing + validation
+ * for the whole shape so later tasks need only consume it.
+ */
+
+import type { AuthMode, ServerConfig } from '../transports/types.js';
+
+export type ApprovalMode = 'yolo' | 'smart' | 'manual';
+
+/** Top-level [server] block — optional. */
+export interface ServerSection {
+  /** Audit dir; defaults to ~/.ssh-mcp. Expanded ~ at parse time. */
+  audit_dir?: string;
+  /** Per-record stdout/stderr cap. Default 10000. */
+  audit_max_bytes?: number;
+}
+
+/** Top-level [webui] block — optional. WebUI is OFF unless enabled or --webui passed. */
+export interface WebUISection {
+  enabled?: boolean;
+  host?: string;        // default 127.0.0.1
+  port?: number;        // default 8088
+  auth_token?: string;  // required when host != 127.0.0.1; supports env:NAME
+}
+
+/** [approval.llm] block — used in smart mode. */
+export interface ApprovalLLMSection {
+  endpoint?: string;
+  api_key?: string;     // supports env:NAME
+  model?: string;
+  timeout_ms?: number;
+  provider?: 'openai' | string;
+}
+
+/** Top-level [approval] block — optional. */
+export interface ApprovalSection {
+  mode?: ApprovalMode;       // default 'manual'
+  fail_closed?: boolean;     // default true
+  llm?: ApprovalLLMSection;
+}
+
+/** A single [[sources]] entry from the TOML. */
+export interface TomlSource {
+  id: string;
+  description?: string;
+  host: string;
+  port?: number;
+  user: string;
+  auth: AuthMode;
+  key_path?: string;
+  private_key?: string;
+  password?: string;        // supports env:NAME
+  sudo_password?: string;   // supports env:NAME
+  su_password?: string;     // supports env:NAME
+  transport?: 'ssh2' | 'openssh';
+  kerberos?: boolean;
+  gssapi_delegate_credentials?: 'yes' | 'no';
+  known_hosts_file?: string;
+  strict_host_key_checking?: 'yes' | 'no' | 'accept-new';
+  default?: boolean;
+  /** Per-source approval override (just `mode` for v1). */
+  approval?: { mode?: ApprovalMode };
+}
+
+/** The raw, parsed TOML document (post-validation). */
+export interface TomlConfig {
+  server?: ServerSection;
+  webui?: WebUISection;
+  approval?: ApprovalSection;
+  sources: TomlSource[];
+}
+
+/**
+ * The shape consumed by `src/index.ts` and the TransportRegistry. Mirrors
+ * the existing `ServerConfig` array (one per registered host) plus a few
+ * top-level sections future tasks (audit/approval/webui) will read.
+ */
+export interface ResolvedConfig {
+  /** ServerConfig values fed to TransportRegistry.register, in order. */
+  sources: ServerConfig[];
+  /** Name of the source TransportRegistry should treat as default, if any. */
+  defaultName?: string;
+  /** Per-source approval override, keyed by source name. */
+  perSourceApproval: Record<string, ApprovalMode>;
+  server?: ServerSection;
+  webui?: WebUISection;
+  approval?: ApprovalSection;
+  /** Path the TOML was loaded from (for diagnostics). Undefined when no TOML used. */
+  configPath?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ const resolvedConfig: ResolvedConfig = (isCliEnabled || isTestMode)
       cliSources: cliSourceConfigs,
       cliConfigPath: typeof CONFIG_PATH === 'string' ? CONFIG_PATH : undefined,
     })
-  : { sources: [], perSourceApproval: {} };
+  : { sources: [], perSourceApproval: {}, defaultExplicit: false };
 
 if (isCliEnabled) {
   if (isMultiHost) {
@@ -392,8 +392,32 @@ async function bootstrapRegistry(): Promise<void> {
     await prepareKeyContents(cfg);
     registry.register(cfg);
   }
-  if (resolvedConfig.defaultName) {
-    registry.setDefault(resolvedConfig.defaultName);
+  applyRegistryConnectionPolicy(registry, resolvedConfig);
+}
+
+/**
+ * Wire the resolved connection policy onto a registry whose sources are already
+ * registered. Split out (and exported) so the explicit-default / fallback /
+ * require_connection opt-out matrix is unit-testable without booting the server.
+ *
+ * Two independent knobs:
+ *  - defaultExplicit: call setDefault() ONLY when the user explicitly chose a
+ *    default. Falling through to register()'s first-registered fallback leaves
+ *    the registry's defaultExplicit=false, so a multi-source config with no
+ *    explicit default still rejects an omitted connectionName (the headline
+ *    security fix) instead of silently routing to the first host.
+ *  - requireConnection: when false, opt out of that guard entirely. Absent the
+ *    field (older ResolvedConfig shape) it defaults to safe (guard ON).
+ */
+export function applyRegistryConnectionPolicy(
+  reg: Pick<TransportRegistry, 'setDefault' | 'setRequireConnectionWhenMulti'>,
+  config: ResolvedConfig,
+): void {
+  const requireConnection =
+    (config as { requireConnection?: boolean }).requireConnection ?? true;
+  reg.setRequireConnectionWhenMulti(requireConnection);
+  if (config.defaultExplicit && config.defaultName) {
+    reg.setDefault(config.defaultName);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -634,38 +634,58 @@ let auditSink: AuditSink = { record() { /* no-op until wired (or audit absent) *
  * perSourceModes for the manual-without-resolver boot warning) so the warning
  * can never disagree with the mode the engine actually runs.
  */
-function resolveApprovalEngineInput(): BuildEngineFromConfigInput | null {
-  const approvalCfg = resolvedConfig.approval;
-  const perSourceModes: ApprovalMode[] = Object.values(resolvedConfig.perSourceApproval ?? {});
+export function resolveApprovalEngineInput(
+  config: ResolvedConfig = resolvedConfig,
+): BuildEngineFromConfigInput | null {
+  const approvalCfg = config.approval;
+  const perSourceModes: ApprovalMode[] = Object.values(config.perSourceApproval ?? {});
   if (approvalCfg === undefined && perSourceModes.length === 0) {
     return null;
   }
+  const approvalLlmOnly = approvalCfg !== undefined
+    && approvalCfg.mode === undefined
+    && approvalCfg.fail_closed === undefined
+    && approvalCfg.llm !== undefined;
+  const perSourceOnlyDefault = perSourceModes.length > 0
+    && (approvalCfg === undefined || approvalLlmOnly);
   return {
     // Resolve the GLOBAL default mode:
     //  - explicit [approval].mode set        -> honor it.
-    //  - no global mode, per-source overrides -> the [approval] block (when
-    //    present at all) exists only to host [approval.llm] for a per-source
-    //    smart override; keep the global default 'yolo' (unrestricted) so only
-    //    the overridden sources are gated. Defining [approval.llm] for a
-    //    per-source `mode = "smart"` makes resolvedConfig.approval non-undefined
-    //    even though no global mode was requested, so keying solely on
-    //    `approvalCfg === undefined` would wrongly fall through to manual here
-    //    and gate every ungated host (or throw at boot with WebUI off). This
-    //    also covers the no-[approval]-block case (per-source overrides only).
-    //  - no global mode and no per-source overrides -> a bare [approval] block
-    //    (e.g. `fail_closed = true`, or `[approval.llm]` alone) was added
+    //  - no global mode, per-source overrides, and either no [approval] block
+    //    or an [approval.llm]-only block -> keep the global default 'yolo'
+    //    (unrestricted) so only the overridden sources are gated. Defining
+    //    [approval.llm] for a per-source `mode = "smart"` makes
+    //    resolvedConfig.approval non-undefined even though no global mode was
+    //    requested, so keying solely on `approvalCfg === undefined` would
+    //    wrongly fall through to manual here and gate every ungated host (or
+    //    throw at boot with WebUI off).
+    //  - no global mode but a real top-level approval knob (e.g.
+    //    `fail_closed = true`, or a bare [approval] block) was added
     //    deliberately to enable approval; leave defaultMode undefined so
     //    buildApprovalEngineFromConfig applies the documented 'manual' default.
     defaultMode:
       approvalCfg?.mode !== undefined
         ? approvalCfg.mode
-        : perSourceModes.length > 0
+        : perSourceOnlyDefault
           ? 'yolo'
           : undefined,
     fail_closed: approvalCfg?.fail_closed,
     llm: approvalCfg?.llm,
     perSourceModes,
   };
+}
+
+export function approvalResolverWarningFromInput(
+  input: BuildEngineFromConfigInput | null,
+  params: { webuiEnabled: boolean; resolverWired: boolean },
+): string | null {
+  if (input === null) return null;
+  return manualWithoutResolverWarning({
+    webuiEnabled: params.webuiEnabled,
+    defaultMode: input.defaultMode,
+    perSourceModes: input.perSourceModes,
+    resolverWired: params.resolverWired,
+  });
 }
 
 /**
@@ -722,10 +742,8 @@ async function wireApprovalAndAudit(): Promise<void> {
   // still succeeds (the queue exists, it just times out until a resolver lands);
   // warn so the operator is not left wondering why every command hangs.
   const input = resolveApprovalEngineInput();
-  const warning = manualWithoutResolverWarning({
+  const warning = approvalResolverWarningFromInput(input, {
     webuiEnabled: webuiActive,
-    defaultMode: input?.defaultMode,
-    perSourceModes: input?.perSourceModes,
     resolverWired: isApprovalResolverWired(),
   });
   if (warning) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -686,22 +686,36 @@ export function applyRegistryConnectionPolicy(
   }
 }
 
-/** Effective profile/connection name for gating + audit attribution. */
-function resolvedProfileName(connectionName?: string): string {
-  // Treat an empty/blank connectionName as "omitted", mirroring
-  // TransportRegistry.resolveName() (which routes `''` to the default host).
-  // Otherwise gating + audit attribution would be computed for the literal
-  // profile id '' while the command actually ran against the default host,
-  // silently bypassing that host's per-source approval policy.
-  const name = connectionName && connectionName.trim() !== '' ? connectionName : undefined;
-  if (name) return name;
+/**
+ * Profile label used before registry target resolution succeeds.
+ *
+ * Match TransportRegistry.resolveRegisteredName() exactly: only a falsy name
+ * is omitted. In particular, whitespace is a supplied (invalid) name, so a
+ * rejected call must remain attributed to that unresolved value instead of a
+ * real default host.
+ */
+export function preResolutionProfileName(
+  connectionName: string | undefined,
+  defaultName: string | null,
+  wouldRejectOmittedName: boolean,
+): string {
+  if (connectionName) return connectionName;
   // An omitted/blank name that the registry would REJECT (multi-source, no
   // explicit default, guard on) never lands on a host: resolveName() throws
   // before selection. Attributing that rejected call to getDefaultName() (the
   // first-registered host) would corrupt audit profile for exactly the guard
   // case. Mirror the guard and label it unresolved instead of a real host.
-  if (registry.wouldRejectOmittedName()) return '(unresolved)';
-  return registry.getDefaultName() ?? 'default';
+  if (wouldRejectOmittedName) return '(unresolved)';
+  return defaultName ?? 'default';
+}
+
+/** Effective profile/connection name for gating + audit attribution. */
+function resolvedProfileName(connectionName?: string): string {
+  return preResolutionProfileName(
+    connectionName,
+    registry.getDefaultName(),
+    registry.wouldRejectOmittedName(),
+  );
 }
 
 export function buildApprovalProfile(

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,10 @@ async function getOrCreateTransport(): Promise<ISshTransport> {
  * Map ExecResult to MCP tool response. Preserves upstream semantics:
  *   - auth/host_key/connect/transport categories → reject with descriptive error
  *   - timeout → reject with timeout error
- *   - non-zero exit with stderr → reject (wraps as "Error (code N):\n<stderr>")
+ *   - non-zero exit → reject (wraps as "Error (code N):\n<stderr>"), even when
+ *     stderr is empty (e.g. `false`, `test -f missing`): the synthetic detail
+ *     "Command exited with status N" is used so a failed command never looks
+ *     like a success just because it printed nothing to stderr.
  *   - exit 0 → success, even if stderr is non-empty
  *
  * Exit 0 is treated as success regardless of stderr: the OpenSSH transport
@@ -254,8 +257,9 @@ export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'transport') {
     throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
   }
-  if (result.stderr && result.exitCode !== 0) {
-    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
+  if (result.exitCode !== null && result.exitCode !== 0) {
+    const detail = result.stderr || `Command exited with status ${result.exitCode}`;
+    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${detail}`);
   }
   return {
     content: [{

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,13 @@ import {
 } from './utils/shell.js';
 import {
   gateApproval,
+  getApprovalDecisionFromError,
   setApprovalEngine,
   buildApprovalEngineFromConfig,
   type ApprovalDecision,
   type BuildEngineFromConfigInput,
   type ApprovalDispatcher,
+  type ResolvedSource,
 } from './approval/index.js';
 import { loadAuditSink, type AuditSink } from './approval/audit-seam.js';
 
@@ -411,6 +413,34 @@ function resolvedProfileName(connectionName?: string): string {
   return connectionName ?? registry.getDefaultName() ?? 'default';
 }
 
+export function buildApprovalProfile(
+  id: string,
+  perSourceApproval: Record<string, ApprovalMode> = {},
+  source?: { description?: string },
+): ResolvedSource {
+  const mode = perSourceApproval[id];
+  return {
+    id,
+    ...(source?.description ? { description: source.description } : {}),
+    ...(mode ? { approval: { mode } } : {}),
+  };
+}
+
+function approvalProfileForConnection(connectionName?: string): ResolvedSource {
+  const id = resolvedProfileName(connectionName);
+  const source = resolvedConfig.sources.find(s => s.name === id);
+  return buildApprovalProfile(id, resolvedConfig.perSourceApproval ?? {}, source);
+}
+
+export function appendDescriptionComment(command: string, description?: string): string {
+  if (!description) return command;
+  const safeDescription = description
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/[\t\f\v ]+/g, ' ')
+    .trim();
+  return safeDescription ? `${command} # ${safeDescription}` : command;
+}
+
 // =============================================================================
 // Approval engine + OPTIONAL audit-truth seam (Decision D2).
 //
@@ -435,7 +465,7 @@ let auditSink: AuditSink = { record() { /* no-op until wired (or audit absent) *
 function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher | null {
   const approvalCfg = resolvedConfig.approval;
   const perSourceModes: ApprovalMode[] = Object.values(resolvedConfig.perSourceApproval ?? {});
-  if (!approvalCfg?.mode && perSourceModes.length === 0) {
+  if (approvalCfg === undefined && perSourceModes.length === 0) {
     return null;
   }
   const input: BuildEngineFromConfigInput = {
@@ -528,6 +558,7 @@ server.tool(
   },
   async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
+    const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
     const profile = resolvedProfileName(connectionName);
     const startedAt = Date.now();
     let audited = false;
@@ -535,14 +566,11 @@ server.tool(
     try {
       const t = await registry.get(connectionName);
       approvalDecision = await gateApproval({
-        profile: { id: connectionName ?? 'default' },
+        profile: approvalProfileForConnection(connectionName),
         tool: 'exec',
-        command: sanitizedCommand,
+        command: commandWithDescription,
         description,
       });
-      const commandWithDescription = description
-        ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
-        : sanitizedCommand;
       const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
       auditSink.record({
         tool: 'exec',
@@ -556,10 +584,11 @@ server.tool(
       audited = true;
       return resultToMcpContent(result);
     } catch (err: any) {
+      approvalDecision = approvalDecision ?? getApprovalDecisionFromError(err);
       if (!audited) auditSink.record({
         tool: 'exec',
         profile,
-        command: sanitizedCommand,
+        command: commandWithDescription,
         description,
         startedAt,
         error: err,
@@ -582,6 +611,7 @@ if (!DISABLE_SUDO) {
     },
     async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
+      const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
       const profile = resolvedProfileName(connectionName);
       const startedAt = Date.now();
       let audited = false;
@@ -589,14 +619,11 @@ if (!DISABLE_SUDO) {
       try {
         const t = await registry.get(connectionName);
         approvalDecision = await gateApproval({
-          profile: { id: connectionName ?? 'default' },
+          profile: approvalProfileForConnection(connectionName),
           tool: 'sudo-exec',
-          command: sanitizedCommand,
+          command: commandWithDescription,
           description,
         });
-        const commandWithDescription = description
-          ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
-          : sanitizedCommand;
         // Legacy single-host mode may still pass --sudoPassword on CLI; in
         // multi-host mode each ServerConfig carries its own sudoPassword.
         const legacySudo = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined && !isMultiHost)
@@ -619,10 +646,11 @@ if (!DISABLE_SUDO) {
         audited = true;
         return resultToMcpContent(result);
       } catch (err: any) {
+        approvalDecision = approvalDecision ?? getApprovalDecisionFromError(err);
         if (!audited) auditSink.record({
           tool: 'sudo-exec',
           profile,
-          command: sanitizedCommand,
+          command: commandWithDescription,
           description,
           startedAt,
           error: err,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { ISshTransport, TransportConfig, ServerConfig, ExecResult, AuthMode } fr
 import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
 import { createTransport } from './transports/factory.js';
 import { TransportRegistry } from './transports/registry.js';
+import { resolveConfig } from './config/resolver.js';
+import type { ResolvedConfig } from './config/types.js';
 import {
   sanitizeCommand as sanitizeCommandImpl,
   sanitizePassword,
@@ -57,7 +59,7 @@ function parseServerConfigJson(raw: string): ServerConfig {
   try {
     obj = JSON.parse(raw);
   } catch (e: any) {
-    throw new Error(`--ssh JSON parse error: ${e?.message || e}\nRaw: ${raw}`);
+    throw new Error(`--ssh JSON parse error: ${e?.message || e}`);
   }
   if (!obj.name) throw new Error('--ssh JSON missing required "name"');
   if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
@@ -133,6 +135,17 @@ const KERBEROS_FLAG = argvConfig.kerberos !== undefined && argvConfig.kerberos !
 const GSSAPI_DELEGATE = argvConfig.gssapiDelegateCredentials;
 const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
 const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
+const CONFIG_PATH = argvConfig.config;
+
+const legacyFlagNames = [
+  'host', 'user', 'password', 'key', 'kerberos', 'transport',
+  'strictHostKeyChecking', 'knownHostsFile', 'gssapiDelegateCredentials',
+  'suPassword', 'sudoPassword', 'disableSudo', 'port',
+] as const;
+
+function hasLegacyCliFlags(config: Record<string, string | null>): boolean {
+  return legacyFlagNames.some(f => config[f] !== undefined);
+}
 
 function validateConfig(config: Record<string, string | null>, multiHost: boolean) {
   const errors: string[] = [];
@@ -178,9 +191,65 @@ function validateConfig(config: Record<string, string | null>, multiHost: boolea
 }
 
 const isMultiHost = sshJsonArgs.length > 0;
+const hasLegacyCli = hasLegacyCliFlags(argvConfig);
+
+function buildLegacyServerConfig(): ServerConfig | undefined {
+  if (!HOST || !USER) return undefined;
+
+  const authMode: AuthMode | undefined = KERBEROS_FLAG ? 'kerberos'
+    : KEY ? 'key'
+    : PASSWORD ? 'password'
+    : undefined;
+  const resolvedTransport: 'ssh2' | 'openssh' =
+    (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) ? 'openssh' : 'ssh2';
+
+  const cfg: ServerConfig = {
+    name: 'default',
+    host: HOST,
+    port: PORT,
+    username: USER,
+    transport: resolvedTransport,
+    authMode,
+  };
+  if (PASSWORD) cfg.password = PASSWORD;
+  if (KEY) cfg.keyPath = KEY;
+  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
+  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
+  if (KERBEROS_FLAG) cfg.kerberos = true;
+  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
+  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
+  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+  return cfg;
+}
+
+const cliSourceConfigs: ServerConfig[] = (() => {
+  if (isMultiHost) {
+    return sshJsonArgs.map(raw => parseServerConfigJson(raw));
+  }
+  if (hasLegacyCli) {
+    const legacy = buildLegacyServerConfig();
+    return legacy ? [legacy] : [];
+  }
+  return [];
+})();
+
+const resolvedConfig: ResolvedConfig = (isCliEnabled || isTestMode)
+  ? resolveConfig({
+      cliSources: cliSourceConfigs,
+      cliConfigPath: typeof CONFIG_PATH === 'string' ? CONFIG_PATH : undefined,
+    })
+  : { sources: [], perSourceApproval: {} };
 
 if (isCliEnabled) {
-  validateConfig(argvConfig, isMultiHost);
+  if (isMultiHost) {
+    validateConfig(argvConfig, true);
+  } else if (hasLegacyCli) {
+    validateConfig(argvConfig, false);
+  } else if (resolvedConfig.sources.length === 0) {
+    throw new Error(
+      'Configuration error:\nMissing required --host (or use --ssh=<JSON>, --config=<path>, SSH_MCP_CONFIG, or a default ssh-mcp config.toml)',
+    );
+  }
 }
 
 export function sanitizeCommand(command: string): string {
@@ -202,39 +271,12 @@ async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
 }
 
 async function bootstrapRegistry(): Promise<void> {
-  if (isMultiHost) {
-    for (const raw of sshJsonArgs) {
-      const cfg = parseServerConfigJson(raw);
-      await prepareKeyContents(cfg);
-      registry.register(cfg);
-    }
-  } else {
-    if (!HOST || !USER) return; // Test mode with no CLI — tools will error if called
-    const authMode: AuthMode | undefined = KERBEROS_FLAG ? 'kerberos'
-      : KEY ? 'key'
-      : PASSWORD ? 'password'
-      : undefined;
-    const resolvedTransport: 'ssh2' | 'openssh' =
-      (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) ? 'openssh' : 'ssh2';
-
-    const cfg: ServerConfig = {
-      name: 'default',
-      host: HOST,
-      port: PORT,
-      username: USER,
-      transport: resolvedTransport,
-      authMode,
-    };
-    if (PASSWORD) cfg.password = PASSWORD;
-    if (KEY) cfg.keyPath = KEY;
-    if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
-    if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
-    if (KERBEROS_FLAG) cfg.kerberos = true;
-    if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
-    if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
-    if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+  for (const cfg of resolvedConfig.sources) {
     await prepareKeyContents(cfg);
     registry.register(cfg);
+  }
+  if (resolvedConfig.defaultName) {
+    registry.setDefault(resolvedConfig.defaultName);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,14 +78,16 @@ function validateConfig(config: Record<string, string | null>) {
   if (!config.user) errors.push('Missing required --user');
   if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
 
-  const transport = config.transport ?? 'ssh2';
+  const transportExplicit = config.transport;
   const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+  // --kerberos alone implies --transport=openssh
+  const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
 
   if (transport !== 'ssh2' && transport !== 'openssh') {
     errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
   }
-  if (kerberos && transport === 'ssh2') {
-    errors.push('--kerberos requires --transport=openssh (or pass --kerberos alone, which implies openssh)');
+  if (kerberos && transportExplicit === 'ssh2') {
+    errors.push('--kerberos requires --transport=openssh (remove --transport=ssh2 or pass --kerberos alone)');
   }
   if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
     errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');

--- a/src/index.ts
+++ b/src/index.ts
@@ -709,7 +709,9 @@ export function buildApprovalProfile(
   perSourceApproval: Record<string, ApprovalMode> = {},
   source?: { description?: string },
 ): ResolvedSource {
-  const mode = perSourceApproval[id];
+  const mode = Object.prototype.hasOwnProperty.call(perSourceApproval, id)
+    ? perSourceApproval[id]
+    : undefined;
   return {
     id,
     ...(source?.description ? { description: source.description } : {}),
@@ -800,6 +802,20 @@ export function resolveApprovalEngineInput(
     llm: approvalCfg?.llm,
     perSourceModes,
   };
+}
+
+/** Effective configured mode used when audit must record a pre-gate failure. */
+export function resolveConfiguredApprovalMode(
+  profileId: string,
+  config: ResolvedConfig = resolvedConfig,
+): ApprovalMode {
+  const input = resolveApprovalEngineInput(config);
+  if (input === null) return 'yolo';
+  const profile = buildApprovalProfile(
+    profileId,
+    config.perSourceApproval ?? {},
+  );
+  return profile.approval?.mode ?? input.defaultMode ?? 'manual';
 }
 
 export function approvalResolverWarningFromInput(
@@ -1008,6 +1024,7 @@ server.tool(
     const sanitizedCommand = sanitizeCommand(command);
     const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
     let profile = resolvedProfileName(connectionName);
+    let approvalMode = resolveConfiguredApprovalMode(profile);
     // Fallback timestamp for errors raised before the transport call (registry
     // init failure, approval deny). Re-captured immediately before t.exec below
     // so a SUCCESSFUL command's audit durationMs measures command runtime only,
@@ -1018,6 +1035,7 @@ server.tool(
     try {
       const target = approvalTargetForConnection(connectionName);
       profile = target.profile;
+      approvalMode = resolveConfiguredApprovalMode(profile);
       approvalDecision = await gateApproval({
         profile: target.approvalProfile,
         tool: 'exec',
@@ -1035,6 +1053,7 @@ server.tool(
         description,
         startedAt,
         approval: approvalDecision,
+        approvalMode,
       }, result);
       return response;
     } catch (err: any) {
@@ -1047,6 +1066,7 @@ server.tool(
         startedAt,
         error: err,
         approval: approvalDecision,
+        approvalMode,
       });
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
@@ -1067,6 +1087,7 @@ if (!DISABLE_SUDO) {
       const sanitizedCommand = sanitizeCommand(command);
       const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
       let profile = resolvedProfileName(connectionName);
+      let approvalMode = resolveConfiguredApprovalMode(profile);
       // Fallback timestamp for errors raised before the transport call (registry
       // init failure, approval deny). Re-captured immediately before
       // t.execElevated below so a SUCCESSFUL command's audit durationMs measures
@@ -1077,6 +1098,7 @@ if (!DISABLE_SUDO) {
       try {
         const target = approvalTargetForConnection(connectionName);
         profile = target.profile;
+        approvalMode = resolveConfiguredApprovalMode(profile);
         approvalDecision = await gateApproval({
           profile: target.approvalProfile,
           tool: 'sudo-exec',
@@ -1103,6 +1125,7 @@ if (!DISABLE_SUDO) {
           description,
           startedAt,
           approval: approvalDecision,
+          approvalMode,
         }, result);
         return response;
       } catch (err: any) {
@@ -1115,6 +1138,7 @@ if (!DISABLE_SUDO) {
           startedAt,
           error: err,
           approval: approvalDecision,
+          approvalMode,
         });
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,14 +407,14 @@ async function bootstrapRegistry(): Promise<void> {
  *    explicit default still rejects an omitted connectionName (the headline
  *    security fix) instead of silently routing to the first host.
  *  - requireConnection: when false, opt out of that guard entirely. Absent the
- *    field (older ResolvedConfig shape) it defaults to safe (guard ON).
+ *    field (older ResolvedConfig shape / no [server].require_connection) it
+ *    defaults to safe (guard ON).
  */
 export function applyRegistryConnectionPolicy(
   reg: Pick<TransportRegistry, 'setDefault' | 'setRequireConnectionWhenMulti'>,
   config: ResolvedConfig,
 ): void {
-  const requireConnection =
-    (config as { requireConnection?: boolean }).requireConnection ?? true;
+  const requireConnection = config.requireConnection ?? true;
   reg.setRequireConnectionWhenMulti(requireConnection);
   if (config.defaultExplicit && config.defaultName) {
     reg.setDefault(config.defaultName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,13 +147,20 @@ const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
 const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
 const CONFIG_PATH = argvConfig.config;
 
+// Flags that signal intent to use the legacy single-host CLI mode. NOTE:
+// `disableSudo` is deliberately excluded — it only controls whether the sudo
+// tool is registered and is valid across ALL modes (multi-host --ssh and TOML
+// --config included). Treating it as a legacy trigger made
+// `--config cfg.toml --disableSudo` route through validateConfig(false) and
+// wrongly demand --host/--user. `port` stays here because it is only
+// meaningful as part of a single-host source.
 const legacyFlagNames = [
   'host', 'user', 'password', 'key', 'kerberos', 'transport',
   'strictHostKeyChecking', 'knownHostsFile', 'gssapiDelegateCredentials',
-  'suPassword', 'sudoPassword', 'disableSudo', 'port',
+  'suPassword', 'sudoPassword', 'port',
 ] as const;
 
-function hasLegacyCliFlags(config: Record<string, string | null>): boolean {
+export function hasLegacyCliFlags(config: Record<string, string | null>): boolean {
   return legacyFlagNames.some(f => config[f] !== undefined);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,13 @@ export function parseServerConfigJson(raw: string): ServerConfig {
   if (typeof obj.name !== 'string' || obj.name.length === 0) {
     throw new Error('--ssh JSON requires a non-empty string "name"');
   }
-  if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
+  if (typeof obj.host !== 'string' || obj.host.length === 0) {
+    throw new Error(`--ssh "${obj.name}" missing required "host" (expected a non-empty string)`);
+  }
   const user = obj.user ?? obj.username;
-  if (!user) throw new Error(`--ssh "${obj.name}" missing required "user" (or "username")`);
+  if (typeof user !== 'string' || user.length === 0) {
+    throw new Error(`--ssh "${obj.name}" missing required "user" (or "username") (expected a non-empty string)`);
+  }
   const auth: AuthMode | undefined = obj.auth;
   if (!auth || !['kerberos', 'key', 'password'].includes(auth)) {
     throw new Error(`--ssh "${obj.name}" requires "auth": "kerberos" | "key" | "password"`);
@@ -134,6 +138,14 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       // a credential-less key config (Codex 3541767246).
       if (obj.key !== undefined) {
         throw new Error(`--ssh "${obj.name}" auth "key" uses "keyPath" (or "privateKey" for ssh2), not "key"`);
+      }
+      if (obj.keyPath !== undefined &&
+          (typeof obj.keyPath !== 'string' || obj.keyPath.length === 0)) {
+        throw new Error(`--ssh "${obj.name}" "keyPath" must be a non-empty string`);
+      }
+      if (obj.privateKey !== undefined &&
+          (typeof obj.privateKey !== 'string' || obj.privateKey.length === 0)) {
+        throw new Error(`--ssh "${obj.name}" "privateKey" must be a non-empty string`);
       }
       // OpenSshTransport.buildArgs only passes cfg.keyPath via `-i`; an inline
       // privateKey would be silently ignored and ssh would fall back to

--- a/src/index.ts
+++ b/src/index.ts
@@ -756,6 +756,12 @@ export function resolveApprovalEngineInput(
     && approvalCfg.llm !== undefined;
   const perSourceOnlyDefault = perSourceModes.length > 0
     && (approvalCfg === undefined || approvalLlmOnly);
+  // An [approval.llm]-only block supplies settings for smart mode but does not
+  // select approval by itself. Keep it inert unless a per-source override uses
+  // it; otherwise undefined defaultMode would accidentally activate manual.
+  if (approvalLlmOnly && perSourceModes.length === 0) {
+    return null;
+  }
   return {
     // Resolve the GLOBAL default mode:
     //  - explicit [approval].mode set        -> honor it.
@@ -815,13 +821,19 @@ function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher
   });
 }
 
+/** Resolve a bare/string boolean CLI switch without treating `--flag=false` as enabled. */
+export function isCliSwitchEnabled(args: Record<string, unknown>, key: string): boolean {
+  if (!(key in args)) return false;
+  const value = args[key];
+  return !(typeof value === 'string' && value.toLowerCase() === 'false');
+}
+
 /** Decide whether the WebUI will be active at boot (TOML or --webui). */
 function isWebUIActive(): boolean {
-  // `--webui` (bare flag) parses to a key present in argvConfig. The WebUI
-  // server itself lands in a later lane; here we only need the boot-time
-  // decision so manual-mode's gate-12 invariant resolves correctly.
-  const cliWebui = 'webui' in argvConfig;
-  return cliWebui || resolvedConfig.webui?.enabled === true;
+  // A bare `--webui` parses as a present key, while `--webui=false` must remain
+  // disabled. The WebUI server itself lands in a later lane; here we only need
+  // the boot-time decision so manual-mode's gate-12 invariant resolves correctly.
+  return isCliSwitchEnabled(argvConfig, 'webui') || resolvedConfig.webui?.enabled === true;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,18 @@ export function hasLegacyCliFlags(config: Record<string, string | null>): boolea
   return legacyFlagNames.some(f => config[f] !== undefined);
 }
 
+/**
+ * Reject a present-but-value-less --ssh before TOML discovery can provide a
+ * lower-precedence source. parseArgv records bare `--ssh` (including the first
+ * half of a space-separated `--ssh JSON` invocation) as null, while valid
+ * repeatable `--ssh=<JSON>` arguments are collected separately.
+ */
+export function validateSshCliFlag(config: Record<string, string | null>): void {
+  if ('ssh' in config && config.ssh === null) {
+    throw new Error('Configuration error:\n--ssh requires a value (--ssh=<JSON>)');
+  }
+}
+
 function validateConfig(config: Record<string, string | null>, multiHost = false) {
   const errors: string[] = [];
 
@@ -370,6 +382,7 @@ const hasLegacyCli = hasLegacyCliFlags(argvConfig);
 // TOML file and report that TOML's parse/env error before the real missing
 // `--user` legacy CLI error.
 if (isCliEnabled || isTestMode) {
+  validateSshCliFlag(argvConfig);
   if (isMultiHost) {
     validateConfig(argvConfig, true);
   } else if (hasLegacyCli) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,21 @@ import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
 import { createTransport } from './transports/factory.js';
 import { TransportRegistry } from './transports/registry.js';
 import { resolveConfig } from './config/resolver.js';
-import type { ResolvedConfig } from './config/types.js';
+import type { ResolvedConfig, ApprovalMode } from './config/types.js';
 import {
   sanitizeCommand as sanitizeCommandImpl,
   sanitizePassword,
   escapeCommandForShell,
 } from './utils/shell.js';
+import {
+  gateApproval,
+  setApprovalEngine,
+  buildApprovalEngineFromConfig,
+  type ApprovalDecision,
+  type BuildEngineFromConfigInput,
+  type ApprovalDispatcher,
+} from './approval/index.js';
+import { loadAuditSink, type AuditSink } from './approval/audit-seam.js';
 
 // Re-exports for backward compatibility with existing tests.
 export { SSHConnectionManager, escapeCommandForShell };
@@ -280,6 +289,72 @@ async function bootstrapRegistry(): Promise<void> {
   }
 }
 
+/** Effective profile/connection name for gating + audit attribution. */
+function resolvedProfileName(connectionName?: string): string {
+  return connectionName ?? registry.getDefaultName() ?? 'default';
+}
+
+// =============================================================================
+// Approval engine + OPTIONAL audit-truth seam (Decision D2).
+//
+// The approval engine is the source of truth for whether a command runs. The
+// audit seam is OPTIONAL: when `src/audit/` is part of the build it logs the
+// real decision; when absent (e.g. on `pr/toml-config`, this lane's base) it
+// no-ops. `auditSink` starts as a no-op so the exec/sudo-exec handlers can call
+// it unconditionally; `wireApprovalAndAudit()` upgrades it at boot.
+// =============================================================================
+
+let auditSink: AuditSink = { record() { /* no-op until wired (or audit absent) */ } };
+
+/**
+ * Build the production approval engine from resolvedConfig. Returns null for
+ * the legacy CLI path (no [approval] section and no per-source overrides) so
+ * the gate keeps its backward-compatible `legacy:no-engine` allow.
+ *
+ * Throws (fatal at boot):
+ *   - manual mode requested but WebUI disabled (gate-12 invariant)
+ *   - smart mode requested but [approval.llm] missing endpoint or model
+ */
+function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher | null {
+  const approvalCfg = resolvedConfig.approval;
+  const perSourceModes: ApprovalMode[] = Object.values(resolvedConfig.perSourceApproval ?? {});
+  if (!approvalCfg?.mode && perSourceModes.length === 0) {
+    return null;
+  }
+  const input: BuildEngineFromConfigInput = {
+    defaultMode: approvalCfg?.mode,
+    fail_closed: approvalCfg?.fail_closed,
+    llm: approvalCfg?.llm,
+    perSourceModes,
+  };
+  return buildApprovalEngineFromConfig(input, {
+    manualOpts: { webuiEnabled: webuiActive },
+  });
+}
+
+/** Decide whether the WebUI will be active at boot (TOML or --webui). */
+function isWebUIActive(): boolean {
+  // `--webui` (bare flag) parses to a key present in argvConfig. The WebUI
+  // server itself lands in a later lane; here we only need the boot-time
+  // decision so manual-mode's gate-12 invariant resolves correctly.
+  const cliWebui = 'webui' in argvConfig;
+  return cliWebui || resolvedConfig.webui?.enabled === true;
+}
+
+/**
+ * Wire the approval engine into the gate and load the optional audit sink.
+ * Safe to call before the MCP transport connects so the first exec is gated.
+ */
+async function wireApprovalAndAudit(): Promise<void> {
+  const engine = buildProductionApprovalEngine(isWebUIActive());
+  setApprovalEngine(engine);
+  auditSink = await loadAuditSink({
+    auditDir: resolvedConfig.server?.audit_dir,
+    auditMaxBytes: resolvedConfig.server?.audit_max_bytes,
+  });
+}
+
+
 export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
@@ -336,14 +411,43 @@ server.tool(
   },
   async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
+    const profile = resolvedProfileName(connectionName);
+    const startedAt = Date.now();
+    let audited = false;
+    let approvalDecision: ApprovalDecision | undefined;
     try {
       const t = await registry.get(connectionName);
+      approvalDecision = await gateApproval({
+        profile: { id: connectionName ?? 'default' },
+        tool: 'exec',
+        command: sanitizedCommand,
+        description,
+      });
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
       const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
+      auditSink.record({
+        tool: 'exec',
+        profile,
+        command: commandWithDescription,
+        description,
+        startedAt,
+        result,
+        approval: approvalDecision,
+      });
+      audited = true;
       return resultToMcpContent(result);
     } catch (err: any) {
+      if (!audited) auditSink.record({
+        tool: 'exec',
+        profile,
+        command: sanitizedCommand,
+        description,
+        startedAt,
+        error: err,
+        approval: approvalDecision,
+      });
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
     }
@@ -361,8 +465,18 @@ if (!DISABLE_SUDO) {
     },
     async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
+      const profile = resolvedProfileName(connectionName);
+      const startedAt = Date.now();
+      let audited = false;
+      let approvalDecision: ApprovalDecision | undefined;
       try {
         const t = await registry.get(connectionName);
+        approvalDecision = await gateApproval({
+          profile: { id: connectionName ?? 'default' },
+          tool: 'sudo-exec',
+          command: sanitizedCommand,
+          description,
+        });
         const commandWithDescription = description
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
@@ -376,8 +490,27 @@ if (!DISABLE_SUDO) {
           mode: 'sudo',
           password: legacySudo,
         });
+        auditSink.record({
+          tool: 'sudo-exec',
+          profile,
+          command: commandWithDescription,
+          description,
+          startedAt,
+          result,
+          approval: approvalDecision,
+        });
+        audited = true;
         return resultToMcpContent(result);
       } catch (err: any) {
+        if (!audited) auditSink.record({
+          tool: 'sudo-exec',
+          profile,
+          command: sanitizedCommand,
+          description,
+          startedAt,
+          error: err,
+          approval: approvalDecision,
+        });
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
       }
@@ -563,6 +696,9 @@ export async function execSshCommand(
 
 async function main() {
   await bootstrapRegistry();
+  // Boot the approval engine + optional audit seam BEFORE the MCP transport so
+  // the very first exec / sudo-exec call is gated and (optionally) audited.
+  await wireApprovalAndAudit();
   const transport = new StdioServerTransport();
   await server.connect(transport);
   const mode = isMultiHost ? `multi-host (${registry.names().length} servers: ${registry.names().join(', ')})` : 'single-host';
@@ -584,6 +720,9 @@ if (isTestMode) {
     try {
       await bootstrapRegistry();
     } catch { /* tests may not configure hosts */ }
+    try {
+      await wireApprovalAndAudit();
+    } catch { /* tests may not configure an approval engine */ }
     const transport = new StdioServerTransport();
     server.connect(transport).catch(error => {
       console.error('Fatal error connecting server:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -434,7 +434,13 @@ export function applyRegistryConnectionPolicy(
 
 /** Effective profile/connection name for gating + audit attribution. */
 function resolvedProfileName(connectionName?: string): string {
-  return connectionName ?? registry.getDefaultName() ?? 'default';
+  // Treat an empty/blank connectionName as "omitted", mirroring
+  // TransportRegistry.resolveName() (which routes `''` to the default host).
+  // Otherwise gating + audit attribution would be computed for the literal
+  // profile id '' while the command actually ran against the default host,
+  // silently bypassing that host's per-source approval policy.
+  const name = connectionName && connectionName.trim() !== '' ? connectionName : undefined;
+  return name ?? registry.getDefaultName() ?? 'default';
 }
 
 export function buildApprovalProfile(
@@ -493,7 +499,16 @@ function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher
     return null;
   }
   const input: BuildEngineFromConfigInput = {
-    defaultMode: approvalCfg?.mode,
+    // When there is NO top-level [approval] block (only per-source overrides),
+    // the global default stays 'yolo' (unrestricted) rather than inheriting
+    // buildApprovalEngineFromConfig's [approval]-present 'manual' fallback.
+    // This mirrors the `return null` (legacy unrestricted) branch one level up
+    // for the no-config case: adding per-source gates should gate only those
+    // sources, not silently flip the global default to manual — which would
+    // gate every ungated host and, without WebUI, throw at boot.
+    // A present [approval] block with an unspecified mode still defaults to
+    // manual (the documented TOML default), preserving that contract.
+    defaultMode: approvalCfg === undefined ? 'yolo' : approvalCfg.mode,
     fail_closed: approvalCfg?.fail_closed,
     llm: approvalCfg?.llm,
     perSourceModes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,27 @@
 #!/usr/bin/env node
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
+import { ISshTransport, TransportConfig, ExecResult } from './transports/types.js';
+import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
+import { createTransport } from './transports/factory.js';
+import {
+  sanitizeCommand as sanitizeCommandImpl,
+  sanitizePassword,
+  escapeCommandForShell,
+} from './utils/shell.js';
+
+// Re-exports for backward compatibility with existing tests (smoke.ssh.test.ts,
+// persistent-connection.test.ts, etc.).
+export { SSHConnectionManager, escapeCommandForShell };
+export type { SSHConfig };
+
 // Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
+// Kerberos SSO:   node build/index.js --host=host --user=user@REALM --kerberos
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
@@ -14,20 +29,20 @@ function parseArgv() {
     if (arg.startsWith('--')) {
       const equalIndex = arg.indexOf('=');
       if (equalIndex === -1) {
-        // Flag without value
         config[arg.slice(2)] = null;
       } else {
-        // Key=value pair
         config[arg.slice(2, equalIndex)] = arg.slice(equalIndex + 1);
       }
     }
   }
   return config;
 }
+
 const isTestMode = process.env.SSH_MCP_TEST === '1';
 const isCliEnabled = process.env.SSH_MCP_DISABLE_MAIN !== '1';
 const argvConfig = (isCliEnabled || isTestMode) ? parseArgv() : {} as Record<string, string>;
 
+// Connection config (legacy flags)
 const HOST = argvConfig.host;
 const PORT = argvConfig.port ? parseInt(argvConfig.port) : 22;
 const USER = argvConfig.user;
@@ -36,13 +51,7 @@ const SUPASSWORD = argvConfig.suPassword;
 const SUDOPASSWORD = argvConfig.sudoPassword;
 const DISABLE_SUDO = argvConfig.disableSudo !== undefined;
 const KEY = argvConfig.key;
-const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000; // 60 seconds default timeout
-// Max characters configuration:
-// - Default: 1000 characters
-// - When set via --maxChars:
-//   * a positive integer enforces that limit
-//   * 0 or a negative value disables the limit (no max)
-//   * the string "none" (case-insensitive) disables the limit (no max)
+const DEFAULT_TIMEOUT = argvConfig.timeout ? parseInt(argvConfig.timeout) : 60000;
 const MAX_CHARS_RAW = argvConfig.maxChars;
 const MAX_CHARS = (() => {
   if (typeof MAX_CHARS_RAW === 'string') {
@@ -56,11 +65,38 @@ const MAX_CHARS = (() => {
   return 1000;
 })();
 
+// Transport config (new flags)
+const TRANSPORT_FLAG = argvConfig.transport;
+const KERBEROS_FLAG = argvConfig.kerberos !== undefined && argvConfig.kerberos !== 'false';
+const GSSAPI_DELEGATE = argvConfig.gssapiDelegateCredentials;
+const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
+const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
+
 function validateConfig(config: Record<string, string | null>) {
-  const errors = [];
+  const errors: string[] = [];
   if (!config.host) errors.push('Missing required --host');
   if (!config.user) errors.push('Missing required --user');
   if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
+
+  const transport = config.transport ?? 'ssh2';
+  const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+
+  if (transport !== 'ssh2' && transport !== 'openssh') {
+    errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
+  }
+  if (kerberos && transport === 'ssh2') {
+    errors.push('--kerberos requires --transport=openssh (or pass --kerberos alone, which implies openssh)');
+  }
+  if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
+    errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
+  }
+  if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
+    errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
+  }
+  if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
+    errors.push('--gssapiDelegateCredentials must be yes or no');
+  }
+
   if (errors.length > 0) {
     throw new Error('Configuration error:\n' + errors.join('\n'));
   }
@@ -70,277 +106,101 @@ if (isCliEnabled) {
   validateConfig(argvConfig);
 }
 
-// Command sanitization and validation
 export function sanitizeCommand(command: string): string {
-  if (typeof command !== 'string') {
-    throw new McpError(ErrorCode.InvalidParams, 'Command must be a string');
-  }
-
-  const trimmedCommand = command.trim();
-  if (!trimmedCommand) {
-    throw new McpError(ErrorCode.InvalidParams, 'Command cannot be empty');
-  }
-
-  // Length check
-  if (Number.isFinite(MAX_CHARS) && trimmedCommand.length > (MAX_CHARS as number)) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
-      `Command is too long (max ${MAX_CHARS} characters)`
-    );
-  }
-
-  return trimmedCommand;
+  return sanitizeCommandImpl(command, MAX_CHARS as number);
 }
 
-function sanitizePassword(password: string | undefined): string | undefined {
-  if (typeof password !== 'string') return undefined;
-  // minimal check, do not log or modify content
-  if (password.length === 0) return undefined;
-  return password;
+function resolveTransport(): 'ssh2' | 'openssh' {
+  if (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) return 'openssh';
+  return 'ssh2';
 }
 
-// Escape command for use in shell contexts (like pkill)
-export function escapeCommandForShell(command: string): string {
-  // Replace single quotes with escaped single quotes
-  return command.replace(/'/g, "'\"'\"'");
+function resolveAuthMode(): 'kerberos' | 'key' | 'password' | undefined {
+  if (KERBEROS_FLAG) return 'kerberos';
+  if (KEY) return 'key';
+  if (PASSWORD) return 'password';
+  return undefined;
 }
 
-// SSH Connection Manager to maintain persistent connection
-export interface SSHConfig {
-  host: string;
-  port: number;
-  username: string;
-  password?: string;
-  privateKey?: string;
-  suPassword?: string;
-  sudoPassword?: string;  // Password for sudo commands specifically (if different from suPassword)
+async function buildTransportConfig(): Promise<TransportConfig> {
+  if (!HOST || !USER) {
+    throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+  }
+
+  const cfg: TransportConfig = {
+    host: HOST,
+    port: PORT,
+    username: USER,
+    transport: resolveTransport(),
+    authMode: resolveAuthMode(),
+  };
+
+  if (PASSWORD) cfg.password = PASSWORD;
+  if (KEY) {
+    cfg.keyPath = KEY;
+    // ssh2 transport needs the key contents, not the path
+    if (cfg.transport === 'ssh2') {
+      const fs = await import('fs/promises');
+      cfg.privateKey = await fs.readFile(KEY, 'utf8');
+    }
+  }
+  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
+  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
+  if (KERBEROS_FLAG) cfg.kerberos = true;
+  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
+  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
+  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+
+  return cfg;
 }
 
-export class SSHConnectionManager {
-  private conn: Client | null = null;
-  private sshConfig: SSHConfig;
-  private isConnecting = false;
-  private connectionPromise: Promise<void> | null = null;
-  private suShell: any = null;  // Store the elevated shell session
-  private suPromise: Promise<void> | null = null;
-  private isElevated = false;  // Track if we're in su mode
+let activeTransport: ISshTransport | null = null;
 
-  constructor(config: SSHConfig) {
-    this.sshConfig = config;
-  }
-
-  async connect(): Promise<void> {
-    if (this.conn && this.isConnected()) {
-      return; // Already connected
-    }
-
-    if (this.isConnecting && this.connectionPromise) {
-      return this.connectionPromise; // Wait for ongoing connection
-    }
-
-    this.isConnecting = true;
-    this.connectionPromise = new Promise((resolve, reject) => {
-      this.conn = new Client();
-
-      const timeoutId = setTimeout(() => {
-        this.conn?.end();
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-        reject(new McpError(ErrorCode.InternalError, 'SSH connection timeout'));
-      }, 30000); // 30 seconds connection timeout
-
-      this.conn.on('ready', async () => {
-        clearTimeout(timeoutId);
-        this.isConnecting = false;
-
-        // In test mode, don't wait for su elevation during connection setup, as it
-        // may cause JSON-RPC server initialization to hang. Instead, elevation will
-        // be triggered on-demand when a command is executed.
-        // In production, elevation during connection is desirable for robustness.
-        if (this.sshConfig.suPassword && !process.env.SSH_MCP_TEST) {
-          try {
-            await this.ensureElevated();
-          } catch (err) {
-            // Do not reject the connection; just log the error. Subsequent commands
-            // will either use the su shell if available or fall back to normal execution.
-          }
-        }
-
-        resolve();
-      });
-
-      this.conn.on('error', (err: Error) => {
-        clearTimeout(timeoutId);
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-        reject(new McpError(ErrorCode.InternalError, `SSH connection error: ${err.message}`));
-      });
-
-      this.conn.on('end', () => {
-        console.error('SSH connection ended');
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-      });
-
-      this.conn.on('close', () => {
-        console.error('SSH connection closed');
-        this.conn = null;
-        this.isConnecting = false;
-        this.connectionPromise = null;
-      });
-
-      this.conn.connect(this.sshConfig);
-    });
-
-    return this.connectionPromise;
-  }
-
-  isConnected(): boolean {
-    return this.conn !== null && (this.conn as any)._sock && !(this.conn as any)._sock.destroyed;
-  }
-
-  getSudoPassword(): string | undefined {
-    return this.sshConfig.sudoPassword;
-  }
-
-  getSuPassword(): string | undefined {
-    return this.sshConfig.suPassword;
-  }
-
-  async setSuPassword(pwd?: string): Promise<void> {
-    this.sshConfig.suPassword = pwd;
-    if (pwd) {
-      try {
-        await this.ensureElevated();
-      } catch (err) {
-        console.error('setSuPassword: failed to elevate to su shell:', err);
-      }
-    } else {
-      // If clearing suPassword, drop any existing suShell
-      if (this.suShell) {
-        try { this.suShell.end(); } catch (e) { /* ignore */ }
-        this.suShell = null;
-        this.isElevated = false;
-      }
-    }
-  }
-
-  private async ensureElevated(): Promise<void> {
-    if (this.isElevated && this.suShell) return;
-    if (!this.sshConfig.suPassword) return;
-
-    if (this.suPromise) return this.suPromise;
-
-    this.suPromise = new Promise((resolve, reject) => {
-      const conn = this.getConnection();
-
-      // Add a safety timeout so elevation doesn't hang forever
-      const timeoutId = setTimeout(() => {
-        this.suPromise = null;
-        reject(new McpError(ErrorCode.InternalError, 'su elevation timed out'));
-      }, 10000);  // 10 second timeout for elevation
-
-      conn.shell({ term: 'xterm', cols: 80, rows: 24 }, (err: Error | undefined, stream: ClientChannel) => {
-        if (err) {
-          clearTimeout(timeoutId);
-          this.suPromise = null;
-          reject(new McpError(ErrorCode.InternalError, `Failed to start interactive shell for su: ${err.message}`));
-          return;
-        }
-
-        let buffer = '';
-        let passwordSent = false;
-        const cleanup = () => {
-          try { stream.removeAllListeners('data'); } catch (e) { /* ignore */ }
-        };
-
-        const onData = (data: Buffer) => {
-          const text = data.toString();
-          buffer += text;
-
-          // If we haven't sent the password yet, look for the password prompt
-          if (!passwordSent && /password[: ]/i.test(buffer)) {
-            passwordSent = true;
-            stream.write(this.sshConfig.suPassword + '\n');
-            // Don't return; keep looking for root prompt
-          }
-
-          // After password is sent, look for any root indicator
-          // Look for '#' which indicates root prompt (may be followed by spaces, escape codes, etc)
-          if (passwordSent) {
-            if (/#/.test(buffer)) {
-              clearTimeout(timeoutId);
-              cleanup();
-              this.suShell = stream;
-              this.isElevated = true;
-              this.suPromise = null;
-              resolve();
-              return;
-            }
-          }
-
-          // Detect authentication failure messages
-          if (/authentication failure|incorrect password|su: .*failed|su: failure/i.test(buffer)) {
-            clearTimeout(timeoutId);
-            cleanup();
-            this.suPromise = null;
-            reject(new McpError(ErrorCode.InternalError, `su authentication failed: ${buffer}`));
-            return;
-          }
-        };
-
-        stream.on('data', onData);
-
-        stream.on('close', () => {
-          clearTimeout(timeoutId);
-          if (!this.isElevated) {
-            this.suPromise = null;
-            reject(new McpError(ErrorCode.InternalError, 'su shell closed before elevation completed'));
-          }
-        });
-
-        // Kick off the su command
-        stream.write('su -\n');
-      });
-    });
-
-    return this.suPromise;
-  }
-
-  async ensureConnected(): Promise<void> {
-    if (!this.isConnected()) {
-      await this.connect();
-    }
-  }
-
-  getConnection(): Client {
-    if (!this.conn) {
-      throw new McpError(ErrorCode.InternalError, 'SSH connection not established');
-    }
-    return this.conn;
-  }
-
-  close(): void {
-    if (this.conn) {
-      if (this.suShell) {
-        try { this.suShell.end(); } catch (e) { /* ignore */ }
-        this.suShell = null;
-        this.isElevated = false;
-      }
-      this.conn.end();
-      this.conn = null;
-    }
-  }
+async function getOrCreateTransport(): Promise<ISshTransport> {
+  if (activeTransport) return activeTransport;
+  const cfg = await buildTransportConfig();
+  activeTransport = createTransport(cfg);
+  await activeTransport.init();
+  return activeTransport;
 }
 
-let connectionManager: SSHConnectionManager | null = null;
+/**
+ * Map ExecResult to MCP tool response. Preserves upstream semantics:
+ *   - stderr present → reject with McpError (wraps as "Error (code N):\n<stderr>")
+ *   - auth/host_key/connect/transport categories → reject with descriptive error
+ *   - timeout → reject with timeout error
+ *   - success → return {content: [{type:'text', text: stdout}]}
+ */
+function resultToMcpContent(result: ExecResult) {
+  if (result.category === 'timeout') {
+    throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
+  }
+  if (result.category === 'auth') {
+    throw new McpError(ErrorCode.InternalError, `SSH authentication error: ${result.stderr}`);
+  }
+  if (result.category === 'host_key') {
+    throw new McpError(ErrorCode.InternalError, `SSH host key error: ${result.stderr}`);
+  }
+  if (result.category === 'connect') {
+    throw new McpError(ErrorCode.InternalError, `SSH connection error: ${result.stderr}`);
+  }
+  if (result.category === 'transport') {
+    throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
+  }
+  if (result.stderr) {
+    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
+  }
+  return {
+    content: [{
+      type: 'text' as const,
+      text: result.stdout,
+    }],
+  };
+}
 
 const server = new McpServer({
   name: 'SSH MCP Server',
-  version: '1.5.0',
+  version: '2.0.0',
   capabilities: {
     resources: {},
     tools: {},
@@ -348,146 +208,52 @@ const server = new McpServer({
 });
 
 server.tool(
-  "exec",
-  "Execute a shell command on the remote SSH server and return the output.",
+  'exec',
+  'Execute a shell command on the remote SSH server and return the output.',
   {
-    command: z.string().describe("Shell command to execute on the remote SSH server"),
-    description: z.string().optional().describe("Optional description of what this command will do"),
+    command: z.string().describe('Shell command to execute on the remote SSH server'),
+    description: z.string().optional().describe('Optional description of what this command will do'),
   },
   async ({ command, description }) => {
-    // Sanitize command input
     const sanitizedCommand = sanitizeCommand(command);
-
     try {
-      // Initialize connection manager if not already done
-      if (!connectionManager) {
-        if (!HOST || !USER) {
-          throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-        }
-        const sshConfig: SSHConfig = {
-          host: HOST,
-          port: PORT,
-          username: USER,
-        };
-
-        if (PASSWORD) {
-          sshConfig.password = PASSWORD;
-        } else if (KEY) {
-          const fs = await import('fs/promises');
-          sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-        }
-
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-        }
-        connectionManager = new SSHConnectionManager(sshConfig);
-      }
-
-      // Ensure connection is active (reconnect if needed)
-      await connectionManager.ensureConnected();
-
-      // If a suPassword was provided, explicitly wait for elevation before executing.
-      // This is critical: ensureElevated is idempotent and will return immediately if
-      // already elevated, so this ensures we have a su shell before we try to use it.
-      if ((connectionManager as any).getSuPassword && (connectionManager as any).getSuPassword()) {
-        try {
-          const elevationPromise = (connectionManager as any).ensureElevated();
-          // Add a short timeout for elevation to complete
-          await Promise.race([
-            elevationPromise,
-            new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000))
-          ]);
-        } catch (err) {
-          // Log but don't fail; fall back to non-elevated execution if elevation times out
-        }
-      }
-
-      // Append description as comment if provided
+      const t = await getOrCreateTransport();
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
-
-      const result = await execSshCommandWithConnection(connectionManager, commandWithDescription);
-      return result;
+      const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
+      return resultToMcpContent(result);
     } catch (err: any) {
-      // Wrap unexpected errors
       if (err instanceof McpError) throw err;
       throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
     }
   }
 );
 
-// Expose sudo-exec tool unless explicitly disabled
 if (!DISABLE_SUDO) {
   server.tool(
-    "sudo-exec",
-    "Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.",
+    'sudo-exec',
+    'Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.',
     {
-      command: z.string().describe("Shell command to execute with sudo on the remote SSH server"),
-      description: z.string().optional().describe("Optional description of what this command will do"),
+      command: z.string().describe('Shell command to execute with sudo on the remote SSH server'),
+      description: z.string().optional().describe('Optional description of what this command will do'),
     },
     async ({ command, description }) => {
       const sanitizedCommand = sanitizeCommand(command);
-
       try {
-        if (!connectionManager) {
-          if (!HOST || !USER) {
-            throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
-          }
-
-          const sshConfig: SSHConfig = {
-            host: HOST,
-            port: PORT || 22,
-            username: USER,
-          };
-          if (PASSWORD) {
-            sshConfig.password = PASSWORD;
-          } else if (KEY) {
-            const fs = await import('fs/promises');
-            sshConfig.privateKey = await fs.readFile(KEY, 'utf8');
-          }
-          if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-            sshConfig.suPassword = sanitizePassword(SUPASSWORD);
-          }
-          if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-            sshConfig.sudoPassword = sanitizePassword(SUDOPASSWORD);
-          }
-          connectionManager = new SSHConnectionManager(sshConfig);
-        }
-
-        await connectionManager.ensureConnected();
-
-        // If suPassword or sudoPassword were provided on this call but the
-        // existing connection manager was created earlier without them,
-        // update the manager's values so the subsequent sudo-exec call uses
-        // the latest passwords.
-        if (SUPASSWORD !== null && SUPASSWORD !== undefined) {
-          await connectionManager.setSuPassword(sanitizePassword(SUPASSWORD));
-        }
-        if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) {
-          // update sudoPassword on the manager instance
-          (connectionManager as any).sshConfig = { ...(connectionManager as any).sshConfig, sudoPassword: sanitizePassword(SUDOPASSWORD) };
-        }
-
-        let wrapped: string;
-        const sudoPassword = connectionManager.getSudoPassword();
-
-        // Append description as comment if provided
+        const t = await getOrCreateTransport();
         const commandWithDescription = description
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
-
-        if (!sudoPassword) {
-          // No password provided, use -n to fail if sudo requires a password
-          wrapped = `sudo -n sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
-        } else {
-          // Password provided — pipe it into sudo using printf. This avoids complex
-          // PTY/stdin handling on the SSH channel and is simpler and more reliable.
-          const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
-          wrapped = `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${commandWithDescription.replace(/'/g, "'\\''")}'`;
-        }
-
-        return await execSshCommandWithConnection(connectionManager, wrapped);
+        const sudoPwd = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined)
+          ? sanitizePassword(SUDOPASSWORD)
+          : undefined;
+        const result = await t.execElevated(commandWithDescription, {
+          timeoutMs: DEFAULT_TIMEOUT,
+          mode: 'sudo',
+          password: sudoPwd,
+        });
+        return resultToMcpContent(result);
       } catch (err: any) {
         if (err instanceof McpError) throw err;
         throw new McpError(ErrorCode.InternalError, `Unexpected error: ${err?.message || err}`);
@@ -496,16 +262,24 @@ if (!DISABLE_SUDO) {
   );
 }
 
-// New function that uses persistent connection
-export async function execSshCommandWithConnection(manager: SSHConnectionManager, command: string, stdin?: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+// ===========================================================================
+// Legacy exports: preserved so existing tests (which import SSHConnectionManager,
+// execSshCommandWithConnection, execSshCommand) keep working without modification.
+// These call through to Ssh2Transport-equivalent logic or directly to ssh2.
+// ===========================================================================
+
+export async function execSshCommandWithConnection(
+  manager: SSHConnectionManager,
+  command: string,
+  stdin?: string
+): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: 'text'; text: string; } | { [x: string]: unknown; type: 'image'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'audio'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'resource'; resource: any; })[] }> {
   return new Promise((resolve, reject) => {
     let timeoutId: NodeJS.Timeout;
     let isResolved = false;
 
     const conn = manager.getConnection();
-    const shell = (manager as any).suShell;  // Use su shell if available
+    const shell = (manager as any).getSuShell ? (manager as any).getSuShell() : (manager as any).suShell;
 
-    // Set up timeout
     timeoutId = setTimeout(() => {
       if (!isResolved) {
         isResolved = true;
@@ -513,44 +287,29 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
       }
     }, DEFAULT_TIMEOUT);
 
-    // If we have an active su shell, use it directly (commands run as root in session)
     if (shell) {
       let buffer = '';
-
       const dataHandler = (data: Buffer) => {
         const text = data.toString();
         buffer += text;
-
-        // Wait for root prompt (#) to know command is complete
-        // Match # which indicates root prompt (may be followed by spaces, escape codes, etc)
         if (/#/.test(buffer)) {
           if (!isResolved) {
             isResolved = true;
             clearTimeout(timeoutId);
-
-            // Extract output: remove the command echo and final prompt
             const lines = buffer.split('\n');
-            // First line is often the echoed command; last line is the prompt
-            let output = lines.slice(1, -1).join('\n');
-
+            const output = lines.slice(1, -1).join('\n');
             resolve({
-              content: [{
-                type: 'text',
-                text: output + (output ? '\n' : ''),
-              }],
+              content: [{ type: 'text', text: output + (output ? '\n' : '') }],
             });
           }
           shell.removeListener('data', dataHandler);
         }
       };
-
       shell.on('data', dataHandler);
-      // Send command immediately; shell is ready after elevation
       shell.write(command + '\n');
       return;
     }
 
-    // No persistent su shell; use normal exec with optional password piping
     conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
       if (err) {
         if (!isResolved) {
@@ -564,37 +323,21 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
       let stdout = '';
       let stderr = '';
 
-      // If stdin provided (e.g., sudo password), write it
       if (stdin && stdin.length > 0) {
-        try {
-          stream.write(stdin);
-        } catch (e) {
-          console.error('Error writing to stdin:', e);
-        }
+        try { stream.write(stdin); } catch (e) { console.error('Error writing to stdin:', e); }
       }
       try { stream.end(); } catch (e) { /* ignore */ }
 
-      stream.on('data', (data: Buffer) => {
-        stdout += data.toString();
-      });
-
-      stream.stderr.on('data', (data: Buffer) => {
-        stderr += data.toString();
-      });
-
-      stream.on('close', (code: number, signal: string) => {
+      stream.on('data', (data: Buffer) => { stdout += data.toString(); });
+      stream.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+      stream.on('close', (code: number, _signal: string) => {
         if (!isResolved) {
           isResolved = true;
           clearTimeout(timeoutId);
           if (stderr) {
             reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
           } else {
-            resolve({
-              content: [{
-                type: 'text',
-                text: stdout,
-              }],
-            });
+            resolve({ content: [{ type: 'text', text: stdout }] });
           }
         }
       });
@@ -602,24 +345,21 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
   });
 }
 
-// Keep the old function for backward compatibility (used in tests)
-export async function execSshCommand(sshConfig: any, command: string, stdin?: string): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: "text"; text: string; } | { [x: string]: unknown; type: "image"; data: string; mimeType: string; } | { [x: string]: unknown; type: "audio"; data: string; mimeType: string; } | { [x: string]: unknown; type: "resource"; resource: any; })[] }> {
+export async function execSshCommand(
+  sshConfig: any,
+  command: string,
+  stdin?: string
+): Promise<{ [x: string]: unknown; content: ({ [x: string]: unknown; type: 'text'; text: string; } | { [x: string]: unknown; type: 'image'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'audio'; data: string; mimeType: string; } | { [x: string]: unknown; type: 'resource'; resource: any; })[] }> {
   return new Promise((resolve, reject) => {
     const conn = new Client();
     let timeoutId: NodeJS.Timeout;
     let isResolved = false;
 
-    // Set up timeout
     timeoutId = setTimeout(() => {
       if (!isResolved) {
         isResolved = true;
-        // Try to abort the running command before closing connection
-        const abortTimeout = setTimeout(() => {
-          // If abort command itself times out, force close connection
-          conn.end();
-        }, 5000); // 5 second timeout for abort command
-
-        conn.exec('timeout 3s pkill -f \'' + escapeCommandForShell(command) + '\' 2>/dev/null || true', (err: Error | undefined, abortStream: ClientChannel | undefined) => {
+        const abortTimeout = setTimeout(() => { conn.end(); }, 5000);
+        conn.exec(`timeout 3s pkill -f '${escapeCommandForShell(command)}' 2>/dev/null || true`, (err: Error | undefined, abortStream: ClientChannel | undefined) => {
           if (abortStream) {
             abortStream.on('close', () => {
               clearTimeout(abortTimeout);
@@ -645,18 +385,13 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
           conn.end();
           return;
         }
-        // If stdin provided, write it to the stream and end stdin
         if (stdin && stdin.length > 0) {
-          try {
-            stream.write(stdin);
-          } catch (e) {
-            // ignore
-          }
+          try { stream.write(stdin); } catch (e) { /* ignore */ }
         }
         try { stream.end(); } catch (e) { /* ignore */ }
         let stdout = '';
         let stderr = '';
-        stream.on('close', (code: number, signal: string) => {
+        stream.on('close', (code: number, _signal: string) => {
           if (!isResolved) {
             isResolved = true;
             clearTimeout(timeoutId);
@@ -664,21 +399,12 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
             if (stderr) {
               reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
             } else {
-              resolve({
-                content: [{
-                  type: 'text',
-                  text: stdout,
-                }],
-              });
+              resolve({ content: [{ type: 'text', text: stdout }] });
             }
           }
         });
-        stream.on('data', (data: Buffer) => {
-          stdout += data.toString();
-        });
-        stream.stderr.on('data', (data: Buffer) => {
-          stderr += data.toString();
-        });
+        stream.on('data', (data: Buffer) => { stdout += data.toString(); });
+        stream.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
       });
     });
     conn.on('error', (err: Error) => {
@@ -692,17 +418,20 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
   });
 }
 
+// ===========================================================================
+// Server lifecycle
+// ===========================================================================
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("SSH MCP Server running on stdio");
+  console.error('SSH MCP Server running on stdio');
 
-  // Handle graceful shutdown
   const cleanup = () => {
-    console.error("Shutting down SSH MCP Server...");
-    if (connectionManager) {
-      connectionManager.close();
-      connectionManager = null;
+    console.error('Shutting down SSH MCP Server...');
+    if (activeTransport) {
+      void activeTransport.close();
+      activeTransport = null;
     }
     process.exit(0);
   };
@@ -710,26 +439,23 @@ async function main() {
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
   process.on('exit', () => {
-    if (connectionManager) {
-      connectionManager.close();
+    if (activeTransport) {
+      void activeTransport.close();
     }
   });
 }
 
-// Initialize server in test mode for automated tests
 if (isTestMode) {
   const transport = new StdioServerTransport();
   server.connect(transport).catch(error => {
-    console.error("Fatal error connecting server:", error);
+    console.error('Fatal error connecting server:', error);
     process.exit(1);
   });
-}
-// Start server in CLI mode
-else if (isCliEnabled) {
+} else if (isCliEnabled) {
   main().catch((error) => {
-    console.error("Fatal error in main():", error);
-    if (connectionManager) {
-      connectionManager.close();
+    console.error('Fatal error in main():', error);
+    if (activeTransport) {
+      void activeTransport.close();
     }
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -408,11 +408,6 @@ async function bootstrapRegistry(): Promise<void> {
   }
 }
 
-/** Effective profile/connection name for gating + audit attribution. */
-function resolvedProfileName(connectionName?: string): string {
-  return connectionName ?? registry.getDefaultName() ?? 'default';
-}
-
 export function buildApprovalProfile(
   id: string,
   perSourceApproval: Record<string, ApprovalMode> = {},
@@ -553,14 +548,20 @@ server.tool(
   async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
     const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
-    const profile = resolvedProfileName(connectionName);
+    // Audit attribution starts as unresolved and is pinned to the canonical
+    // host name only after registry.get() confirms a host resolved. This keeps
+    // a rejected/ambiguous call (e.g. omitted connectionName in multi-host mode)
+    // from being misattributed to the first-registered server.
+    let profile = connectionName ?? '(unresolved)';
     const startedAt = Date.now();
     let audited = false;
     let approvalDecision: ApprovalDecision | undefined;
     try {
       const t = await registry.get(connectionName);
+      const resolvedProfile = registry.profile(connectionName);
+      profile = resolvedProfile.id;
       approvalDecision = await gateApproval({
-        profile: registry.profile(connectionName),
+        profile: resolvedProfile,
         tool: 'exec',
         command: commandWithDescription,
         description,
@@ -606,14 +607,20 @@ if (!DISABLE_SUDO) {
     async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
       const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
-      const profile = resolvedProfileName(connectionName);
+      // Audit attribution starts as unresolved and is pinned to the canonical
+      // host name only after registry.get() confirms a host resolved. This keeps
+      // a rejected/ambiguous call (e.g. omitted connectionName in multi-host mode)
+      // from being misattributed to the first-registered server.
+      let profile = connectionName ?? '(unresolved)';
       const startedAt = Date.now();
       let audited = false;
       let approvalDecision: ApprovalDecision | undefined;
       try {
         const t = await registry.get(connectionName);
+        const resolvedProfile = registry.profile(connectionName);
+        profile = resolvedProfile.id;
         approvalDecision = await gateApproval({
-          profile: registry.profile(connectionName),
+          profile: resolvedProfile,
           tool: 'sudo-exec',
           command: commandWithDescription,
           description,

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,11 +92,20 @@ function validateConfig(config: Record<string, string | null>) {
   if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
     errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
   }
-  if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
+  // OpenSSH options that require an explicit value. A value-less flag (e.g.
+  // `--strictHostKeyChecking` with no `=value`) is recorded as `null` by
+  // parseArgv; guarding on truthiness would silently skip validation and let
+  // buildTransportConfig drop the option, falling back to the default and (for
+  // strictHostKeyChecking) weakening the requested host-key policy. Detect the
+  // flag by property presence so a missing value is rejected with a clear error.
+  if ('strictHostKeyChecking' in config && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
     errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
   }
-  if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
+  if ('gssapiDelegateCredentials' in config && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
     errors.push('--gssapiDelegateCredentials must be yes or no');
+  }
+  if ('knownHostsFile' in config && !config.knownHostsFile) {
+    errors.push('--knownHostsFile requires a file path');
   }
 
   if (errors.length > 0) {
@@ -297,7 +306,14 @@ function stripBenignSshWarnings(stderr: string): string {
 }
 export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
-    throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
+    // Always surface that the command timed out, even when the process wrote to
+    // stderr before the deadline. A build/tool that prints progress or
+    // diagnostics to stderr and then hangs would otherwise be reported as an
+    // ordinary error, hiding the timeout. Keep any captured stderr as trailing
+    // context so its diagnostics are not lost.
+    const timeoutMsg = `Command execution timed out after ${DEFAULT_TIMEOUT}ms`;
+    const detail = result.stderr ? `${timeoutMsg}\n${result.stderr}` : timeoutMsg;
+    throw new McpError(ErrorCode.InternalError, detail);
   }
   if (result.category === 'auth') {
     throw new McpError(ErrorCode.InternalError, `SSH authentication error: ${result.stderr}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -677,10 +677,13 @@ export function buildApprovalProfile(
   };
 }
 
-function approvalProfileForConnection(connectionName?: string): ResolvedSource {
-  const id = resolvedProfileName(connectionName);
+function approvalTargetForConnection(connectionName?: string): { profile: string; approvalProfile: ResolvedSource } {
+  const id = registry.resolveRegisteredName(connectionName);
   const source = resolvedConfig.sources.find(s => s.name === id);
-  return buildApprovalProfile(id, resolvedConfig.perSourceApproval ?? {}, source);
+  return {
+    profile: id,
+    approvalProfile: buildApprovalProfile(id, resolvedConfig.perSourceApproval ?? {}, source),
+  };
 }
 
 export function appendDescriptionComment(command: string, description?: string): string {
@@ -952,7 +955,7 @@ server.tool(
   async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
     const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
-    const profile = resolvedProfileName(connectionName);
+    let profile = resolvedProfileName(connectionName);
     // Fallback timestamp for errors raised before the transport call (registry
     // init failure, approval deny). Re-captured immediately before t.exec below
     // so a SUCCESSFUL command's audit durationMs measures command runtime only,
@@ -961,15 +964,18 @@ server.tool(
     let audited = false;
     let approvalDecision: ApprovalDecision | undefined;
     try {
+      const target = approvalTargetForConnection(connectionName);
+      profile = target.profile;
       approvalDecision = await gateApproval({
-        profile: approvalProfileForConnection(connectionName),
+        profile: target.approvalProfile,
         tool: 'exec',
         command: commandWithDescription,
         description,
       });
-      const t = await registry.get(connectionName);
+      const t = await registry.get(target.profile);
       startedAt = Date.now();
       const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
+      audited = true;
       const response = recordAuditResult({
         tool: 'exec',
         profile,
@@ -978,7 +984,6 @@ server.tool(
         startedAt,
         approval: approvalDecision,
       }, result);
-      audited = true;
       return response;
     } catch (err: any) {
       approvalDecision = approvalDecision ?? getApprovalDecisionFromError(err);
@@ -1009,7 +1014,7 @@ if (!DISABLE_SUDO) {
     async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
       const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
-      const profile = resolvedProfileName(connectionName);
+      let profile = resolvedProfileName(connectionName);
       // Fallback timestamp for errors raised before the transport call (registry
       // init failure, approval deny). Re-captured immediately before
       // t.execElevated below so a SUCCESSFUL command's audit durationMs measures
@@ -1018,13 +1023,15 @@ if (!DISABLE_SUDO) {
       let audited = false;
       let approvalDecision: ApprovalDecision | undefined;
       try {
+        const target = approvalTargetForConnection(connectionName);
+        profile = target.profile;
         approvalDecision = await gateApproval({
-          profile: approvalProfileForConnection(connectionName),
+          profile: target.approvalProfile,
           tool: 'sudo-exec',
           command: commandWithDescription,
           description,
         });
-        const t = await registry.get(connectionName);
+        const t = await registry.get(target.profile);
         // Legacy single-host mode may still pass --sudoPassword on CLI; in
         // multi-host mode each ServerConfig carries its own sudoPassword.
         const legacySudo = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined && !isMultiHost)
@@ -1036,6 +1043,7 @@ if (!DISABLE_SUDO) {
           mode: 'sudo',
           password: legacySudo,
         });
+        audited = true;
         const response = recordAuditResult({
           tool: 'sudo-exec',
           profile,
@@ -1044,7 +1052,6 @@ if (!DISABLE_SUDO) {
           startedAt,
           approval: approvalDecision,
         }, result);
-        audited = true;
         return response;
       } catch (err: any) {
         approvalDecision = approvalDecision ?? getApprovalDecisionFromError(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,46 +112,90 @@ export function sanitizeCommand(command: string): string {
   return sanitizeCommandImpl(command, MAX_CHARS as number);
 }
 
-function resolveTransport(): 'ssh2' | 'openssh' {
-  if (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) return 'openssh';
+function resolveTransport(opts: { transportFlag?: string | null; kerberos?: boolean }): 'ssh2' | 'openssh' {
+  if (opts.transportFlag === 'openssh' || opts.kerberos) return 'openssh';
   return 'ssh2';
 }
 
-function resolveAuthMode(): 'kerberos' | 'key' | 'password' | undefined {
-  if (KERBEROS_FLAG) return 'kerberos';
-  if (KEY) return 'key';
-  if (PASSWORD) return 'password';
+/**
+ * Resolve the effective auth mode from the provided credential flags.
+ *
+ * Precedence: kerberos > password > key. Password is ranked above key to
+ * preserve the legacy ssh2 behaviour (base `main`): when both a password and a
+ * key path are supplied, the password wins and the key file is never read. This
+ * avoids an ENOENT crash for password configs that still carry a stale/sample
+ * `--key=path/to/key`.
+ */
+export function resolveAuthMode(opts: {
+  kerberos?: boolean;
+  key?: string | null;
+  password?: string | null;
+}): 'kerberos' | 'key' | 'password' | undefined {
+  if (opts.kerberos) return 'kerberos';
+  if (opts.password) return 'password';
+  if (opts.key) return 'key';
   return undefined;
 }
 
-async function buildTransportConfig(): Promise<TransportConfig> {
-  if (!HOST || !USER) {
+/**
+ * Inputs for {@link buildTransportConfig}. Mirrors the legacy CLI flags but is
+ * passed explicitly so the resolution logic is pure and unit-testable.
+ */
+export interface BuildTransportConfigInputs {
+  host?: string | null;
+  port: number;
+  username?: string | null;
+  password?: string | null;
+  key?: string | null;
+  suPassword?: string | null;
+  sudoPassword?: string | null;
+  kerberos?: boolean;
+  transportFlag?: string | null;
+  gssapiDelegateCredentials?: string | null;
+  knownHostsFile?: string | null;
+  strictHostKeyChecking?: string | null;
+}
+
+export async function buildTransportConfig(inputs: BuildTransportConfigInputs): Promise<TransportConfig> {
+  const { host, username } = inputs;
+  if (!host || !username) {
     throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
   }
 
+  const transport = resolveTransport({ transportFlag: inputs.transportFlag, kerberos: inputs.kerberos });
+  const authMode = resolveAuthMode({
+    kerberos: inputs.kerberos,
+    password: inputs.password,
+    key: inputs.key,
+  });
+
   const cfg: TransportConfig = {
-    host: HOST,
-    port: PORT,
-    username: USER,
-    transport: resolveTransport(),
-    authMode: resolveAuthMode(),
+    host,
+    port: inputs.port,
+    username,
+    transport,
+    authMode,
   };
 
-  if (PASSWORD) cfg.password = PASSWORD;
-  if (KEY) {
-    cfg.keyPath = KEY;
-    // ssh2 transport needs the key contents, not the path
-    if (cfg.transport === 'ssh2') {
+  if (inputs.password) cfg.password = inputs.password;
+  if (inputs.key) {
+    cfg.keyPath = inputs.key;
+    // ssh2 transport needs the key contents, not the path — but only when the
+    // key is the resolved auth mode. A password config that also carries a
+    // stale/sample --key must NOT read the (possibly nonexistent) key file,
+    // which would otherwise throw ENOENT before connecting (regression vs base
+    // main, where password took precedence and the key was never read).
+    if (transport === 'ssh2' && authMode === 'key') {
       const fs = await import('fs/promises');
-      cfg.privateKey = await fs.readFile(KEY, 'utf8');
+      cfg.privateKey = await fs.readFile(inputs.key, 'utf8');
     }
   }
-  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
-  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
-  if (KERBEROS_FLAG) cfg.kerberos = true;
-  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
-  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
-  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+  if (inputs.suPassword !== null && inputs.suPassword !== undefined) cfg.suPassword = sanitizePassword(inputs.suPassword);
+  if (inputs.sudoPassword !== null && inputs.sudoPassword !== undefined) cfg.sudoPassword = sanitizePassword(inputs.sudoPassword);
+  if (inputs.kerberos) cfg.kerberos = true;
+  if (inputs.gssapiDelegateCredentials) cfg.gssapiDelegateCredentials = inputs.gssapiDelegateCredentials as 'yes' | 'no';
+  if (inputs.knownHostsFile) cfg.knownHostsFile = inputs.knownHostsFile;
+  if (inputs.strictHostKeyChecking) cfg.strictHostKeyChecking = inputs.strictHostKeyChecking as 'yes' | 'no' | 'accept-new';
 
   return cfg;
 }
@@ -160,7 +204,20 @@ let activeTransport: ISshTransport | null = null;
 
 async function getOrCreateTransport(): Promise<ISshTransport> {
   if (activeTransport) return activeTransport;
-  const cfg = await buildTransportConfig();
+  const cfg = await buildTransportConfig({
+    host: HOST,
+    port: PORT,
+    username: USER,
+    password: PASSWORD,
+    key: KEY,
+    suPassword: SUPASSWORD,
+    sudoPassword: SUDOPASSWORD,
+    kerberos: KERBEROS_FLAG,
+    transportFlag: TRANSPORT_FLAG,
+    gssapiDelegateCredentials: GSSAPI_DELEGATE,
+    knownHostsFile: KNOWN_HOSTS_FILE,
+    strictHostKeyChecking: STRICT_HOST_KEY,
+  });
   activeTransport = createTransport(cfg);
   await activeTransport.init();
   return activeTransport;
@@ -168,12 +225,20 @@ async function getOrCreateTransport(): Promise<ISshTransport> {
 
 /**
  * Map ExecResult to MCP tool response. Preserves upstream semantics:
- *   - stderr present → reject with McpError (wraps as "Error (code N):\n<stderr>")
  *   - auth/host_key/connect/transport categories → reject with descriptive error
  *   - timeout → reject with timeout error
- *   - success → return {content: [{type:'text', text: stdout}]}
+ *   - non-zero exit with stderr → reject (wraps as "Error (code N):\n<stderr>")
+ *   - exit 0 → success, even if stderr is non-empty
+ *
+ * Exit 0 is treated as success regardless of stderr: the OpenSSH transport
+ * surfaces benign diagnostics on stderr (e.g. with the default
+ * StrictHostKeyChecking=accept-new, the first connection to a host prints
+ * "Warning: Permanently added '<host>' ... to the list of known hosts." while
+ * exiting 0). Throwing on any stderr would turn every first-connect into an
+ * error. stderr is only an error indicator when the command actually failed
+ * (non-zero exit) and no more specific category applies.
  */
-function resultToMcpContent(result: ExecResult) {
+export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
   }
@@ -189,7 +254,7 @@ function resultToMcpContent(result: ExecResult) {
   if (result.category === 'transport') {
     throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
   }
-  if (result.stderr) {
+  if (result.stderr && result.exitCode !== 0) {
     throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
   }
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   getApprovalDecisionFromError,
   setApprovalEngine,
   buildApprovalEngineFromConfig,
+  manualWithoutResolverWarning,
   type ApprovalDecision,
   type BuildEngineFromConfigInput,
   type ApprovalDispatcher,
@@ -517,21 +518,20 @@ export function appendDescriptionComment(command: string, description?: string):
 let auditSink: AuditSink = { record() { /* no-op until wired (or audit absent) */ } };
 
 /**
- * Build the production approval engine from resolvedConfig. Returns null for
- * the legacy CLI path (no [approval] section and no per-source overrides) so
- * the gate keeps its backward-compatible `legacy:no-engine` allow.
- *
- * Throws (fatal at boot):
- *   - manual mode requested but WebUI disabled (gate-12 invariant)
- *   - smart mode requested but [approval.llm] missing endpoint or model
+ * Resolve the [approval]/per-source config into the concrete engine input.
+ * Returns null for the legacy CLI path (no [approval] section and no per-source
+ * overrides). Shared by buildProductionApprovalEngine (which builds the engine)
+ * and wireApprovalAndAudit (which reuses the SAME resolved defaultMode +
+ * perSourceModes for the manual-without-resolver boot warning) so the warning
+ * can never disagree with the mode the engine actually runs.
  */
-function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher | null {
+function resolveApprovalEngineInput(): BuildEngineFromConfigInput | null {
   const approvalCfg = resolvedConfig.approval;
   const perSourceModes: ApprovalMode[] = Object.values(resolvedConfig.perSourceApproval ?? {});
   if (approvalCfg === undefined && perSourceModes.length === 0) {
     return null;
   }
-  const input: BuildEngineFromConfigInput = {
+  return {
     // Resolve the GLOBAL default mode:
     //  - explicit [approval].mode set        -> honor it.
     //  - no global mode, per-source overrides -> the [approval] block (when
@@ -557,6 +557,22 @@ function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher
     llm: approvalCfg?.llm,
     perSourceModes,
   };
+}
+
+/**
+ * Build the production approval engine from resolvedConfig. Returns null for
+ * the legacy CLI path (no [approval] section and no per-source overrides) so
+ * the gate keeps its backward-compatible `legacy:no-engine` allow.
+ *
+ * Throws (fatal at boot):
+ *   - manual mode requested but WebUI disabled (gate-12 invariant)
+ *   - smart mode requested but [approval.llm] missing endpoint or model
+ */
+function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher | null {
+  const input = resolveApprovalEngineInput();
+  if (input === null) {
+    return null;
+  }
   return buildApprovalEngineFromConfig(input, {
     manualOpts: { webuiEnabled: webuiActive },
   });
@@ -572,11 +588,40 @@ function isWebUIActive(): boolean {
 }
 
 /**
+ * True when a driver that settles the manual-approval queue is wired into this
+ * build. The queue resolver — the WebUI manual-approval server — lands in the
+ * child lane `pr/webui-manual-approval`; the approval-engine lane ships only the
+ * queue primitive, so no resolver is wired here. Kept as an explicit predicate
+ * (rather than inlining `false`) so the child lane can flip it to a real
+ * detection — e.g. `return isWebUIServerWired();` — without touching the warning
+ * call site.
+ */
+function isApprovalResolverWired(): boolean {
+  return false;
+}
+
+/**
  * Wire the approval engine into the gate and load the optional audit sink.
  * Safe to call before the MCP transport connects so the first exec is gated.
  */
 async function wireApprovalAndAudit(): Promise<void> {
-  const engine = buildProductionApprovalEngine(isWebUIActive());
+  const webuiActive = isWebUIActive();
+  const engine = buildProductionApprovalEngine(webuiActive);
+
+  // Non-fatal boot advisory: manual mode boots a queue with no driver when the
+  // approval-engine lane runs standalone, ahead of its child WebUI lane. Boot
+  // still succeeds (the queue exists, it just times out until a resolver lands);
+  // warn so the operator is not left wondering why every command hangs.
+  const input = resolveApprovalEngineInput();
+  const warning = manualWithoutResolverWarning({
+    webuiEnabled: webuiActive,
+    defaultMode: input?.defaultMode,
+    perSourceModes: input?.perSourceModes,
+    resolverWired: isApprovalResolverWired(),
+  });
+  if (warning) {
+    console.error(`WARN: ${warning}`);
+  }
   setApprovalEngine(engine);
   auditSink = await loadAuditSink({
     auditDir: resolvedConfig.server?.audit_dir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,16 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       break;
     case 'password':
       cfg.transport = resolveJsonTransport(obj);
-      if (obj.password) cfg.password = obj.password;
+      // Require actual password material. An empty/missing password still
+      // registers the server as password-authenticated but fails on first use:
+      // OpenSshTransport.init() throws "authMode=password requires --password",
+      // and the default ssh2 path attempts to connect without the credential the
+      // selected auth mode promises. Fail at parse time like the key-auth branch
+      // already does for missing key material (Codex 3549295040).
+      if (typeof obj.password !== 'string' || obj.password.length === 0) {
+        throw new Error(`--ssh "${obj.name}" auth "password" requires a non-empty "password"`);
+      }
+      cfg.password = obj.password;
       break;
   }
 
@@ -435,9 +444,20 @@ export async function buildTransportConfig(
 
 const registry = new TransportRegistry(prepareKeyContents);
 
-async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
+export async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
   // ssh2 transport reads key contents in memory; openssh uses -i path.
-  if (cfg.transport === 'ssh2' && cfg.keyPath && !cfg.privateKey) {
+  // Gate on authMode === 'key': buildTransportConfig() still records keyPath
+  // even when password auth takes precedence over a stale/sample --key, so a
+  // config such as `--password=... --key=/stale` must NOT read the (possibly
+  // nonexistent) key file here — otherwise the first tool call fails with
+  // ENOENT instead of using the password (Codex 3549295046). Mirrors the eager
+  // read's `authMode === 'key'` guard in buildTransportConfig().
+  if (
+    cfg.authMode === 'key' &&
+    cfg.transport === 'ssh2' &&
+    cfg.keyPath &&
+    !cfg.privateKey
+  ) {
     const fs = await import('fs/promises');
     cfg.privateKey = await fs.readFile(cfg.keyPath, 'utf8');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,27 +200,64 @@ export async function buildTransportConfig(inputs: BuildTransportConfigInputs): 
   return cfg;
 }
 
-let activeTransport: ISshTransport | null = null;
+export interface TransportInitCache {
+  activeTransport: ISshTransport | null;
+  initPromise: Promise<ISshTransport> | null;
+}
+
+const activeTransportCache: TransportInitCache = {
+  activeTransport: null,
+  initPromise: null,
+};
+
+/**
+ * Return the active transport, or share one in-flight initialization.
+ *
+ * The transport must not be published before init() completes: OpenSSH password
+ * auth prepares SSH_ASKPASS asynchronously, and a concurrent tool call that sees
+ * a half-initialized transport can enter runSsh before the helper/env is ready.
+ */
+export function getOrCreateInitializedTransport(
+  cache: TransportInitCache,
+  createInitializedTransport: () => Promise<ISshTransport>,
+): Promise<ISshTransport> {
+  if (cache.activeTransport) return Promise.resolve(cache.activeTransport);
+  if (cache.initPromise) return cache.initPromise;
+
+  const initPromise = createInitializedTransport()
+    .then((transport) => {
+      cache.activeTransport = transport;
+      if (cache.initPromise === initPromise) cache.initPromise = null;
+      return transport;
+    })
+    .catch((err) => {
+      if (cache.initPromise === initPromise) cache.initPromise = null;
+      throw err;
+    });
+  cache.initPromise = initPromise;
+  return initPromise;
+}
 
 async function getOrCreateTransport(): Promise<ISshTransport> {
-  if (activeTransport) return activeTransport;
-  const cfg = await buildTransportConfig({
-    host: HOST,
-    port: PORT,
-    username: USER,
-    password: PASSWORD,
-    key: KEY,
-    suPassword: SUPASSWORD,
-    sudoPassword: SUDOPASSWORD,
-    kerberos: KERBEROS_FLAG,
-    transportFlag: TRANSPORT_FLAG,
-    gssapiDelegateCredentials: GSSAPI_DELEGATE,
-    knownHostsFile: KNOWN_HOSTS_FILE,
-    strictHostKeyChecking: STRICT_HOST_KEY,
+  return getOrCreateInitializedTransport(activeTransportCache, async () => {
+    const cfg = await buildTransportConfig({
+      host: HOST,
+      port: PORT,
+      username: USER,
+      password: PASSWORD,
+      key: KEY,
+      suPassword: SUPASSWORD,
+      sudoPassword: SUDOPASSWORD,
+      kerberos: KERBEROS_FLAG,
+      transportFlag: TRANSPORT_FLAG,
+      gssapiDelegateCredentials: GSSAPI_DELEGATE,
+      knownHostsFile: KNOWN_HOSTS_FILE,
+      strictHostKeyChecking: STRICT_HOST_KEY,
+    });
+    const transport = createTransport(cfg);
+    await transport.init();
+    return transport;
   });
-  activeTransport = createTransport(cfg);
-  await activeTransport.init();
-  return activeTransport;
 }
 
 /**
@@ -500,9 +537,10 @@ async function main() {
 
   const cleanup = () => {
     console.error('Shutting down SSH MCP Server...');
-    if (activeTransport) {
-      void activeTransport.close();
-      activeTransport = null;
+    if (activeTransportCache.activeTransport) {
+      void activeTransportCache.activeTransport.close();
+      activeTransportCache.activeTransport = null;
+      activeTransportCache.initPromise = null;
     }
     process.exit(0);
   };
@@ -510,8 +548,8 @@ async function main() {
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
   process.on('exit', () => {
-    if (activeTransport) {
-      void activeTransport.close();
+    if (activeTransportCache.activeTransport) {
+      void activeTransportCache.activeTransport.close();
     }
   });
 }
@@ -525,8 +563,8 @@ if (isTestMode) {
 } else if (isCliEnabled) {
   main().catch((error) => {
     console.error('Fatal error in main():', error);
-    if (activeTransport) {
-      void activeTransport.close();
+    if (activeTransportCache.activeTransport) {
+      void activeTransportCache.activeTransport.close();
     }
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,7 +418,7 @@ server.tool(
     try {
       const t = await registry.get(connectionName);
       approvalDecision = await gateApproval({
-        profile: { id: connectionName ?? 'default' },
+        profile: registry.profile(connectionName),
         tool: 'exec',
         command: sanitizedCommand,
         description,
@@ -472,7 +472,7 @@ if (!DISABLE_SUDO) {
       try {
         const t = await registry.get(connectionName);
         approvalDecision = await gateApproval({
-          profile: { id: connectionName ?? 'default' },
+          profile: registry.profile(connectionName),
           tool: 'sudo-exec',
           command: sanitizedCommand,
           description,

--- a/src/index.ts
+++ b/src/index.ts
@@ -582,18 +582,24 @@ server.tool(
     const sanitizedCommand = sanitizeCommand(command);
     const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
     // Audit attribution starts as unresolved and is pinned to the canonical
-    // host name only after registry.get() confirms a host resolved. This keeps
-    // a rejected/ambiguous call (e.g. omitted connectionName in multi-host mode)
-    // from being misattributed to the first-registered server. A blank/whitespace
-    // name is treated as omitted, mirroring TransportRegistry.resolveName().
+    // host name via registry.profile() — a pure name resolution that does NOT
+    // connect. Pinning it BEFORE registry.get() (which lazily inits the
+    // transport and can reject on bad credentials, host-key rejection, or an
+    // unreachable host) keeps pre-command init failures audited under the real
+    // host identity when the target is unambiguous. When the name is genuinely
+    // ambiguous/unknown (omitted connectionName in multi-host mode without an
+    // explicit default, or an unregistered name) registry.profile() throws and
+    // the audit keeps the raw '(unresolved)'/bad-name attribution. A
+    // blank/whitespace name is treated as omitted, mirroring
+    // TransportRegistry.resolveName().
     let profile = connectionName && connectionName.trim() !== '' ? connectionName : '(unresolved)';
     const startedAt = Date.now();
     let audited = false;
     let approvalDecision: ApprovalDecision | undefined;
     try {
-      const t = await registry.get(connectionName);
       const resolvedProfile = registry.profile(connectionName);
       profile = resolvedProfile.id;
+      const t = await registry.get(connectionName);
       approvalDecision = await gateApproval({
         profile: resolvedProfile,
         tool: 'exec',
@@ -642,18 +648,24 @@ if (!DISABLE_SUDO) {
       const sanitizedCommand = sanitizeCommand(command);
       const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
       // Audit attribution starts as unresolved and is pinned to the canonical
-      // host name only after registry.get() confirms a host resolved. This keeps
-      // a rejected/ambiguous call (e.g. omitted connectionName in multi-host mode)
-      // from being misattributed to the first-registered server. A blank/whitespace
-      // name is treated as omitted, mirroring TransportRegistry.resolveName().
+      // host name via registry.profile() — a pure name resolution that does NOT
+      // connect. Pinning it BEFORE registry.get() (which lazily inits the
+      // transport and can reject on bad credentials, host-key rejection, or an
+      // unreachable host) keeps pre-command init failures audited under the real
+      // host identity when the target is unambiguous. When the name is genuinely
+      // ambiguous/unknown (omitted connectionName in multi-host mode without an
+      // explicit default, or an unregistered name) registry.profile() throws and
+      // the audit keeps the raw '(unresolved)'/bad-name attribution. A
+      // blank/whitespace name is treated as omitted, mirroring
+      // TransportRegistry.resolveName().
       let profile = connectionName && connectionName.trim() !== '' ? connectionName : '(unresolved)';
       const startedAt = Date.now();
       let audited = false;
       let approvalDecision: ApprovalDecision | undefined;
       try {
-        const t = await registry.get(connectionName);
         const resolvedProfile = registry.profile(connectionName);
         profile = resolvedProfile.id;
+        const t = await registry.get(connectionName);
         approvalDecision = await gateApproval({
           profile: resolvedProfile,
           tool: 'sudo-exec',

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,14 @@ function resolvedProfileName(connectionName?: string): string {
   // profile id '' while the command actually ran against the default host,
   // silently bypassing that host's per-source approval policy.
   const name = connectionName && connectionName.trim() !== '' ? connectionName : undefined;
-  return name ?? registry.getDefaultName() ?? 'default';
+  if (name) return name;
+  // An omitted/blank name that the registry would REJECT (multi-source, no
+  // explicit default, guard on) never lands on a host: resolveName() throws
+  // before selection. Attributing that rejected call to getDefaultName() (the
+  // first-registered host) would corrupt audit profile for exactly the guard
+  // case. Mirror the guard and label it unresolved instead of a real host.
+  if (registry.wouldRejectOmittedName()) return '(unresolved)';
+  return registry.getDefaultName() ?? 'default';
 }
 
 export function buildApprovalProfile(
@@ -525,16 +532,27 @@ function buildProductionApprovalEngine(webuiActive: boolean): ApprovalDispatcher
     return null;
   }
   const input: BuildEngineFromConfigInput = {
-    // When there is NO top-level [approval] block (only per-source overrides),
-    // the global default stays 'yolo' (unrestricted) rather than inheriting
-    // buildApprovalEngineFromConfig's [approval]-present 'manual' fallback.
-    // This mirrors the `return null` (legacy unrestricted) branch one level up
-    // for the no-config case: adding per-source gates should gate only those
-    // sources, not silently flip the global default to manual — which would
-    // gate every ungated host and, without WebUI, throw at boot.
-    // A present [approval] block with an unspecified mode still defaults to
-    // manual (the documented TOML default), preserving that contract.
-    defaultMode: approvalCfg === undefined ? 'yolo' : approvalCfg.mode,
+    // Resolve the GLOBAL default mode:
+    //  - explicit [approval].mode set        -> honor it.
+    //  - no global mode, per-source overrides -> the [approval] block (when
+    //    present at all) exists only to host [approval.llm] for a per-source
+    //    smart override; keep the global default 'yolo' (unrestricted) so only
+    //    the overridden sources are gated. Defining [approval.llm] for a
+    //    per-source `mode = "smart"` makes resolvedConfig.approval non-undefined
+    //    even though no global mode was requested, so keying solely on
+    //    `approvalCfg === undefined` would wrongly fall through to manual here
+    //    and gate every ungated host (or throw at boot with WebUI off). This
+    //    also covers the no-[approval]-block case (per-source overrides only).
+    //  - no global mode and no per-source overrides -> a bare [approval] block
+    //    (e.g. `fail_closed = true`, or `[approval.llm]` alone) was added
+    //    deliberately to enable approval; leave defaultMode undefined so
+    //    buildApprovalEngineFromConfig applies the documented 'manual' default.
+    defaultMode:
+      approvalCfg?.mode !== undefined
+        ? approvalCfg.mode
+        : perSourceModes.length > 0
+          ? 'yolo'
+          : undefined,
     fail_closed: approvalCfg?.fail_closed,
     llm: approvalCfg?.llm,
     perSourceModes,
@@ -662,7 +680,11 @@ server.tool(
     const sanitizedCommand = sanitizeCommand(command);
     const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
     const profile = resolvedProfileName(connectionName);
-    const startedAt = Date.now();
+    // Fallback timestamp for errors raised before the transport call (registry
+    // init failure, approval deny). Re-captured immediately before t.exec below
+    // so a SUCCESSFUL command's audit durationMs measures command runtime only,
+    // not SSH init + approval wait time.
+    let startedAt = Date.now();
     let audited = false;
     let approvalDecision: ApprovalDecision | undefined;
     try {
@@ -673,6 +695,7 @@ server.tool(
         command: commandWithDescription,
         description,
       });
+      startedAt = Date.now();
       const result = await t.exec(commandWithDescription, { timeoutMs: DEFAULT_TIMEOUT });
       auditSink.record({
         tool: 'exec',
@@ -715,7 +738,11 @@ if (!DISABLE_SUDO) {
       const sanitizedCommand = sanitizeCommand(command);
       const commandWithDescription = appendDescriptionComment(sanitizedCommand, description);
       const profile = resolvedProfileName(connectionName);
-      const startedAt = Date.now();
+      // Fallback timestamp for errors raised before the transport call (registry
+      // init failure, approval deny). Re-captured immediately before
+      // t.execElevated below so a SUCCESSFUL command's audit durationMs measures
+      // command runtime only, not SSH init + approval wait time.
+      let startedAt = Date.now();
       let audited = false;
       let approvalDecision: ApprovalDecision | undefined;
       try {
@@ -731,6 +758,7 @@ if (!DISABLE_SUDO) {
         const legacySudo = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined && !isMultiHost)
           ? sanitizePassword(SUDOPASSWORD)
           : undefined;
+        startedAt = Date.now();
         const result = await t.execElevated(commandWithDescription, {
           timeoutMs: DEFAULT_TIMEOUT,
           mode: 'sudo',

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ function collectSshJsonArgs(): string[] {
     .map(a => a.slice('--ssh='.length));
 }
 
-function parseServerConfigJson(raw: string): ServerConfig {
+export function parseServerConfigJson(raw: string): ServerConfig {
   let obj: any;
   try {
     obj = JSON.parse(raw);
@@ -95,6 +95,16 @@ function parseServerConfigJson(raw: string): ServerConfig {
 
   if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
   if (obj.suPassword) cfg.suPassword = obj.suPassword;
+  // knownHostsFile / strictHostKeyChecking are openssh-transport-only. The ssh2
+  // transport ignores both, so accepting them on an ssh2 config would silently
+  // drop the requested host-key enforcement — a security downgrade. Mirror the
+  // legacy single-host rule ("--knownHostsFile and --strictHostKeyChecking
+  // require --transport=openssh") and reject the combination here.
+  if ((obj.knownHostsFile || obj.strictHostKeyChecking) && cfg.transport !== 'openssh') {
+    throw new Error(
+      `--ssh "${obj.name}" knownHostsFile/strictHostKeyChecking require "transport": "openssh" (got ${cfg.transport})`
+    );
+  }
   if (obj.knownHostsFile) cfg.knownHostsFile = obj.knownHostsFile;
   if (obj.strictHostKeyChecking) cfg.strictHostKeyChecking = obj.strictHostKeyChecking;
   return cfg;
@@ -138,8 +148,13 @@ function validateConfig(config: Record<string, string | null>, multiHost: boolea
   const errors: string[] = [];
 
   if (multiHost) {
-    // Multi-host mode: legacy single-host flags are disallowed to avoid ambiguity
-    const legacyFlags = ['host', 'user', 'password', 'key', 'kerberos', 'transport',
+    // Multi-host mode: legacy single-host flags are disallowed to avoid ambiguity.
+    // bootstrapRegistry reads connection details ONLY from each --ssh JSON in
+    // this mode, so any legacy flag would be silently ignored — including
+    // --port (wrong port), --sudoPassword and --suPassword (elevation would run
+    // without the password). Reject the whole set rather than drop them quietly.
+    const legacyFlags = ['host', 'user', 'port', 'password', 'key', 'kerberos', 'transport',
+                         'sudoPassword', 'suPassword',
                          'strictHostKeyChecking', 'knownHostsFile', 'gssapiDelegateCredentials'];
     const set = legacyFlags.filter(f => config[f] !== undefined);
     if (set.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ async function bootstrapRegistry(): Promise<void> {
   }
 }
 
-function resultToMcpContent(result: ExecResult) {
+export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
   }
@@ -254,13 +254,23 @@ function resultToMcpContent(result: ExecResult) {
   if (result.category === 'transport') {
     throw new McpError(ErrorCode.InternalError, result.stderr || 'SSH transport error');
   }
-  if (result.stderr) {
-    throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${result.stderr}`);
+  // Only treat stderr as a hard failure when the command actually failed (non-zero exit).
+  // Many tools (sudo with -S, curl, git, apt) write progress/info to stderr on success.
+  const exitCode = result.exitCode ?? 0;
+  if (exitCode !== 0 && result.stderr) {
+    throw new McpError(ErrorCode.InternalError, `Error (code ${exitCode}):\n${result.stderr}`);
   }
+  // Success path: include stderr alongside stdout when it has substantive content.
+  const trimmedStderr = result.stderr.trim();
+  const text = trimmedStderr
+    ? (result.stdout
+        ? `${result.stdout.replace(/\n+$/, '')}\n[stderr]\n${result.stderr}`
+        : result.stderr)
+    : result.stdout;
   return {
     content: [{
       type: 'text' as const,
-      text: result.stdout,
+      text,
     }],
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,8 @@ const KERBEROS_FLAG = argvConfig.kerberos !== undefined && argvConfig.kerberos !
 const GSSAPI_DELEGATE = argvConfig.gssapiDelegateCredentials;
 const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
 const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
-const CONFIG_PATH = argvConfig.config;
+// The explicit `--config` path is resolved (and value-less `--config` rejected)
+// via resolveCliConfigPath at the resolveConfig call site below.
 
 // Flags that signal intent to use the legacy single-host CLI mode. NOTE:
 // `disableSudo` is deliberately excluded — it only controls whether the sudo
@@ -244,10 +245,17 @@ const hasLegacyCli = hasLegacyCliFlags(argvConfig);
 function buildLegacyServerConfig(): ServerConfig | undefined {
   if (!HOST || !USER) return undefined;
 
-  const authMode: AuthMode | undefined = KERBEROS_FLAG ? 'kerberos'
-    : KEY ? 'key'
-    : PASSWORD ? 'password'
-    : undefined;
+  // Precedence must match resolveAuthMode (kerberos > password > key), NOT a
+  // key-before-password order. When a legacy invocation supplies both
+  // --password and --key, password wins: classifying it as key auth would make
+  // prepareKeyContents read the (possibly stale/sample) key file → ENOENT, and
+  // could let the ssh2 transport prefer the key over the intended password
+  // (regression vs base `main`). See resolveAuthMode's doc-comment.
+  const authMode: AuthMode | undefined = resolveAuthMode({
+    kerberos: KERBEROS_FLAG,
+    password: PASSWORD,
+    key: KEY,
+  });
   const resolvedTransport: 'ssh2' | 'openssh' =
     (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) ? 'openssh' : 'ssh2';
 
@@ -260,7 +268,11 @@ function buildLegacyServerConfig(): ServerConfig | undefined {
     authMode,
   };
   if (PASSWORD) cfg.password = PASSWORD;
-  if (KEY) cfg.keyPath = KEY;
+  // Only attach the key path when key auth actually wins. Attaching a stale
+  // --key on a password/kerberos source would make prepareKeyContents (ssh2)
+  // read the possibly-nonexistent file, and openssh's password/kerberos
+  // branches never use keyPath anyway.
+  if (KEY && authMode === 'key') cfg.keyPath = KEY;
   if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
   if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
   if (KERBEROS_FLAG) cfg.kerberos = true;
@@ -281,10 +293,31 @@ const cliSourceConfigs: ServerConfig[] = (() => {
   return [];
 })();
 
+/**
+ * Resolve the explicit `--config` path from parsed argv.
+ *
+ * `parseArgv` records a value-less `--config` (no `=path`) as `null`. Silently
+ * coercing that to `undefined` would drop the explicit flag and fall back to
+ * `SSH_MCP_CONFIG`/default discovery, so a mistyped `--config` could start the
+ * process against the wrong configured source instead of failing fast. Reject a
+ * present-but-value-less `--config` like the other value-requiring flags.
+ * Returns the path when supplied, or `undefined` when the flag is absent.
+ */
+export function resolveCliConfigPath(
+  config: Record<string, string | null>,
+): string | undefined {
+  if (!('config' in config)) return undefined;
+  const value = config.config;
+  if (typeof value !== 'string') {
+    throw new Error('Configuration error:\n--config requires a value (--config=<path>)');
+  }
+  return value;
+}
+
 const resolvedConfig: ResolvedConfig = (isCliEnabled || isTestMode)
   ? resolveConfig({
       cliSources: cliSourceConfigs,
-      cliConfigPath: typeof CONFIG_PATH === 'string' ? CONFIG_PATH : undefined,
+      cliConfigPath: resolveCliConfigPath(argvConfig),
     })
   : { sources: [], perSourceApproval: {}, defaultExplicit: false };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,26 @@ import { Client, ClientChannel } from 'ssh2';
 import { z } from 'zod';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
-import { ISshTransport, TransportConfig, ExecResult } from './transports/types.js';
+import { ISshTransport, TransportConfig, ServerConfig, ExecResult, AuthMode } from './transports/types.js';
 import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
 import { createTransport } from './transports/factory.js';
+import { TransportRegistry } from './transports/registry.js';
 import {
   sanitizeCommand as sanitizeCommandImpl,
   sanitizePassword,
   escapeCommandForShell,
 } from './utils/shell.js';
 
-// Re-exports for backward compatibility with existing tests (smoke.ssh.test.ts,
-// persistent-connection.test.ts, etc.).
+// Re-exports for backward compatibility with existing tests.
 export { SSHConnectionManager, escapeCommandForShell };
 export type { SSHConfig };
 
-// Example usage: node build/index.js --host=1.2.3.4 --port=22 --user=root --password=pass --key=path/to/key --timeout=5000 --disableSudo
-// Kerberos SSO:   node build/index.js --host=host --user=user@REALM --kerberos
+// =============================================================================
+// CLI parsing — two modes:
+//   (A) Multi-host: repeated --ssh=<JSON> (each JSON must include "name")
+//   (B) Legacy single-host: --host --user [--kerberos | --key | --password] ...
+// =============================================================================
+
 function parseArgv() {
   const args = process.argv.slice(2);
   const config: Record<string, string | null> = {};
@@ -31,18 +35,77 @@ function parseArgv() {
       if (equalIndex === -1) {
         config[arg.slice(2)] = null;
       } else {
-        config[arg.slice(2, equalIndex)] = arg.slice(equalIndex + 1);
+        const key = arg.slice(2, equalIndex);
+        // --ssh is handled separately below (repeatable); skip here so we
+        // don't clobber with only the last value.
+        if (key === 'ssh') continue;
+        config[key] = arg.slice(equalIndex + 1);
       }
     }
   }
   return config;
 }
 
+function collectSshJsonArgs(): string[] {
+  return process.argv.slice(2)
+    .filter(a => a.startsWith('--ssh='))
+    .map(a => a.slice('--ssh='.length));
+}
+
+function parseServerConfigJson(raw: string): ServerConfig {
+  let obj: any;
+  try {
+    obj = JSON.parse(raw);
+  } catch (e: any) {
+    throw new Error(`--ssh JSON parse error: ${e?.message || e}\nRaw: ${raw}`);
+  }
+  if (!obj.name) throw new Error('--ssh JSON missing required "name"');
+  if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
+  const user = obj.user ?? obj.username;
+  if (!user) throw new Error(`--ssh "${obj.name}" missing required "user" (or "username")`);
+  const auth: AuthMode | undefined = obj.auth;
+  if (!auth || !['kerberos', 'key', 'password'].includes(auth)) {
+    throw new Error(`--ssh "${obj.name}" requires "auth": "kerberos" | "key" | "password"`);
+  }
+
+  const cfg: ServerConfig = {
+    name: obj.name,
+    host: obj.host,
+    port: obj.port ?? 22,
+    username: user,
+    authMode: auth,
+  };
+
+  switch (auth) {
+    case 'kerberos':
+      cfg.kerberos = true;
+      cfg.transport = 'openssh';
+      if (obj.gssapiDelegateCredentials) cfg.gssapiDelegateCredentials = obj.gssapiDelegateCredentials;
+      break;
+    case 'key':
+      cfg.transport = obj.transport ?? 'ssh2';
+      if (obj.keyPath) cfg.keyPath = obj.keyPath;
+      if (obj.privateKey) cfg.privateKey = obj.privateKey;
+      break;
+    case 'password':
+      cfg.transport = obj.transport ?? 'ssh2';
+      if (obj.password) cfg.password = obj.password;
+      break;
+  }
+
+  if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
+  if (obj.suPassword) cfg.suPassword = obj.suPassword;
+  if (obj.knownHostsFile) cfg.knownHostsFile = obj.knownHostsFile;
+  if (obj.strictHostKeyChecking) cfg.strictHostKeyChecking = obj.strictHostKeyChecking;
+  return cfg;
+}
+
 const isTestMode = process.env.SSH_MCP_TEST === '1';
 const isCliEnabled = process.env.SSH_MCP_DISABLE_MAIN !== '1';
 const argvConfig = (isCliEnabled || isTestMode) ? parseArgv() : {} as Record<string, string>;
+const sshJsonArgs = (isCliEnabled || isTestMode) ? collectSshJsonArgs() : [];
 
-// Connection config (legacy flags)
+// Legacy (single-host) flags
 const HOST = argvConfig.host;
 const PORT = argvConfig.port ? parseInt(argvConfig.port) : 22;
 const USER = argvConfig.user;
@@ -65,38 +128,48 @@ const MAX_CHARS = (() => {
   return 1000;
 })();
 
-// Transport config (new flags)
 const TRANSPORT_FLAG = argvConfig.transport;
 const KERBEROS_FLAG = argvConfig.kerberos !== undefined && argvConfig.kerberos !== 'false';
 const GSSAPI_DELEGATE = argvConfig.gssapiDelegateCredentials;
 const KNOWN_HOSTS_FILE = argvConfig.knownHostsFile;
 const STRICT_HOST_KEY = argvConfig.strictHostKeyChecking;
 
-function validateConfig(config: Record<string, string | null>) {
+function validateConfig(config: Record<string, string | null>, multiHost: boolean) {
   const errors: string[] = [];
-  if (!config.host) errors.push('Missing required --host');
-  if (!config.user) errors.push('Missing required --user');
-  if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
 
-  const transportExplicit = config.transport;
-  const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
-  // --kerberos alone implies --transport=openssh
-  const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
+  if (multiHost) {
+    // Multi-host mode: legacy single-host flags are disallowed to avoid ambiguity
+    const legacyFlags = ['host', 'user', 'password', 'key', 'kerberos', 'transport',
+                         'strictHostKeyChecking', 'knownHostsFile', 'gssapiDelegateCredentials'];
+    const set = legacyFlags.filter(f => config[f] !== undefined);
+    if (set.length > 0) {
+      errors.push(`Multi-host (--ssh) mode cannot be mixed with legacy single-host flags: ${set.map(s => '--' + s).join(', ')}`);
+    }
+  } else {
+    // Legacy single-host validation
+    if (!config.host) errors.push('Missing required --host (or use --ssh=<JSON> for multi-host mode)');
+    if (!config.user) errors.push('Missing required --user');
+    if (config.port && isNaN(Number(config.port))) errors.push('Invalid --port');
 
-  if (transport !== 'ssh2' && transport !== 'openssh') {
-    errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
-  }
-  if (kerberos && transportExplicit === 'ssh2') {
-    errors.push('--kerberos requires --transport=openssh (remove --transport=ssh2 or pass --kerberos alone)');
-  }
-  if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
-    errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
-  }
-  if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
-    errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
-  }
-  if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
-    errors.push('--gssapiDelegateCredentials must be yes or no');
+    const transportExplicit = config.transport;
+    const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+    const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
+
+    if (transport !== 'ssh2' && transport !== 'openssh') {
+      errors.push(`Invalid --transport=${transport} (expected: ssh2 or openssh)`);
+    }
+    if (kerberos && transportExplicit === 'ssh2') {
+      errors.push('--kerberos requires --transport=openssh (remove --transport=ssh2 or pass --kerberos alone)');
+    }
+    if (transport === 'ssh2' && (config.knownHostsFile || config.strictHostKeyChecking)) {
+      errors.push('--knownHostsFile and --strictHostKeyChecking require --transport=openssh');
+    }
+    if (STRICT_HOST_KEY && !['yes', 'no', 'accept-new'].includes(config.strictHostKeyChecking!)) {
+      errors.push('--strictHostKeyChecking must be one of: yes, no, accept-new');
+    }
+    if (GSSAPI_DELEGATE && !['yes', 'no'].includes(config.gssapiDelegateCredentials!)) {
+      errors.push('--gssapiDelegateCredentials must be yes or no');
+    }
   }
 
   if (errors.length > 0) {
@@ -104,75 +177,67 @@ function validateConfig(config: Record<string, string | null>) {
   }
 }
 
+const isMultiHost = sshJsonArgs.length > 0;
+
 if (isCliEnabled) {
-  validateConfig(argvConfig);
+  validateConfig(argvConfig, isMultiHost);
 }
 
 export function sanitizeCommand(command: string): string {
   return sanitizeCommandImpl(command, MAX_CHARS as number);
 }
 
-function resolveTransport(): 'ssh2' | 'openssh' {
-  if (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) return 'openssh';
-  return 'ssh2';
-}
+// =============================================================================
+// Transport registry — lazy init, single entry for legacy single-host mode.
+// =============================================================================
 
-function resolveAuthMode(): 'kerberos' | 'key' | 'password' | undefined {
-  if (KERBEROS_FLAG) return 'kerberos';
-  if (KEY) return 'key';
-  if (PASSWORD) return 'password';
-  return undefined;
-}
+const registry = new TransportRegistry();
 
-async function buildTransportConfig(): Promise<TransportConfig> {
-  if (!HOST || !USER) {
-    throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
+async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
+  // ssh2 transport reads key contents in memory; openssh uses -i path.
+  if (cfg.transport === 'ssh2' && cfg.keyPath && !cfg.privateKey) {
+    const fs = await import('fs/promises');
+    cfg.privateKey = await fs.readFile(cfg.keyPath, 'utf8');
   }
+}
 
-  const cfg: TransportConfig = {
-    host: HOST,
-    port: PORT,
-    username: USER,
-    transport: resolveTransport(),
-    authMode: resolveAuthMode(),
-  };
-
-  if (PASSWORD) cfg.password = PASSWORD;
-  if (KEY) {
-    cfg.keyPath = KEY;
-    // ssh2 transport needs the key contents, not the path
-    if (cfg.transport === 'ssh2') {
-      const fs = await import('fs/promises');
-      cfg.privateKey = await fs.readFile(KEY, 'utf8');
+async function bootstrapRegistry(): Promise<void> {
+  if (isMultiHost) {
+    for (const raw of sshJsonArgs) {
+      const cfg = parseServerConfigJson(raw);
+      await prepareKeyContents(cfg);
+      registry.register(cfg);
     }
+  } else {
+    if (!HOST || !USER) return; // Test mode with no CLI — tools will error if called
+    const authMode: AuthMode | undefined = KERBEROS_FLAG ? 'kerberos'
+      : KEY ? 'key'
+      : PASSWORD ? 'password'
+      : undefined;
+    const resolvedTransport: 'ssh2' | 'openssh' =
+      (TRANSPORT_FLAG === 'openssh' || KERBEROS_FLAG) ? 'openssh' : 'ssh2';
+
+    const cfg: ServerConfig = {
+      name: 'default',
+      host: HOST,
+      port: PORT,
+      username: USER,
+      transport: resolvedTransport,
+      authMode,
+    };
+    if (PASSWORD) cfg.password = PASSWORD;
+    if (KEY) cfg.keyPath = KEY;
+    if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
+    if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
+    if (KERBEROS_FLAG) cfg.kerberos = true;
+    if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
+    if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
+    if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
+    await prepareKeyContents(cfg);
+    registry.register(cfg);
   }
-  if (SUPASSWORD !== null && SUPASSWORD !== undefined) cfg.suPassword = sanitizePassword(SUPASSWORD);
-  if (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined) cfg.sudoPassword = sanitizePassword(SUDOPASSWORD);
-  if (KERBEROS_FLAG) cfg.kerberos = true;
-  if (GSSAPI_DELEGATE) cfg.gssapiDelegateCredentials = GSSAPI_DELEGATE as 'yes' | 'no';
-  if (KNOWN_HOSTS_FILE) cfg.knownHostsFile = KNOWN_HOSTS_FILE;
-  if (STRICT_HOST_KEY) cfg.strictHostKeyChecking = STRICT_HOST_KEY as 'yes' | 'no' | 'accept-new';
-
-  return cfg;
 }
 
-let activeTransport: ISshTransport | null = null;
-
-async function getOrCreateTransport(): Promise<ISshTransport> {
-  if (activeTransport) return activeTransport;
-  const cfg = await buildTransportConfig();
-  activeTransport = createTransport(cfg);
-  await activeTransport.init();
-  return activeTransport;
-}
-
-/**
- * Map ExecResult to MCP tool response. Preserves upstream semantics:
- *   - stderr present → reject with McpError (wraps as "Error (code N):\n<stderr>")
- *   - auth/host_key/connect/transport categories → reject with descriptive error
- *   - timeout → reject with timeout error
- *   - success → return {content: [{type:'text', text: stdout}]}
- */
 function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
@@ -202,24 +267,25 @@ function resultToMcpContent(result: ExecResult) {
 
 const server = new McpServer({
   name: 'SSH MCP Server',
-  version: '2.0.0',
-  capabilities: {
-    resources: {},
-    tools: {},
-  },
+  version: '2.1.0',
+  capabilities: { resources: {}, tools: {} },
 });
+
+const connectionNameSchema = z.string().optional()
+  .describe('Name of the SSH connection (from --ssh config). Optional when only one server is configured.');
 
 server.tool(
   'exec',
-  'Execute a shell command on the remote SSH server and return the output.',
+  'Execute a shell command on a remote SSH server and return the output.',
   {
     command: z.string().describe('Shell command to execute on the remote SSH server'),
     description: z.string().optional().describe('Optional description of what this command will do'),
+    connectionName: connectionNameSchema,
   },
-  async ({ command, description }) => {
+  async ({ command, description, connectionName }) => {
     const sanitizedCommand = sanitizeCommand(command);
     try {
-      const t = await getOrCreateTransport();
+      const t = await registry.get(connectionName);
       const commandWithDescription = description
         ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
         : sanitizedCommand;
@@ -235,25 +301,28 @@ server.tool(
 if (!DISABLE_SUDO) {
   server.tool(
     'sudo-exec',
-    'Execute a shell command on the remote SSH server using sudo. Will use sudo password if provided, otherwise assumes passwordless sudo.',
+    'Execute a shell command on a remote SSH server using sudo. Uses the configured sudoPassword if provided; otherwise assumes passwordless sudo.',
     {
       command: z.string().describe('Shell command to execute with sudo on the remote SSH server'),
       description: z.string().optional().describe('Optional description of what this command will do'),
+      connectionName: connectionNameSchema,
     },
-    async ({ command, description }) => {
+    async ({ command, description, connectionName }) => {
       const sanitizedCommand = sanitizeCommand(command);
       try {
-        const t = await getOrCreateTransport();
+        const t = await registry.get(connectionName);
         const commandWithDescription = description
           ? `${sanitizedCommand} # ${description.replace(/#/g, '\\#')}`
           : sanitizedCommand;
-        const sudoPwd = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined)
+        // Legacy single-host mode may still pass --sudoPassword on CLI; in
+        // multi-host mode each ServerConfig carries its own sudoPassword.
+        const legacySudo = (SUDOPASSWORD !== null && SUDOPASSWORD !== undefined && !isMultiHost)
           ? sanitizePassword(SUDOPASSWORD)
           : undefined;
         const result = await t.execElevated(commandWithDescription, {
           timeoutMs: DEFAULT_TIMEOUT,
           mode: 'sudo',
-          password: sudoPwd,
+          password: legacySudo,
         });
         return resultToMcpContent(result);
       } catch (err: any) {
@@ -264,11 +333,27 @@ if (!DISABLE_SUDO) {
   );
 }
 
-// ===========================================================================
-// Legacy exports: preserved so existing tests (which import SSHConnectionManager,
-// execSshCommandWithConnection, execSshCommand) keep working without modification.
-// These call through to Ssh2Transport-equivalent logic or directly to ssh2.
-// ===========================================================================
+server.tool(
+  'list-servers',
+  'List all configured SSH server connections, their auth mode, and current connection status.',
+  {},
+  async () => {
+    const rows = registry.list();
+    if (rows.length === 0) {
+      return { content: [{ type: 'text', text: 'No SSH servers are configured.' }] };
+    }
+    const text = rows.map(r => {
+      const tag = r.isDefault ? ' (default)' : '';
+      const state = r.connected ? 'connected' : 'not yet connected';
+      return `- ${r.name}${tag}: ${r.username}@${r.host}:${r.port} [transport=${r.transport}, auth=${r.authMode}, ${state}]`;
+    }).join('\n');
+    return { content: [{ type: 'text', text }] };
+  }
+);
+
+// =============================================================================
+// Legacy exports preserved for existing test files.
+// =============================================================================
 
 export async function execSshCommandWithConnection(
   manager: SSHConnectionManager,
@@ -420,45 +505,43 @@ export async function execSshCommand(
   });
 }
 
-// ===========================================================================
+// =============================================================================
 // Server lifecycle
-// ===========================================================================
+// =============================================================================
 
 async function main() {
+  await bootstrapRegistry();
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error('SSH MCP Server running on stdio');
+  const mode = isMultiHost ? `multi-host (${registry.names().length} servers: ${registry.names().join(', ')})` : 'single-host';
+  console.error(`SSH MCP Server running on stdio — ${mode}`);
 
   const cleanup = () => {
     console.error('Shutting down SSH MCP Server...');
-    if (activeTransport) {
-      void activeTransport.close();
-      activeTransport = null;
-    }
+    void registry.closeAll();
     process.exit(0);
   };
 
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
-  process.on('exit', () => {
-    if (activeTransport) {
-      void activeTransport.close();
-    }
-  });
+  process.on('exit', () => { void registry.closeAll(); });
 }
 
 if (isTestMode) {
-  const transport = new StdioServerTransport();
-  server.connect(transport).catch(error => {
-    console.error('Fatal error connecting server:', error);
-    process.exit(1);
-  });
+  (async () => {
+    try {
+      await bootstrapRegistry();
+    } catch { /* tests may not configure hosts */ }
+    const transport = new StdioServerTransport();
+    server.connect(transport).catch(error => {
+      console.error('Fatal error connecting server:', error);
+      process.exit(1);
+    });
+  })();
 } else if (isCliEnabled) {
   main().catch((error) => {
     console.error('Fatal error in main():', error);
-    if (activeTransport) {
-      void activeTransport.close();
-    }
+    void registry.closeAll();
     process.exit(1);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,16 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       break;
     case 'key':
       cfg.transport = resolveJsonTransport(obj);
+      // The legacy single-host CLI used `--key=<path>`; the multi-host JSON
+      // schema uses `keyPath` (openssh -i / ssh2 read from disk) or
+      // `privateKey` (ssh2 inline contents). A legacy-shaped top-level `key`
+      // field is read by neither transport, so a config that supplies only
+      // `key` has NO key material and would silently fall back to ambient
+      // agent/default identities. Reject it with guidance instead of accepting
+      // a credential-less key config (Codex 3541767246).
+      if (obj.key !== undefined) {
+        throw new Error(`--ssh "${obj.name}" auth "key" uses "keyPath" (or "privateKey" for ssh2), not "key"`);
+      }
       // OpenSshTransport.buildArgs only passes cfg.keyPath via `-i`; an inline
       // privateKey would be silently ignored and ssh would fall back to
       // agent/default identities. Reject the combination so the configured
@@ -134,6 +144,17 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       }
       if (obj.keyPath) cfg.keyPath = obj.keyPath;
       if (obj.privateKey) cfg.privateKey = obj.privateKey;
+      // Require actual key material. Without keyPath (openssh -i / ssh2 read)
+      // or an inline privateKey (ssh2), buildArgs() omits `-i` and
+      // `IdentitiesOnly=yes`, and the ssh2 transport has no key, so the
+      // connection silently falls back to whatever default or agent identity is
+      // offered instead of the intended key. Fail at parse time rather than
+      // let a key-auth config connect with an ambient identity (Codex 3541767246).
+      if (!cfg.keyPath && !cfg.privateKey) {
+        throw new Error(
+          `--ssh "${obj.name}" auth "key" requires "keyPath"${cfg.transport === 'ssh2' ? ' or inline "privateKey"' : ''}`,
+        );
+      }
       break;
     case 'password':
       cfg.transport = resolveJsonTransport(obj);
@@ -344,7 +365,22 @@ export interface BuildTransportConfigInputs {
   strictHostKeyChecking?: string | null;
 }
 
-export async function buildTransportConfig(inputs: BuildTransportConfigInputs): Promise<TransportConfig> {
+export interface BuildTransportConfigOptions {
+  /**
+   * When true, an ssh2 key config records `keyPath` but does NOT read the key
+   * file contents into `privateKey`. The read is deferred to the registry's
+   * lazy `prepareKeyContents` hook on the first tool call. Used by the legacy
+   * single-host bootstrap so a key mounted after process launch still works —
+   * matching the pre-registry behavior where the key was only read inside
+   * getOrCreateTransport() on first use, not at startup.
+   */
+  deferKeyRead?: boolean;
+}
+
+export async function buildTransportConfig(
+  inputs: BuildTransportConfigInputs,
+  opts: BuildTransportConfigOptions = {},
+): Promise<TransportConfig> {
   const { host, username } = inputs;
   if (!host || !username) {
     throw new McpError(ErrorCode.InvalidParams, 'Missing required host or username');
@@ -373,7 +409,12 @@ export async function buildTransportConfig(inputs: BuildTransportConfigInputs): 
     // stale/sample --key must NOT read the (possibly nonexistent) key file,
     // which would otherwise throw ENOENT before connecting (regression vs base
     // main, where password took precedence and the key was never read).
-    if (transport === 'ssh2' && authMode === 'key') {
+    //
+    // deferKeyRead skips the eager read entirely so the registry's lazy
+    // prepareKeyContents hook reads it on first tool call instead. The legacy
+    // single-host bootstrap uses this so a key mounted after process launch is
+    // still honored — startup must not read the key file (Codex 3541767256).
+    if (transport === 'ssh2' && authMode === 'key' && !opts.deferKeyRead) {
       const fs = await import('fs/promises');
       cfg.privateKey = await fs.readFile(inputs.key, 'utf8');
     }
@@ -415,10 +456,13 @@ async function bootstrapRegistry(): Promise<void> {
   } else {
     if (!HOST || !USER) return; // Test mode with no CLI — tools will error if called
     // Route the legacy single-host path through buildTransportConfig so it
-    // inherits the kerberos>password>key precedence and the gated key read
-    // (a password config carrying a stale --key must not ENOENT on a missing
-    // key file). buildTransportConfig already loads privateKey when key is the
-    // resolved auth mode, so no separate prepareKeyContents call is needed here.
+    // inherits the kerberos>password>key precedence. Pass deferKeyRead so the
+    // ssh2 key file is NOT read at startup: prepareKeyContents (the registry's
+    // lazy prepareConfig hook) reads it on the first tool call instead, exactly
+    // like the multi-host path. This preserves the pre-registry behavior where
+    // the key was read only inside getOrCreateTransport(), so a key-based
+    // deployment whose secret mount appears after process launch still starts
+    // (Codex 3541767256).
     const tcfg = await buildTransportConfig({
       host: HOST,
       port: PORT,
@@ -432,7 +476,7 @@ async function bootstrapRegistry(): Promise<void> {
       gssapiDelegateCredentials: GSSAPI_DELEGATE,
       knownHostsFile: KNOWN_HOSTS_FILE,
       strictHostKeyChecking: STRICT_HOST_KEY,
-    });
+    }, { deferKeyRead: true });
     registry.register({ ...tcfg, name: 'default' });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,9 +275,26 @@ async function getOrCreateTransport(): Promise<ISshTransport> {
  * StrictHostKeyChecking=accept-new, the first connection to a host prints
  * "Warning: Permanently added '<host>' ... to the list of known hosts." while
  * exiting 0). Throwing on any stderr would turn every first-connect into an
- * error. stderr is only an error indicator when the command actually failed
- * (non-zero exit) and no more specific category applies.
+ * error. On success the benign OpenSSH host-key warning is filtered out, but
+ * any remaining stderr is appended to the text response so callers do not lose
+ * useful command diagnostics/progress from tools (git clone, curl, build
+ * tools) that write to stderr while succeeding.
  */
+/**
+ * Strip the benign OpenSSH first-connect host-key notice from a stderr stream,
+ * leaving genuine command diagnostics intact. With StrictHostKeyChecking=
+ * accept-new the client prints
+ *   "Warning: Permanently added '<host>' (<keytype>) to the list of known hosts."
+ * on the first connection to a host while still exiting 0; that line is noise,
+ * not output the caller asked for.
+ */
+function stripBenignSshWarnings(stderr: string): string {
+  return stderr
+    .split('\n')
+    .filter(line => !/^Warning: Permanently added .*to the list of known hosts\.?\s*$/.test(line))
+    .join('\n')
+    .trim();
+}
 export function resultToMcpContent(result: ExecResult) {
   if (result.category === 'timeout') {
     throw new McpError(ErrorCode.InternalError, result.stderr || `Command execution timed out after ${DEFAULT_TIMEOUT}ms`);
@@ -298,10 +315,14 @@ export function resultToMcpContent(result: ExecResult) {
     const detail = result.stderr || `Command exited with status ${result.exitCode}`;
     throw new McpError(ErrorCode.InternalError, `Error (code ${result.exitCode}):\n${detail}`);
   }
+  const diagnostics = stripBenignSshWarnings(result.stderr);
+  const text = diagnostics
+    ? `${result.stdout}${result.stdout && !result.stdout.endsWith('\n') ? '\n' : ''}${diagnostics}`
+    : result.stdout;
   return {
     content: [{
       type: 'text' as const,
-      text: result.stdout,
+      text,
     }],
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,14 +52,38 @@ function collectSshJsonArgs(): string[] {
     .map(a => a.slice('--ssh='.length));
 }
 
+/**
+ * Resolve and validate the transport for a multi-host --ssh JSON config.
+ * Defaults to 'ssh2'; rejects any value that is not exactly 'ssh2' or 'openssh'
+ * so a typo like "opnssh" fails at parse time instead of silently running the
+ * default ssh2 transport. (createTransport treats any non-'openssh' value as
+ * ssh2, while prepareKeyContents only loads a key when transport === 'ssh2',
+ * so an unchecked typo would connect over ssh2 without the configured key.)
+ * Mirrors the legacy CLI's `Invalid --transport` rejection.
+ */
+function resolveJsonTransport(obj: any): 'ssh2' | 'openssh' {
+  const t = obj.transport ?? 'ssh2';
+  if (t !== 'ssh2' && t !== 'openssh') {
+    throw new Error(`--ssh "${obj.name}" invalid "transport": ${JSON.stringify(obj.transport)} (expected "ssh2" or "openssh")`);
+  }
+  return t;
+}
+
 export function parseServerConfigJson(raw: string): ServerConfig {
   let obj: any;
   try {
     obj = JSON.parse(raw);
   } catch (e: any) {
-    throw new Error(`--ssh JSON parse error: ${e?.message || e}\nRaw: ${raw}`);
+    // Do NOT echo the raw argument: a malformed --ssh config can still carry a
+    // password or private key alongside the syntax error, and main() prints the
+    // thrown error to stderr. Surface only the parser message, never the config.
+    throw new Error(`--ssh JSON parse error: ${e?.message || e}`);
   }
-  if (!obj.name) throw new Error('--ssh JSON missing required "name"');
+  // name must be a non-empty string: a numeric key (e.g. `"name": 1`) registers
+  // under a Map key the MCP tools' string connectionName can never resolve.
+  if (typeof obj.name !== 'string' || obj.name.length === 0) {
+    throw new Error('--ssh JSON requires a non-empty string "name"');
+  }
   if (!obj.host) throw new Error(`--ssh "${obj.name}" missing required "host"`);
   const user = obj.user ?? obj.username;
   if (!user) throw new Error(`--ssh "${obj.name}" missing required "user" (or "username")`);
@@ -68,10 +92,23 @@ export function parseServerConfigJson(raw: string): ServerConfig {
     throw new Error(`--ssh "${obj.name}" requires "auth": "kerberos" | "key" | "password"`);
   }
 
+  // port: mirror the legacy --port numeric validation. An unchecked value fails
+  // only at first use (openssh `ssh -G -p abc` -> "Bad port", exit 255; ssh2
+  // receives a non-numeric port), advertised by list-servers as if healthy.
+  // Reject a non-integer / out-of-range port at parse time.
+  let port = 22;
+  if (obj.port !== undefined) {
+    const p = typeof obj.port === 'number' ? obj.port : Number(obj.port);
+    if (!Number.isInteger(p) || p < 1 || p > 65535) {
+      throw new Error(`--ssh "${obj.name}" invalid "port": ${JSON.stringify(obj.port)} (expected integer 1-65535)`);
+    }
+    port = p;
+  }
+
   const cfg: ServerConfig = {
     name: obj.name,
     host: obj.host,
-    port: obj.port ?? 22,
+    port,
     username: user,
     authMode: auth,
   };
@@ -80,21 +117,56 @@ export function parseServerConfigJson(raw: string): ServerConfig {
     case 'kerberos':
       cfg.kerberos = true;
       cfg.transport = 'openssh';
-      if (obj.gssapiDelegateCredentials) cfg.gssapiDelegateCredentials = obj.gssapiDelegateCredentials;
+      // Kerberos implies openssh; reject an explicit conflicting transport
+      // rather than silently overriding it (mirrors the legacy --kerberos rule).
+      if (obj.transport !== undefined && obj.transport !== 'openssh') {
+        throw new Error(`--ssh "${obj.name}" auth "kerberos" implies transport "openssh" (got ${JSON.stringify(obj.transport)})`);
+      }
       break;
     case 'key':
-      cfg.transport = obj.transport ?? 'ssh2';
+      cfg.transport = resolveJsonTransport(obj);
+      // OpenSshTransport.buildArgs only passes cfg.keyPath via `-i`; an inline
+      // privateKey would be silently ignored and ssh would fall back to
+      // agent/default identities. Reject the combination so the configured
+      // credential is actually used (or the user switches to keyPath).
+      if (cfg.transport === 'openssh' && obj.privateKey) {
+        throw new Error(`--ssh "${obj.name}" inline "privateKey" is not supported for transport "openssh"; use "keyPath"`);
+      }
       if (obj.keyPath) cfg.keyPath = obj.keyPath;
       if (obj.privateKey) cfg.privateKey = obj.privateKey;
       break;
     case 'password':
-      cfg.transport = obj.transport ?? 'ssh2';
+      cfg.transport = resolveJsonTransport(obj);
       if (obj.password) cfg.password = obj.password;
       break;
   }
 
   if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
   if (obj.suPassword) cfg.suPassword = obj.suPassword;
+
+  // gssapiDelegateCredentials: enum-validate and require kerberos auth (the only
+  // path that emits GSSAPIDelegateCredentials). An unchecked typo like "maybe"
+  // registers but fails every command (openssh `ssh -G -o
+  // GSSAPIDelegateCredentials=maybe` -> "unsupported option", exit 255).
+  // Mirrors the legacy rules "must be yes or no" + "requires --kerberos".
+  if (obj.gssapiDelegateCredentials !== undefined) {
+    if (!['yes', 'no'].includes(obj.gssapiDelegateCredentials)) {
+      throw new Error(`--ssh "${obj.name}" gssapiDelegateCredentials must be "yes" or "no" (got ${JSON.stringify(obj.gssapiDelegateCredentials)})`);
+    }
+    if (auth !== 'kerberos') {
+      throw new Error(`--ssh "${obj.name}" gssapiDelegateCredentials requires auth "kerberos"`);
+    }
+    cfg.gssapiDelegateCredentials = obj.gssapiDelegateCredentials;
+  }
+
+  // strictHostKeyChecking: enum-validate. An unchecked value fails every command
+  // (openssh `ssh -G -o StrictHostKeyChecking=maybe` -> "unsupported option",
+  // exit 255). Mirrors the legacy enum check.
+  if (obj.strictHostKeyChecking !== undefined &&
+      !['yes', 'no', 'accept-new'].includes(obj.strictHostKeyChecking)) {
+    throw new Error(`--ssh "${obj.name}" strictHostKeyChecking must be one of: yes, no, accept-new (got ${JSON.stringify(obj.strictHostKeyChecking)})`);
+  }
+
   // knownHostsFile / strictHostKeyChecking are openssh-transport-only. The ssh2
   // transport ignores both, so accepting them on an ssh2 config would silently
   // drop the requested host-key enforcement — a security downgrade. Mirror the
@@ -320,7 +392,7 @@ export async function buildTransportConfig(inputs: BuildTransportConfigInputs): 
 // Transport registry — lazy init, single entry for legacy single-host mode.
 // =============================================================================
 
-const registry = new TransportRegistry();
+const registry = new TransportRegistry(prepareKeyContents);
 
 async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
   // ssh2 transport reads key contents in memory; openssh uses -i path.
@@ -334,7 +406,10 @@ async function bootstrapRegistry(): Promise<void> {
   if (isMultiHost) {
     for (const raw of sshJsonArgs) {
       const cfg = parseServerConfigJson(raw);
-      await prepareKeyContents(cfg);
+      // Do NOT read key files here — prepareKeyContents is deferred to the
+      // registry's lazy get(name) path (passed as the registry's prepareConfig
+      // hook), so one host with a missing/unmounted key path can't break
+      // startup or list-servers for the other, healthy hosts.
       registry.register(cfg);
     }
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,14 @@ function validateConfig(config: Record<string, string | null>) {
 
   const transportExplicit = config.transport;
   const kerberos = config.kerberos !== undefined && config.kerberos !== 'false';
+  // A value-less `--transport` is recorded as `null` by parseArgv; the nullish
+  // fallback below would treat it as absent and silently run the default ssh2
+  // transport, so a mistyped OpenSSH selection would run the wrong transport.
+  // Reject a present-but-value-less --transport like the other value-requiring
+  // flags.
+  if ('transport' in config && transportExplicit == null) {
+    errors.push('--transport requires a value (ssh2 or openssh)');
+  }
   // --kerberos alone implies --transport=openssh
   const transport = transportExplicit ?? (kerberos ? 'openssh' : 'ssh2');
 
@@ -106,6 +114,14 @@ function validateConfig(config: Record<string, string | null>) {
   }
   if ('knownHostsFile' in config && !config.knownHostsFile) {
     errors.push('--knownHostsFile requires a file path');
+  }
+  // GSSAPIDelegateCredentials is only emitted by the OpenSSH transport in the
+  // Kerberos auth branch (see OpenSshTransport.buildArgs). Accepting the flag
+  // without --kerberos would let a user request credential delegation while the
+  // server silently omits it, breaking second-hop SSO with no error. Require
+  // Kerberos auth so the requested delegation is actually honored.
+  if ('gssapiDelegateCredentials' in config && !kerberos) {
+    errors.push('--gssapiDelegateCredentials requires --kerberos');
   }
 
   if (errors.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { SSHConnectionManager, SSHConfig } from './transports/ssh2.js';
 import { createTransport } from './transports/factory.js';
 import { TransportRegistry } from './transports/registry.js';
 import { resolveConfig } from './config/resolver.js';
+import { expandHome } from './config/toml-loader.js';
 import type { ResolvedConfig } from './config/types.js';
 import {
   sanitizeCommand as sanitizeCommandImpl,
@@ -421,7 +422,7 @@ export function resolveCliConfigPath(
   if (value === '') {
     throw new Error('Configuration error:\n--config requires a value (--config=<path>)');
   }
-  return value;
+  return expandHome(value);
 }
 
 const resolvedConfig: ResolvedConfig = (isCliEnabled || isTestMode)

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,8 +183,12 @@ export function parseServerConfigJson(raw: string): ServerConfig {
       break;
   }
 
-  if (obj.sudoPassword) cfg.sudoPassword = obj.sudoPassword;
-  if (obj.suPassword) cfg.suPassword = obj.suPassword;
+  for (const field of ['sudoPassword', 'suPassword'] as const) {
+    if (obj[field] !== undefined && typeof obj[field] !== 'string') {
+      throw new Error(`--ssh "${obj.name}" "${field}" must be a string`);
+    }
+    if (obj[field]) cfg[field] = obj[field];
+  }
 
   // gssapiDelegateCredentials: enum-validate and require kerberos auth (the only
   // path that emits GSSAPIDelegateCredentials). An unchecked typo like "maybe"
@@ -214,7 +218,11 @@ export function parseServerConfigJson(raw: string): ServerConfig {
   // drop the requested host-key enforcement — a security downgrade. Mirror the
   // legacy single-host rule ("--knownHostsFile and --strictHostKeyChecking
   // require --transport=openssh") and reject the combination here.
-  if ((obj.knownHostsFile || obj.strictHostKeyChecking) && cfg.transport !== 'openssh') {
+  if (obj.knownHostsFile !== undefined &&
+      (typeof obj.knownHostsFile !== 'string' || obj.knownHostsFile.length === 0)) {
+    throw new Error(`--ssh "${obj.name}" "knownHostsFile" must be a non-empty string`);
+  }
+  if ((obj.knownHostsFile !== undefined || obj.strictHostKeyChecking !== undefined) && cfg.transport !== 'openssh') {
     throw new Error(
       `--ssh "${obj.name}" knownHostsFile/strictHostKeyChecking require "transport": "openssh" (got ${cfg.transport})`
     );
@@ -454,6 +462,7 @@ export async function buildTransportConfig(
 // Transport registry — lazy init, single entry for legacy single-host mode.
 // =============================================================================
 
+const fileLoadedKeyConfigs = new WeakSet<ServerConfig>();
 const registry = new TransportRegistry(prepareKeyContents);
 
 export async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
@@ -464,14 +473,20 @@ export async function prepareKeyContents(cfg: ServerConfig): Promise<void> {
   // nonexistent) key file here — otherwise the first tool call fails with
   // ENOENT instead of using the password (Codex 3549295046). Mirrors the eager
   // read's `authMode === 'key'` guard in buildTransportConfig().
+  //
+  // Once this hook loads a keyPath, re-read it on every later init attempt. The
+  // registry retries rejected initialization with the same config object; the
+  // WeakSet distinguishes file-loaded contents from an explicit inline key so a
+  // key rotation can recover without a process restart.
   if (
     cfg.authMode === 'key' &&
     cfg.transport === 'ssh2' &&
     cfg.keyPath &&
-    !cfg.privateKey
+    (!cfg.privateKey || fileLoadedKeyConfigs.has(cfg))
   ) {
     const fs = await import('fs/promises');
     cfg.privateKey = await fs.readFile(cfg.keyPath, 'utf8');
+    fileLoadedKeyConfigs.add(cfg);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,6 +345,18 @@ function validateConfig(config: Record<string, string | null>, multiHost = false
 const isMultiHost = sshJsonArgs.length > 0;
 const hasLegacyCli = hasLegacyCliFlags(argvConfig);
 
+// Validate CLI-mode errors before TOML discovery/loading. Otherwise an
+// incomplete legacy invocation such as `--host=h` can auto-discover an unrelated
+// TOML file and report that TOML's parse/env error before the real missing
+// `--user` legacy CLI error.
+if (isCliEnabled || isTestMode) {
+  if (isMultiHost) {
+    validateConfig(argvConfig, true);
+  } else if (hasLegacyCli) {
+    validateConfig(argvConfig, false);
+  }
+}
+
 function buildLegacyServerConfig(): ServerConfig | undefined {
   if (!HOST || !USER) return undefined;
 
@@ -433,11 +445,7 @@ const resolvedConfig: ResolvedConfig = (isCliEnabled || isTestMode)
   : { sources: [], perSourceApproval: {}, defaultExplicit: false };
 
 if (isCliEnabled) {
-  if (isMultiHost) {
-    validateConfig(argvConfig, true);
-  } else if (hasLegacyCli) {
-    validateConfig(argvConfig, false);
-  } else if (resolvedConfig.sources.length === 0) {
+  if (!isMultiHost && !hasLegacyCli && resolvedConfig.sources.length === 0) {
     throw new Error(
       'Configuration error:\nMissing required --host (or use --ssh=<JSON>, --config=<path>, SSH_MCP_CONFIG, or a default ssh-mcp config.toml)',
     );

--- a/src/transports/__tests__/registry.test.ts
+++ b/src/transports/__tests__/registry.test.ts
@@ -1,0 +1,140 @@
+/**
+ * TransportRegistry.profile() — per-source approval/description read path.
+ *
+ * The WIP (wip/per-source-approval) shipped the data path but lacked a test
+ * proving that a per-source `description` + `approval` override actually
+ * propagate the full distance: TOML loader -> ServerConfig -> registry.profile()
+ * -> ApprovalEngine resolution. This suite closes that gap.
+ *
+ * No transport is ever created here (register() only records config; profile()
+ * reads the config map), so no sandbox sshd is required.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { TransportRegistry } from '../registry.js';
+import { parseTomlConfig } from '../../config/toml-loader.js';
+import { buildApprovalEngineFromConfig } from '../../approval/engine.js';
+import type { ApprovalContext } from '../../approval/types.js';
+
+/**
+ * Two sources: a plain default (`lab`, no override -> global yolo) and a
+ * locked-down DC (`dc03`) carrying a policy description + a smart override.
+ * `lab` is listed first so it becomes the registry default.
+ */
+const TWO_SOURCE_TOML = `
+[[sources]]
+id = "lab"
+host = "lab.example"
+user = "root"
+auth = "kerberos"
+
+[[sources]]
+id = "dc03"
+host = "dc03.css.com.tw"
+user = "css\\\\c19087"
+auth = "kerberos"
+description = '''allow only NTDS\\My thumbprint 8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE certificate-object writes; deny PFX, private key reads, restart, reboot'''
+approval = { mode = "smart" }
+`;
+
+function registryFrom(toml: string): { registry: TransportRegistry; cfg: ReturnType<typeof parseTomlConfig> } {
+  const cfg = parseTomlConfig(toml);
+  const registry = new TransportRegistry();
+  // Mirror src/index.ts bootstrapRegistry(): register in source order.
+  for (const src of cfg.sources) registry.register(src);
+  if (cfg.defaultName) registry.setDefault(cfg.defaultName);
+  return { registry, cfg };
+}
+
+describe('TransportRegistry.profile() — read path', () => {
+  it('surfaces per-source description + approval override from the loaded config', () => {
+    const { registry } = registryFrom(TWO_SOURCE_TOML);
+
+    const dc03 = registry.profile('dc03');
+    expect(dc03.id).toBe('dc03');
+    expect(dc03.description).toContain('NTDS\\My');
+    expect(dc03.description).toContain('8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE');
+    expect(dc03.approval?.mode).toBe('smart');
+  });
+
+  it('returns an override-free profile for sources without description/approval', () => {
+    const { registry } = registryFrom(TWO_SOURCE_TOML);
+
+    const lab = registry.profile('lab');
+    expect(lab.id).toBe('lab');
+    expect(lab.description).toBeUndefined();
+    expect(lab.approval).toBeUndefined();
+  });
+
+  it('falls back to the registry default when no name is given', () => {
+    const { registry } = registryFrom(TWO_SOURCE_TOML);
+
+    // `lab` is the first registered source -> the default.
+    const def = registry.profile();
+    expect(def.id).toBe('lab');
+    expect(def.approval).toBeUndefined();
+  });
+
+  it('throws on an unknown connection name (same contract as get())', () => {
+    const { registry } = registryFrom(TWO_SOURCE_TOML);
+    expect(() => registry.profile('does-not-exist')).toThrow(/Unknown connection name/);
+  });
+});
+
+describe('per-source approval propagates loader -> registry -> engine', () => {
+  it('drives engine resolution by source: dc03 -> smart (sees description), lab -> default yolo', async () => {
+    const { registry, cfg } = registryFrom(TWO_SOURCE_TOML);
+
+    // Loader extracted the per-source override into perSourceApproval.
+    expect(cfg.perSourceApproval).toEqual({ dc03: 'smart' });
+
+    // Capture the smart LLM request body so we can assert the per-source
+    // description rode all the way into the prompt.
+    const bodies: string[] = [];
+    const fetchStub = vi.fn(async (_url: string, init: { body: string }) => {
+      bodies.push(init.body);
+      return {
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            choices: [{ message: { content: '{"allow": true, "reason": "policy permits certutil"}' } }],
+          }),
+      };
+    });
+
+    const dispatcher = buildApprovalEngineFromConfig(
+      {
+        defaultMode: 'yolo',
+        llm: { endpoint: 'http://stub/llm', model: 'stub-model', api_key: 'fake' },
+        perSourceModes: Object.values(cfg.perSourceApproval),
+      },
+      { manualOpts: { webuiEnabled: false }, smartFetchImpl: fetchStub as any },
+    );
+
+    // dc03 profile -> smart sub-engine (override beats global yolo default).
+    const dc03Ctx: ApprovalContext = {
+      profile: registry.profile('dc03'),
+      tool: 'exec',
+      command: 'certutil -addstore My cert.cer',
+    };
+    const dc03Decision = await dispatcher.decide(dc03Ctx);
+    expect(dc03Decision.mode).toBe('smart');
+    expect(dc03Decision.decided_by).toBe('smart-llm');
+    expect(dc03Decision.decision).toBe('allow');
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    // The per-source description reached the LLM prompt body.
+    expect(bodies[0]).toContain('8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE');
+
+    // lab profile (no override) -> global yolo default; no LLM call.
+    const labCtx: ApprovalContext = {
+      profile: registry.profile('lab'),
+      tool: 'exec',
+      command: 'uptime',
+    };
+    const labDecision = await dispatcher.decide(labCtx);
+    expect(labDecision.mode).toBe('yolo');
+    expect(labDecision.decided_by).toBe('yolo');
+    expect(fetchStub).toHaveBeenCalledTimes(1); // unchanged — yolo never calls the LLM
+  });
+});

--- a/src/transports/__tests__/registry.test.ts
+++ b/src/transports/__tests__/registry.test.ts
@@ -30,8 +30,8 @@ auth = "kerberos"
 
 [[sources]]
 id = "dc03"
-host = "dc03.css.com.tw"
-user = "css\\\\c19087"
+host = "dc03.example.com"
+user = "corp\\\\svcuser"
 auth = "kerberos"
 description = '''allow only NTDS\\My thumbprint 8A00772D4491E2E71218405BDDE5A5FE3E9C7DBE certificate-object writes; deny PFX, private key reads, restart, reboot'''
 approval = { mode = "smart" }

--- a/src/transports/factory.ts
+++ b/src/transports/factory.ts
@@ -1,0 +1,13 @@
+import { ISshTransport, TransportConfig } from './types.js';
+import { Ssh2Transport } from './ssh2.js';
+import { OpenSshTransport } from './openssh.js';
+
+/**
+ * Choose and construct a transport based on cfg.transport. Default is 'ssh2'
+ * to preserve upstream behaviour for users who don't opt in to OpenSSH.
+ */
+export function createTransport(cfg: TransportConfig): ISshTransport {
+  const choice = cfg.transport ?? 'ssh2';
+  if (choice === 'openssh') return new OpenSshTransport(cfg);
+  return new Ssh2Transport(cfg);
+}

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -316,6 +316,10 @@ export class OpenSshTransport implements ISshTransport {
       // command emitting more than ~8KB (inconsistent with runSsh, which
       // returns the full stream). Keep the full EXEC output here.
       let execCapture = '';
+      // The exact input line written to the root shell in the EXEC state. With
+      // `ssh -tt` the remote PTY echoes it back onto stdout, so it is stored
+      // here to strip that single echoed line from the captured output.
+      let execInput = '';
       let capturedStderr = '';
       let exitCode: number | null = null;
       let timedOut = false;
@@ -401,7 +405,11 @@ export class OpenSshTransport implements ISshTransport {
           // Send sentinel PS1 once we see a non-prompt line (typical: post-auth motd)
           // Trigger: any newline after password sent.
           if (/\r?\n/.test(text)) {
-            writeLine(`export PS1='${readyMark}$ '`);
+            // Set a sentinel PS1 so the root-shell prompt is machine-detectable,
+            // and clear PS2 to '' so the multiline subshell wrapper written in
+            // the EXEC state (see below) does not emit `> ` continuation prompts
+            // into the captured PTY stream.
+            writeLine(`export PS1='${readyMark}$ '; export PS2=''`);
             state = 'ROOT_SHELL';
             setStateTimer(5000, 'awaiting sentinel prompt');
             buffer = '';
@@ -415,9 +423,20 @@ export class OpenSshTransport implements ISshTransport {
           state = 'EXEC';
           buffer = '';
           stdoutTail = '';
-          // Execute user command, then echo sentinel+exitcode
-          writeLine(`${command}`);
-          writeLine(`echo ${endMark}$?`);
+          // Run the user command inside a subshell, then echo the sentinel and
+          // its exit status on the SAME input line.
+          //
+          //  - Subshell isolation: a command that exits or exec-replaces its
+          //    shell (e.g. `echo ok; exit 0`, `exec true`) only terminates the
+          //    subshell. The root control shell survives to run the sentinel, so
+          //    the real exit status is reported instead of the close path
+          //    mistaking a clean exit for a transport failure and dropping the
+          //    output. `$?` after `( ... )` is the subshell's exit status.
+          //  - Same-line sentinel: with `ssh -tt` the sentinel-emit is echoed as
+          //    part of this one input line, so it can never glue onto command
+          //    output that lacks a trailing newline (e.g. `printf foo`).
+          execInput = `( ${command} ); echo ${endMark}$?`;
+          writeLine(execInput);
           return;
         }
 
@@ -428,31 +447,24 @@ export class OpenSshTransport implements ISshTransport {
             // Derive output from the unbounded EXEC capture (not the truncated
             // scan buffer) so large command output is preserved in full. Locate
             // the end-marker within the full capture for the slice boundary.
+            // endRe requires a digit after the marker, so the echoed
+            // `echo <endMark>$?` (literal `$?`) never matches — only the real
+            // sentinel output does.
             const em = execCapture.match(endRe);
             const endIdx = em ? em.index! : execCapture.length;
             capturedStdout = execCapture.slice(0, endIdx).replace(/\r\n/g, '\n');
             // Strip the echoed PS1-sentinel leftovers if any
             capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
-            // Strip the echoed command lines (best effort). With `ssh -tt` the
-            // remote PTY's line discipline echoes every line written to stdin
-            // back onto stdout, so the EXEC capture is polluted by the echoed
-            // user command and the echoed `echo <endMark>$?` sentinel-emit
-            // command. Remove both so the caller sees only the command's real
-            // stdout instead of its own input replayed back.
+            // Strip the single echoed input line the remote PTY replayed at the
+            // head of the capture (present with `ssh -tt`). Because the command
+            // and sentinel-emit are combined into one known `execInput` line,
+            // removing exactly that line (and its trailing newline) yields the
+            // command's real stdout — even when the output is unterminated.
             const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            // 1. Drop the echoed sentinel-emit command line wherever it appears.
             capturedStdout = capturedStdout.replace(
-              new RegExp(`^echo ${escapeRe(endMark)}\\$\\?[ \\t]*\\n?`, 'm'),
+              new RegExp(`^${escapeRe(execInput)}\\r?\\n?`),
               '',
             );
-            // 2. Drop the echoed user command line(s) at the head of the capture.
-            const cmdLines = command.split('\n');
-            const outLines = capturedStdout.split('\n');
-            while (cmdLines.length && outLines.length && outLines[0] === cmdLines[0]) {
-              outLines.shift();
-              cmdLines.shift();
-            }
-            capturedStdout = outLines.join('\n');
             state = 'DONE';
             writeLine('exit');
             writeLine('exit');

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -169,7 +169,15 @@ export class OpenSshTransport implements ISshTransport {
         );
         break;
       case 'key':
-        if (cfg.keyPath) a.push('-i', cfg.keyPath);
+        if (cfg.keyPath) {
+          a.push('-i', cfg.keyPath);
+          // Force OpenSSH to use ONLY the supplied key. Without
+          // IdentitiesOnly=yes, ssh still offers every ssh-agent identity
+          // first, which can exhaust the server's MaxAuthTries before the
+          // chosen `-i` key is ever tried. This matches the ssh2 path, which
+          // authenticates with exactly the configured key.
+          a.push('-o', 'IdentitiesOnly=yes');
+        }
         a.push(
           '-o', 'PreferredAuthentications=publickey',
           '-o', 'PasswordAuthentication=no',
@@ -209,6 +217,7 @@ export class OpenSshTransport implements ISshTransport {
     return new Promise((resolve) => {
       const args = [...this.buildArgs(opts), command];
       let timedOut = false;
+      let exited = false;
       let stdout = '';
       let stderr = '';
 
@@ -230,11 +239,16 @@ export class OpenSshTransport implements ISshTransport {
         timedOut = true;
         child.kill('SIGTERM');
         setTimeout(() => {
-          if (!child.killed) child.kill('SIGKILL');
+          // `child.killed` only reflects that a signal was *sent*, not that the
+          // process actually exited. Gate the SIGKILL fallback on the real
+          // `exited` flag (set from the close event) so a process ignoring
+          // SIGTERM is still force-killed instead of being left to hang.
+          if (!exited) child.kill('SIGKILL');
         }, 2000);
       }, opts.timeoutMs);
 
       child.on('error', (err: Error) => {
+        exited = true;
         clearTimeout(timer);
         resolve({
           stdout,
@@ -245,6 +259,7 @@ export class OpenSshTransport implements ISshTransport {
       });
 
       child.on('close', (code, signal) => {
+        exited = true;
         clearTimeout(timer);
         const category = timedOut ? 'timeout' : classifyError(code, stderr);
         resolve({
@@ -289,6 +304,7 @@ export class OpenSshTransport implements ISshTransport {
       let capturedStderr = '';
       let exitCode: number | null = null;
       let timedOut = false;
+      let exited = false;
       let stateTimer: NodeJS.Timeout | null = null;
 
       const child: ChildProcess = spawn('ssh', args, {
@@ -325,7 +341,11 @@ export class OpenSshTransport implements ISshTransport {
         timedOut = true;
         clearStateTimer();
         child.kill('SIGTERM');
-        setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
+        // Gate the SIGKILL fallback on the real `exited` flag, not
+        // `child.killed` (which is set the instant SIGTERM is *sent*, so the
+        // fallback would always be skipped and a process ignoring SIGTERM
+        // could hang past the deadline).
+        setTimeout(() => { if (!exited) child.kill('SIGKILL'); }, 2000);
       }, opts.timeoutMs);
 
       child.stdout?.on('data', (chunk: Buffer) => {
@@ -338,7 +358,16 @@ export class OpenSshTransport implements ISshTransport {
         // scan buffer so large command output is not lost (see execCapture decl).
         if (state === 'EXEC') execCapture += text;
 
-        if (failRe.test(stdoutTail)) {
+        // Auth-failure detection must run ONLY during the su/login phases.
+        // Once the state machine reaches EXEC, the stream carries the user
+        // command's own stdout, which may legitimately contain phrases like
+        // "incorrect password" or "authentication failure" (e.g. grepping auth
+        // logs). Matching there would kill the session and mis-report the
+        // command's output as an auth error, so gate the check on the pre-EXEC
+        // login states.
+        const inLoginPhase =
+          state === 'SU_PROMPT' || state === 'PASSWORD_SENT' || state === 'ROOT_SHELL';
+        if (inLoginPhase && failRe.test(stdoutTail)) {
           clearStateTimer();
           capturedStderr += stdoutTail;
           child.kill('SIGTERM');
@@ -389,7 +418,26 @@ export class OpenSshTransport implements ISshTransport {
             capturedStdout = execCapture.slice(0, endIdx).replace(/\r\n/g, '\n');
             // Strip the echoed PS1-sentinel leftovers if any
             capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
-            // Strip the echoed command lines (best effort)
+            // Strip the echoed command lines (best effort). With `ssh -tt` the
+            // remote PTY's line discipline echoes every line written to stdin
+            // back onto stdout, so the EXEC capture is polluted by the echoed
+            // user command and the echoed `echo <endMark>$?` sentinel-emit
+            // command. Remove both so the caller sees only the command's real
+            // stdout instead of its own input replayed back.
+            const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            // 1. Drop the echoed sentinel-emit command line wherever it appears.
+            capturedStdout = capturedStdout.replace(
+              new RegExp(`^echo ${escapeRe(endMark)}\\$\\?[ \\t]*\\n?`, 'm'),
+              '',
+            );
+            // 2. Drop the echoed user command line(s) at the head of the capture.
+            const cmdLines = command.split('\n');
+            const outLines = capturedStdout.split('\n');
+            while (cmdLines.length && outLines.length && outLines[0] === cmdLines[0]) {
+              outLines.shift();
+              cmdLines.shift();
+            }
+            capturedStdout = outLines.join('\n');
             state = 'DONE';
             writeLine('exit');
             writeLine('exit');
@@ -402,6 +450,7 @@ export class OpenSshTransport implements ISshTransport {
       });
 
       child.on('error', (err: Error) => {
+        exited = true;
         clearStateTimer();
         clearTimeout(overallTimer);
         resolve({
@@ -413,6 +462,7 @@ export class OpenSshTransport implements ISshTransport {
       });
 
       child.on('close', (code, signal) => {
+        exited = true;
         clearStateTimer();
         clearTimeout(overallTimer);
 

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -11,7 +11,6 @@ import {
   ErrorCategory,
   TransportConfig,
 } from './types.js';
-import { buildSudoWrapper } from './ssh2.js';
 
 /**
  * OpenSshTransport — spawns the system `ssh` binary per command.
@@ -77,7 +76,18 @@ export class OpenSshTransport implements ISshTransport {
       if (pwd === undefined && this.cfg.suPassword) {
         return this.runSuViaPty(command, this.cfg.suPassword, opts);
       }
-      const wrapped = buildSudoWrapper(command, pwd);
+      if (pwd !== undefined) {
+        // OpenSSH receives the remote command as a local ssh argv element.
+        // Embedding the sudo password in that command (the ssh2 wrapper style)
+        // exposes it to local process inspection. Keep argv password-free and
+        // feed sudo -S via stdin instead.
+        const wrapped = buildOpenSshSudoWrapper(command, true);
+        return this.runSsh(wrapped, {
+          ...opts,
+          stdin: `${pwd}\n${opts.stdin ?? ''}`,
+        });
+      }
+      const wrapped = buildOpenSshSudoWrapper(command, false);
       return this.runSsh(wrapped, opts);
     }
     const suPwd = opts.password ?? this.cfg.suPassword;
@@ -480,7 +490,11 @@ export class OpenSshTransport implements ISshTransport {
         if (state === 'DONE' && exitCode !== null) {
           resolve({
             stdout: capturedStdout,
-            stderr: '',
+            // A PTY merges remote stdout and stderr into the captured stdout
+            // stream. Preserve that merged diagnostic text as stderr for
+            // non-zero exits so resultToMcpContent can surface `ls: cannot
+            // access ...` instead of only a generic exit status.
+            stderr: exitCode === 0 ? '' : capturedStdout,
             exitCode,
             category: exitCode === 0 ? undefined : 'remote_exit',
           });
@@ -501,6 +515,22 @@ export class OpenSshTransport implements ISshTransport {
       });
     });
   }
+}
+
+/**
+ * Build a sudo wrapper for the OpenSSH subprocess transport.
+ *
+ * Unlike the ssh2 wrapper, this must never embed the sudo password in the
+ * command string: OpenSSH receives the remote command as a local `ssh` argv
+ * element. When a password is needed, the caller supplies it through stdin for
+ * `sudo -S` instead.
+ */
+export function buildOpenSshSudoWrapper(command: string, expectsPassword: boolean): string {
+  const escaped = command.replace(/'/g, "'\\''");
+  if (expectsPassword) {
+    return `sudo -p "" -S sh -c '${escaped}'`;
+  }
+  return `sudo -n sh -c '${escaped}'`;
 }
 
 /**

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -73,15 +73,20 @@ export class OpenSshTransport implements ISshTransport {
   }
 
   /**
-   * Update everConnected from a completed exec result. A command that reached
-   * the remote host — success, a non-zero remote exit, or an auth/host-key
-   * rejection (all of which require a completed TCP+SSH handshake) — proves the
-   * host is live. Only connect/transport-layer failures (TCP refused, DNS
-   * failure, ssh spawn error) and a bare timeout leave the flag unchanged,
-   * since they do not prove the host ever answered.
+   * Update everConnected from a completed exec result. Only a usable remote
+   * session — success or a remote command's own non-zero exit — proves this
+   * OpenSSH transport can run commands. Authentication and host-key rejections
+   * may reach the server, but they do not establish a usable session and should
+   * not make list-servers report the server as connected.
    */
   private recordLiveness(result: ExecResult): void {
-    if (result.category === 'connect' || result.category === 'transport' || result.category === 'timeout') {
+    if (
+      result.category === 'auth' ||
+      result.category === 'host_key' ||
+      result.category === 'connect' ||
+      result.category === 'transport' ||
+      result.category === 'timeout'
+    ) {
       return;
     }
     this.everConnected = true;

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -32,14 +32,13 @@ export class OpenSshTransport implements ISshTransport {
   private askpassEnvName?: string;
   private cleanupRegistered = false;
   /**
-   * True once at least one command has completed a live SSH session (an exec
-   * whose failure, if any, was not a connect/transport-layer failure). OpenSSH
-   * has no persistent connection — init() only verifies the local ssh binary —
-   * so this is the only proof the configured host is actually reachable.
-   * list-servers reads it via isConnected() so it does not report a merely
-   * initialized transport as "connected" when the host has never answered.
+   * True when the most recent command completed a usable live SSH session (an
+   * exec whose failure, if any, was the remote command's own non-zero exit).
+   * OpenSSH has no persistent connection — init() only verifies the local ssh
+   * binary — so list-servers must reflect the latest session attempt rather
+   * than retain historical success after a later auth/transport failure.
    */
-  private everConnected = false;
+  private lastSessionUsable = false;
 
   constructor(private cfg: TransportConfig) {}
 
@@ -73,7 +72,7 @@ export class OpenSshTransport implements ISshTransport {
   }
 
   /**
-   * Update everConnected from a completed exec result. Only a usable remote
+   * Update lastSessionUsable from a completed exec result. Only a usable remote
    * session — success or a remote command's own non-zero exit — proves this
    * OpenSSH transport can run commands. Authentication and host-key rejections
    * may reach the server, but they do not establish a usable session and should
@@ -87,19 +86,20 @@ export class OpenSshTransport implements ISshTransport {
       result.category === 'transport' ||
       result.category === 'timeout'
     ) {
+      this.lastSessionUsable = false;
       return;
     }
-    this.everConnected = true;
+    this.lastSessionUsable = true;
   }
 
   /**
-   * OpenSSH has no persistent connection; report a live connection only after a
-   * command has actually completed a session (see everConnected). This keeps
-   * list-servers from advertising a merely-initialized transport as connected
-   * when the host has never answered (Codex 3541767250).
+   * OpenSSH has no persistent connection; report a live connection only when the
+   * most recent command completed a usable session (see lastSessionUsable). This
+   * keeps list-servers from advertising a merely-initialized transport as
+   * connected or retaining stale success after a later connection failure.
    */
   isConnected(): boolean {
-    return this.everConnected;
+    return this.lastSessionUsable;
   }
 
   async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -31,6 +31,15 @@ export class OpenSshTransport implements ISshTransport {
   private askpassDir?: string;
   private askpassEnvName?: string;
   private cleanupRegistered = false;
+  /**
+   * True once at least one command has completed a live SSH session (an exec
+   * whose failure, if any, was not a connect/transport-layer failure). OpenSSH
+   * has no persistent connection — init() only verifies the local ssh binary —
+   * so this is the only proof the configured host is actually reachable.
+   * list-servers reads it via isConnected() so it does not report a merely
+   * initialized transport as "connected" when the host has never answered.
+   */
+  private everConnected = false;
 
   constructor(private cfg: TransportConfig) {}
 
@@ -56,10 +65,36 @@ export class OpenSshTransport implements ISshTransport {
   async exec(command: string, opts: ExecOptions): Promise<ExecResult> {
     // If suPassword is configured, route through PTY-su state machine to
     // preserve the implicit-su behaviour that ssh2 transport has.
-    if (this.cfg.suPassword) {
-      return this.runSuViaPty(command, this.cfg.suPassword, opts);
+    const result = this.cfg.suPassword
+      ? await this.runSuViaPty(command, this.cfg.suPassword, opts)
+      : await this.runSsh(command, opts);
+    this.recordLiveness(result);
+    return result;
+  }
+
+  /**
+   * Update everConnected from a completed exec result. A command that reached
+   * the remote host — success, a non-zero remote exit, or an auth/host-key
+   * rejection (all of which require a completed TCP+SSH handshake) — proves the
+   * host is live. Only connect/transport-layer failures (TCP refused, DNS
+   * failure, ssh spawn error) and a bare timeout leave the flag unchanged,
+   * since they do not prove the host ever answered.
+   */
+  private recordLiveness(result: ExecResult): void {
+    if (result.category === 'connect' || result.category === 'transport' || result.category === 'timeout') {
+      return;
     }
-    return this.runSsh(command, opts);
+    this.everConnected = true;
+  }
+
+  /**
+   * OpenSSH has no persistent connection; report a live connection only after a
+   * command has actually completed a session (see everConnected). This keeps
+   * list-servers from advertising a merely-initialized transport as connected
+   * when the host has never answered (Codex 3541767250).
+   */
+  isConnected(): boolean {
+    return this.everConnected;
   }
 
   async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
@@ -74,7 +109,9 @@ export class OpenSshTransport implements ISshTransport {
       // no sudo password is available but a su password is, run the command as
       // root via su to preserve equivalent behaviour.
       if (pwd === undefined && this.cfg.suPassword) {
-        return this.runSuViaPty(command, this.cfg.suPassword, opts);
+        const r = await this.runSuViaPty(command, this.cfg.suPassword, opts);
+        this.recordLiveness(r);
+        return r;
       }
       if (pwd !== undefined) {
         // OpenSSH receives the remote command as a local ssh argv element.
@@ -82,16 +119,21 @@ export class OpenSshTransport implements ISshTransport {
         // exposes it to local process inspection. Keep argv password-free and
         // feed sudo -S via stdin instead.
         const wrapped = buildOpenSshSudoWrapper(command, true);
-        return this.runSsh(wrapped, {
+        const r = await this.runSsh(wrapped, {
           ...opts,
           stdin: `${pwd}\n${opts.stdin ?? ''}`,
         });
+        this.recordLiveness(r);
+        return r;
       }
       const wrapped = buildOpenSshSudoWrapper(command, false);
-      return this.runSsh(wrapped, opts);
+      const r = await this.runSsh(wrapped, opts);
+      this.recordLiveness(r);
+      return r;
     }
     const suPwd = opts.password ?? this.cfg.suPassword;
     if (!suPwd) {
+      // Config error — no command runs, so this does not prove host liveness.
       return {
         stdout: '',
         stderr: 'su elevation requires --suPassword',
@@ -99,7 +141,9 @@ export class OpenSshTransport implements ISshTransport {
         category: 'auth',
       };
     }
-    return this.runSuViaPty(command, suPwd, opts);
+    const r = await this.runSuViaPty(command, suPwd, opts);
+    this.recordLiveness(r);
+    return r;
   }
 
   async close(): Promise<void> {

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -66,6 +66,17 @@ export class OpenSshTransport implements ISshTransport {
   async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
     if (opts.mode === 'sudo') {
       const pwd = opts.password ?? this.cfg.sudoPassword;
+      // Match ssh2 persistent-root semantics: the ssh2 transport establishes a
+      // root `su` shell at connect time when --suPassword is set, so its
+      // sudo-exec re-enters that already-root shell and `sudo -n` trivially
+      // succeeds. The OpenSSH transport spawns a fresh process per command, so a
+      // plain `sudo -n` would run as the unprivileged user and fail for users
+      // who followed the documented persistent-root `--suPassword` setup. When
+      // no sudo password is available but a su password is, run the command as
+      // root via su to preserve equivalent behaviour.
+      if (pwd === undefined && this.cfg.suPassword) {
+        return this.runSuViaPty(command, this.cfg.suPassword, opts);
+      }
       const wrapped = buildSudoWrapper(command, pwd);
       return this.runSsh(wrapped, opts);
     }
@@ -111,7 +122,7 @@ export class OpenSshTransport implements ISshTransport {
   }
 
   /**
-   * Write a `.cmd` askpass helper to a temp dir and remember its path.
+   * Write a `.cmd`/`.sh` askpass helper to a temp dir and remember its path.
    * Password lives in an env var passed only to spawned ssh children —
    * never written to disk, never placed in argv.
    */
@@ -121,9 +132,7 @@ export class OpenSshTransport implements ISshTransport {
     const isWindows = process.platform === 'win32';
     const helperName = isWindows ? 'askpass.cmd' : 'askpass.sh';
     const helperPath = path.join(dir, helperName);
-    const content = isWindows
-      ? `@echo off\r\necho %${envName}%\r\n`
-      : `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
+    const content = renderAskpassHelper(envName, isWindows);
     await fs.writeFile(helperPath, content, { encoding: 'utf8' });
     if (!isWindows) {
       await fs.chmod(helperPath, 0o700);
@@ -271,6 +280,12 @@ export class OpenSshTransport implements ISshTransport {
       let buffer = '';
       let stdoutTail = '';
       let capturedStdout = '';
+      // Unbounded capture of all stdout received while in the EXEC state. The
+      // scanning `buffer` below is truncated to ~4KB to bound regex cost, but
+      // truncating the captured output would silently drop the head of any
+      // command emitting more than ~8KB (inconsistent with runSsh, which
+      // returns the full stream). Keep the full EXEC output here.
+      let execCapture = '';
       let capturedStderr = '';
       let exitCode: number | null = null;
       let timedOut = false;
@@ -301,12 +316,17 @@ export class OpenSshTransport implements ISshTransport {
       // Initial state: wait up to 10s for `su` password prompt
       setStateTimer(10000, 'awaiting su password prompt');
 
+      // Overall hard deadline. types.ts ExecOptions.timeoutMs is documented as a
+      // hard ceiling every transport must enforce; runSsh applies it to the
+      // whole spawn, so the su path must too. The handshake phases (su prompt,
+      // password, root-shell sentinel) are bounded by their own per-state timers
+      // above; they do not get an extra budget on top of the contract deadline.
       const overallTimer = setTimeout(() => {
         timedOut = true;
         clearStateTimer();
         child.kill('SIGTERM');
         setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
-      }, opts.timeoutMs + 30000);
+      }, opts.timeoutMs);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const text = chunk.toString('utf8');
@@ -314,6 +334,9 @@ export class OpenSshTransport implements ISshTransport {
         // Keep last ~4KB for regex scanning
         if (buffer.length > 8192) buffer = buffer.slice(buffer.length - 4096);
         stdoutTail = buffer;
+        // Accumulate the full EXEC-state output separately from the truncated
+        // scan buffer so large command output is not lost (see execCapture decl).
+        if (state === 'EXEC') execCapture += text;
 
         if (failRe.test(stdoutTail)) {
           clearStateTimer();
@@ -358,7 +381,12 @@ export class OpenSshTransport implements ISshTransport {
           const m = stdoutTail.match(endRe);
           if (m) {
             exitCode = parseInt(m[1], 10);
-            capturedStdout = stdoutTail.slice(0, m.index).replace(/\r\n/g, '\n');
+            // Derive output from the unbounded EXEC capture (not the truncated
+            // scan buffer) so large command output is preserved in full. Locate
+            // the end-marker within the full capture for the slice boundary.
+            const em = execCapture.match(endRe);
+            const endIdx = em ? em.index! : execCapture.length;
+            capturedStdout = execCapture.slice(0, endIdx).replace(/\r\n/g, '\n');
             // Strip the echoed PS1-sentinel leftovers if any
             capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
             // Strip the echoed command lines (best effort)
@@ -423,6 +451,32 @@ export class OpenSshTransport implements ISshTransport {
       });
     });
   }
+}
+
+/**
+ * Render the askpass helper script body that prints the password held in the
+ * given environment variable, followed by a newline.
+ *
+ * Windows: a naive `@echo off` + `echo %VAR%` is unsafe — CMD expands `%VAR%`
+ * and then re-parses the resulting line, so a password containing `& | < > ^ %`
+ * breaks the echo (and thus auth). Even `setlocal EnableDelayedExpansion` +
+ * `echo !VAR!` mishandles `!`. Instead, shell out to PowerShell and read the
+ * variable verbatim via `$env:VAR`: the password value is fetched at runtime by
+ * PowerShell and never substituted onto a command line, so no metacharacter is
+ * ever re-interpreted. The env var NAME is `[A-Za-z0-9_]`-only (it is always
+ * `SSH_MCP_PW_<pid>`), so embedding it in the command string is safe.
+ *
+ * POSIX: `printf '%s\n' "$VAR"` is already metacharacter-safe.
+ */
+export function renderAskpassHelper(envName: string, isWindows: boolean): string {
+  if (isWindows) {
+    return (
+      `@echo off\r\n` +
+      `powershell -NoProfile -NonInteractive -Command ` +
+      `"[Console]::Out.Write($env:${envName} + [char]10)"\r\n`
+    );
+  }
+  return `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
 }
 
 /**

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -1,5 +1,5 @@
 import { spawn, ChildProcess, execFile } from 'node:child_process';
-import { promises as fs } from 'node:fs';
+import { promises as fs, rmSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { randomBytes } from 'node:crypto';
@@ -105,7 +105,12 @@ export class OpenSshTransport implements ISshTransport {
   async close(): Promise<void> {
     if (this.askpassDir) {
       try {
-        await fs.rm(this.askpassDir, { recursive: true, force: true });
+        // Synchronous removal: close() is invoked from process 'exit'/SIGINT/
+        // SIGTERM handlers (see init()), which cannot await. An async fs.rm()
+        // there would be discarded — the event loop is torn down by
+        // process.exit() before the removal runs, leaking the short-lived
+        // askpass temp dir. rmSync guarantees cleanup completes before exit.
+        rmSync(this.askpassDir, { recursive: true, force: true });
       } catch (e) {
         // best-effort cleanup
       }
@@ -564,7 +569,10 @@ export function renderAskpassHelper(envName: string, isWindows: boolean): string
  *
  *   exit 0                → undefined  (success)
  *   exit 1-254            → remote_exit (remote command's own non-zero exit)
- *   exit 255              → inspect stderr for SSH-layer failure type
+ *   exit 255              → inspect stderr for SSH-layer failure type;
+ *                           falls back to remote_exit when no SSH-layer
+ *                           signature matches (ssh(1) documents 255 as either
+ *                           an SSH error OR the remote command's own exit 255)
  *   exit null             → treated as transport failure
  */
 export function classifyError(code: number | null, stderr: string): ErrorCategory | undefined {
@@ -587,5 +595,9 @@ export function classifyError(code: number | null, stderr: string): ErrorCategor
   if (/connection reset/.test(s)) return 'connect';
   if (/could not resolve|name or service not known/.test(s)) return 'connect';
   if (/no route to host|network unreachable/.test(s)) return 'connect';
-  return 'transport';
+  // No SSH-layer signature matched. Per ssh(1), 255 is also the exit code a
+  // remote command can legitimately return, so surface it as the remote
+  // command's own non-zero exit (Error (code 255)) rather than masking it as
+  // a generic SSH transport error.
+  return 'remote_exit';
 }

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -30,6 +30,7 @@ export class OpenSshTransport implements ISshTransport {
 
   private askpassDir?: string;
   private askpassEnvName?: string;
+  private askpassConfigPath?: string;
   private cleanupRegistered = false;
 
   constructor(private cfg: TransportConfig) {}
@@ -116,6 +117,7 @@ export class OpenSshTransport implements ISshTransport {
       }
       this.askpassDir = undefined;
       this.askpassEnvName = undefined;
+      this.askpassConfigPath = undefined;
     }
   }
 
@@ -147,13 +149,22 @@ export class OpenSshTransport implements ISshTransport {
     const isWindows = process.platform === 'win32';
     const helperName = isWindows ? 'askpass.cmd' : 'askpass.sh';
     const helperPath = path.join(dir, helperName);
+    const configPath = path.join(dir, 'ssh_config');
     const content = renderAskpassHelper(envName, isWindows);
     await fs.writeFile(helperPath, content, { encoding: 'utf8' });
+    // OpenSSH copies variables selected by SendEnv from its own environment to
+    // the remote session. The askpass password must remain in that environment
+    // for the helper, so load the user's normal SSH config and then remove all
+    // SendEnv patterns in a final directive. Passing this file with -F keeps the
+    // rest of the user's SSH settings while preventing a broad `SendEnv *` from
+    // forwarding SSH_MCP_PW_* to the server.
+    await fs.writeFile(configPath, renderAskpassSshConfig(), { encoding: 'utf8' });
     if (!isWindows) {
       await fs.chmod(helperPath, 0o700);
     }
     this.askpassDir = dir;
     this.askpassEnvName = envName;
+    this.askpassConfigPath = configPath;
     (this as any)._askpassPath = helperPath;
     (this as any)._askpassPassword = password;
   }
@@ -169,6 +180,9 @@ export class OpenSshTransport implements ISshTransport {
       '-o', 'BatchMode=no',
       '-p', String(cfg.port),
     ];
+    if (cfg.authMode === 'password' && this.askpassConfigPath) {
+      a.push('-F', this.askpassConfigPath);
+    }
     if (cfg.knownHostsFile) {
       a.push('-o', `UserKnownHostsFile=${cfg.knownHostsFile}`);
     }
@@ -230,7 +244,20 @@ export class OpenSshTransport implements ISshTransport {
   /** Run a single command via `ssh host <cmd>`, collect output, enforce timeout. */
   private runSsh(command: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
-      const args = [...this.buildArgs(opts), command];
+      const nonce = randomBytes(8).toString('hex');
+      const endMark = `__SSH_MCP_END_${nonce}__`;
+      // Keep the user command in a subshell so `exit`/`exec` cannot prevent the
+      // sentinel. The leading newline in printf is an artificial separator;
+      // parsing removes exactly that byte and therefore preserves unterminated
+      // stdout. A random marker distinguishes the remote command's status 255
+      // from ssh(1)'s own transport/auth failure status 255.
+      const wrappedCommand = `(
+${command}
+)
+__ssh_mcp_rc=$?
+printf '\n${endMark}%s\n' "$__ssh_mcp_rc"
+exit 0`;
+      const args = [...this.buildArgs(opts), wrappedCommand];
       let timedOut = false;
       let exited = false;
       let stdout = '';
@@ -276,11 +303,22 @@ export class OpenSshTransport implements ISshTransport {
       child.on('close', (code, signal) => {
         exited = true;
         clearTimeout(timer);
-        const category = timedOut ? 'timeout' : classifyError(code, stderr);
+        const marker = `\n${endMark}`;
+        const markerIdx = stdout.lastIndexOf(marker);
+        const statusText = markerIdx >= 0
+          ? stdout.slice(markerIdx + marker.length).match(/^(\d{1,3})(?:\r?\n|$)/)
+          : null;
+        const remoteExit = statusText ? parseInt(statusText[1], 10) : null;
+        const commandStdout = remoteExit === null ? stdout : stdout.slice(0, markerIdx);
+        const category = timedOut
+          ? 'timeout'
+          : remoteExit === null
+            ? classifyError(code, stderr)
+            : (remoteExit === 0 ? undefined : 'remote_exit');
         resolve({
-          stdout,
+          stdout: commandStdout,
           stderr,
-          exitCode: timedOut ? null : (code ?? null),
+          exitCode: timedOut ? null : (remoteExit ?? code ?? null),
           signal: signal ?? undefined,
           category,
         });
@@ -424,7 +462,9 @@ export class OpenSshTransport implements ISshTransport {
           buffer = '';
           stdoutTail = '';
           // Run the user command inside a subshell, then echo the sentinel and
-          // its exit status on the SAME input line.
+          // its exit status. Newlines are intentional: a trailing shell comment
+          // (including the MCP description suffix) cannot consume the closing
+          // subshell or sentinel command.
           //
           //  - Subshell isolation: a command that exits or exec-replaces its
           //    shell (e.g. `echo ok; exit 0`, `exec true`) only terminates the
@@ -432,10 +472,10 @@ export class OpenSshTransport implements ISshTransport {
           //    the real exit status is reported instead of the close path
           //    mistaking a clean exit for a transport failure and dropping the
           //    output. `$?` after `( ... )` is the subshell's exit status.
-          //  - Same-line sentinel: with `ssh -tt` the sentinel-emit is echoed as
-          //    part of this one input line, so it can never glue onto command
-          //    output that lacks a trailing newline (e.g. `printf foo`).
-          execInput = `( ${command} ); echo ${endMark}$?`;
+          execInput = `(
+${command}
+)
+echo ${endMark}$?`;
           writeLine(execInput);
           return;
         }
@@ -574,6 +614,18 @@ export function renderAskpassHelper(envName: string, isWindows: boolean): string
     );
   }
   return `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
+}
+
+/**
+ * Per-process OpenSSH config used by askpass password authentication.
+ *
+ * `SendEnv` is a multi-value setting, so a command-line `-o SendEnv=-*` is
+ * evaluated before user configuration and cannot remove patterns added later
+ * by `~/.ssh/config`. Including the user config here and placing `SendEnv -*`
+ * last preserves all other settings while reliably clearing the final list.
+ */
+export function renderAskpassSshConfig(): string {
+  return 'Include ~/.ssh/config\nSendEnv -*\n';
 }
 
 /**

--- a/src/transports/openssh.ts
+++ b/src/transports/openssh.ts
@@ -1,0 +1,457 @@
+import { spawn, ChildProcess, execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import {
+  ISshTransport,
+  ExecOptions,
+  ExecElevatedOptions,
+  ExecResult,
+  ErrorCategory,
+  TransportConfig,
+} from './types.js';
+import { buildSudoWrapper } from './ssh2.js';
+
+/**
+ * OpenSshTransport — spawns the system `ssh` binary per command.
+ *
+ * Rationale: the mscdex/ssh2 library does not implement GSSAPI/Kerberos
+ * userauth (upstream issue #333, open since 2015). Delegating to the OS's
+ * OpenSSH client is the only way to get Kerberos SSO support without
+ * reimplementing the SSH userauth state machine.
+ *
+ * No connection multiplexing: Win32-OpenSSH does not support ControlMaster
+ * (issue #1328), so each exec spawns a fresh `ssh` process. This accepts a
+ * per-call handshake cost (including Kerberos AP-REQ round trip) in
+ * exchange for feature completeness on Windows domain-joined clients.
+ */
+export class OpenSshTransport implements ISshTransport {
+  readonly name = 'openssh' as const;
+
+  private askpassDir?: string;
+  private askpassEnvName?: string;
+  private cleanupRegistered = false;
+
+  constructor(private cfg: TransportConfig) {}
+
+  async init(): Promise<void> {
+    await this.verifySshBinary();
+
+    if (this.cfg.authMode === 'password') {
+      if (!this.cfg.password) {
+        throw new Error('authMode=password requires --password');
+      }
+      await this.prepareAskpassHelper(this.cfg.password);
+    }
+
+    if (!this.cleanupRegistered) {
+      const cleanup = () => { void this.close(); };
+      process.once('exit', cleanup);
+      process.once('SIGINT', () => { cleanup(); process.exit(130); });
+      process.once('SIGTERM', () => { cleanup(); process.exit(143); });
+      this.cleanupRegistered = true;
+    }
+  }
+
+  async exec(command: string, opts: ExecOptions): Promise<ExecResult> {
+    // If suPassword is configured, route through PTY-su state machine to
+    // preserve the implicit-su behaviour that ssh2 transport has.
+    if (this.cfg.suPassword) {
+      return this.runSuViaPty(command, this.cfg.suPassword, opts);
+    }
+    return this.runSsh(command, opts);
+  }
+
+  async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
+    if (opts.mode === 'sudo') {
+      const pwd = opts.password ?? this.cfg.sudoPassword;
+      const wrapped = buildSudoWrapper(command, pwd);
+      return this.runSsh(wrapped, opts);
+    }
+    const suPwd = opts.password ?? this.cfg.suPassword;
+    if (!suPwd) {
+      return {
+        stdout: '',
+        stderr: 'su elevation requires --suPassword',
+        exitCode: null,
+        category: 'auth',
+      };
+    }
+    return this.runSuViaPty(command, suPwd, opts);
+  }
+
+  async close(): Promise<void> {
+    if (this.askpassDir) {
+      try {
+        await fs.rm(this.askpassDir, { recursive: true, force: true });
+      } catch (e) {
+        // best-effort cleanup
+      }
+      this.askpassDir = undefined;
+      this.askpassEnvName = undefined;
+    }
+  }
+
+  /** Verify `ssh` is on PATH and usable. Throws if missing. */
+  private async verifySshBinary(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      execFile('ssh', ['-V'], (err) => {
+        if (err) {
+          reject(new Error(
+            'ssh binary not found on PATH. ' +
+            'Install OpenSSH client (Windows: Settings > Apps > Optional features > OpenSSH Client; ' +
+            'Linux: apt install openssh-client).'
+          ));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Write a `.cmd` askpass helper to a temp dir and remember its path.
+   * Password lives in an env var passed only to spawned ssh children —
+   * never written to disk, never placed in argv.
+   */
+  private async prepareAskpassHelper(password: string): Promise<void> {
+    const envName = `SSH_MCP_PW_${process.pid}`;
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-'));
+    const isWindows = process.platform === 'win32';
+    const helperName = isWindows ? 'askpass.cmd' : 'askpass.sh';
+    const helperPath = path.join(dir, helperName);
+    const content = isWindows
+      ? `@echo off\r\necho %${envName}%\r\n`
+      : `#!/bin/sh\nprintf '%s\\n' "$${envName}"\n`;
+    await fs.writeFile(helperPath, content, { encoding: 'utf8' });
+    if (!isWindows) {
+      await fs.chmod(helperPath, 0o700);
+    }
+    this.askpassDir = dir;
+    this.askpassEnvName = envName;
+    (this as any)._askpassPath = helperPath;
+    (this as any)._askpassPassword = password;
+  }
+
+  /** Build the ssh argv array for a single invocation. */
+  buildArgs(opts: ExecOptions): string[] {
+    const cfg = this.cfg;
+    const a: string[] = [
+      '-o', `StrictHostKeyChecking=${cfg.strictHostKeyChecking ?? 'accept-new'}`,
+      '-o', `ConnectTimeout=${Math.max(1, Math.ceil(opts.timeoutMs / 1000))}`,
+      '-o', 'ServerAliveInterval=30',
+      '-o', 'ServerAliveCountMax=3',
+      '-o', 'BatchMode=no',
+      '-p', String(cfg.port),
+    ];
+    if (cfg.knownHostsFile) {
+      a.push('-o', `UserKnownHostsFile=${cfg.knownHostsFile}`);
+    }
+
+    switch (cfg.authMode) {
+      case 'kerberos':
+        a.push(
+          '-o', 'GSSAPIAuthentication=yes',
+          '-o', `GSSAPIDelegateCredentials=${cfg.gssapiDelegateCredentials ?? 'no'}`,
+          '-o', 'PreferredAuthentications=gssapi-with-mic',
+          '-o', 'PubkeyAuthentication=no',
+          '-o', 'PasswordAuthentication=no',
+        );
+        break;
+      case 'key':
+        if (cfg.keyPath) a.push('-i', cfg.keyPath);
+        a.push(
+          '-o', 'PreferredAuthentications=publickey',
+          '-o', 'PasswordAuthentication=no',
+          '-o', 'GSSAPIAuthentication=no',
+        );
+        break;
+      case 'password':
+        a.push(
+          '-o', 'PreferredAuthentications=password,keyboard-interactive',
+          '-o', 'PubkeyAuthentication=no',
+          '-o', 'GSSAPIAuthentication=no',
+        );
+        break;
+      default:
+        break;
+    }
+
+    if (opts.pty) a.push('-tt');
+    a.push(`${cfg.username}@${cfg.host}`);
+    return a;
+  }
+
+  /** Assemble env vars for spawned ssh process. Injects askpass env when needed. */
+  private buildEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (this.cfg.authMode === 'password' && (this as any)._askpassPath) {
+      env.SSH_ASKPASS = (this as any)._askpassPath;
+      env.SSH_ASKPASS_REQUIRE = 'force';
+      env.DISPLAY = env.DISPLAY ?? 'dummy:0';
+      env[this.askpassEnvName!] = (this as any)._askpassPassword;
+    }
+    return env;
+  }
+
+  /** Run a single command via `ssh host <cmd>`, collect output, enforce timeout. */
+  private runSsh(command: string, opts: ExecOptions): Promise<ExecResult> {
+    return new Promise((resolve) => {
+      const args = [...this.buildArgs(opts), command];
+      let timedOut = false;
+      let stdout = '';
+      let stderr = '';
+
+      const child: ChildProcess = spawn('ssh', args, {
+        env: this.buildEnv(),
+        windowsHide: true,
+      });
+
+      child.stdout?.on('data', (b: Buffer) => { stdout += b.toString('utf8'); });
+      child.stderr?.on('data', (b: Buffer) => { stderr += b.toString('utf8'); });
+
+      if (opts.stdin) {
+        try { child.stdin?.end(opts.stdin); } catch (e) { /* ignore */ }
+      } else {
+        try { child.stdin?.end(); } catch (e) { /* ignore */ }
+      }
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        setTimeout(() => {
+          if (!child.killed) child.kill('SIGKILL');
+        }, 2000);
+      }, opts.timeoutMs);
+
+      child.on('error', (err: Error) => {
+        clearTimeout(timer);
+        resolve({
+          stdout,
+          stderr: stderr + `\nspawn error: ${err.message}`,
+          exitCode: null,
+          category: 'transport',
+        });
+      });
+
+      child.on('close', (code, signal) => {
+        clearTimeout(timer);
+        const category = timedOut ? 'timeout' : classifyError(code, stderr);
+        resolve({
+          stdout,
+          stderr,
+          exitCode: timedOut ? null : (code ?? null),
+          signal: signal ?? undefined,
+          category,
+        });
+      });
+    });
+  }
+
+  /**
+   * PTY-based su interactive exec. Uses `ssh -tt` to force remote PTY
+   * allocation. Drives an expect-style state machine via sentinel prompts.
+   *
+   * Random nonce in sentinels prevents collision if remote command output
+   * happens to contain the same string literally.
+   */
+  private runSuViaPty(command: string, suPassword: string, opts: ExecOptions): Promise<ExecResult> {
+    const nonce = randomBytes(8).toString('hex');
+    const readyMark = `__SSH_MCP_READY_${nonce}__`;
+    const endMark = `__SSH_MCP_END_${nonce}__`;
+    const pwRe = /(?:^|\r?\n|[^\w])[Pp]assword(?:\s+for\s+\S+)?:\s*$/m;
+    const failRe = /(authentication failure|incorrect password|su: (?:failed|Authentication failure|incorrect))/i;
+    const readyRe = new RegExp(`${readyMark}`);
+    const endRe = new RegExp(`${endMark}(\\d{1,3})(?:\\r?\\n|$)`);
+
+    return new Promise((resolve) => {
+      const args = [...this.buildArgs({ ...opts, pty: true }), 'su -'];
+      let state: 'SU_PROMPT' | 'PASSWORD_SENT' | 'ROOT_SHELL' | 'EXEC' | 'DONE' = 'SU_PROMPT';
+      let buffer = '';
+      let stdoutTail = '';
+      let capturedStdout = '';
+      let capturedStderr = '';
+      let exitCode: number | null = null;
+      let timedOut = false;
+      let stateTimer: NodeJS.Timeout | null = null;
+
+      const child: ChildProcess = spawn('ssh', args, {
+        env: this.buildEnv(),
+        windowsHide: true,
+      });
+
+      const setStateTimer = (ms: number, reason: string) => {
+        if (stateTimer) clearTimeout(stateTimer);
+        stateTimer = setTimeout(() => {
+          stateTimer = null;
+          capturedStderr += `\nState timeout in ${state}: ${reason}`;
+          child.kill('SIGTERM');
+        }, ms);
+      };
+
+      const clearStateTimer = () => {
+        if (stateTimer) { clearTimeout(stateTimer); stateTimer = null; }
+      };
+
+      const writeLine = (s: string) => {
+        try { child.stdin?.write(s + '\n'); } catch (e) { /* ignore */ }
+      };
+
+      // Initial state: wait up to 10s for `su` password prompt
+      setStateTimer(10000, 'awaiting su password prompt');
+
+      const overallTimer = setTimeout(() => {
+        timedOut = true;
+        clearStateTimer();
+        child.kill('SIGTERM');
+        setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); }, 2000);
+      }, opts.timeoutMs + 30000);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const text = chunk.toString('utf8');
+        buffer += text;
+        // Keep last ~4KB for regex scanning
+        if (buffer.length > 8192) buffer = buffer.slice(buffer.length - 4096);
+        stdoutTail = buffer;
+
+        if (failRe.test(stdoutTail)) {
+          clearStateTimer();
+          capturedStderr += stdoutTail;
+          child.kill('SIGTERM');
+          return;
+        }
+
+        if (state === 'SU_PROMPT' && pwRe.test(stdoutTail)) {
+          clearStateTimer();
+          state = 'PASSWORD_SENT';
+          writeLine(suPassword);
+          setStateTimer(8000, 'awaiting root shell after password');
+          return;
+        }
+
+        if (state === 'PASSWORD_SENT') {
+          // Send sentinel PS1 once we see a non-prompt line (typical: post-auth motd)
+          // Trigger: any newline after password sent.
+          if (/\r?\n/.test(text)) {
+            writeLine(`export PS1='${readyMark}$ '`);
+            state = 'ROOT_SHELL';
+            setStateTimer(5000, 'awaiting sentinel prompt');
+            buffer = '';
+            stdoutTail = '';
+            return;
+          }
+        }
+
+        if (state === 'ROOT_SHELL' && readyRe.test(stdoutTail)) {
+          clearStateTimer();
+          state = 'EXEC';
+          buffer = '';
+          stdoutTail = '';
+          // Execute user command, then echo sentinel+exitcode
+          writeLine(`${command}`);
+          writeLine(`echo ${endMark}$?`);
+          return;
+        }
+
+        if (state === 'EXEC') {
+          const m = stdoutTail.match(endRe);
+          if (m) {
+            exitCode = parseInt(m[1], 10);
+            capturedStdout = stdoutTail.slice(0, m.index).replace(/\r\n/g, '\n');
+            // Strip the echoed PS1-sentinel leftovers if any
+            capturedStdout = capturedStdout.replace(new RegExp(`${readyMark}\\$\\s*`, 'g'), '');
+            // Strip the echoed command lines (best effort)
+            state = 'DONE';
+            writeLine('exit');
+            writeLine('exit');
+          }
+        }
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        capturedStderr += chunk.toString('utf8');
+      });
+
+      child.on('error', (err: Error) => {
+        clearStateTimer();
+        clearTimeout(overallTimer);
+        resolve({
+          stdout: capturedStdout,
+          stderr: capturedStderr + `\nspawn error: ${err.message}`,
+          exitCode: null,
+          category: 'transport',
+        });
+      });
+
+      child.on('close', (code, signal) => {
+        clearStateTimer();
+        clearTimeout(overallTimer);
+
+        if (timedOut) {
+          resolve({
+            stdout: capturedStdout,
+            stderr: capturedStderr || `PTY exec timed out after ${opts.timeoutMs}ms`,
+            exitCode: null,
+            signal: signal ?? undefined,
+            category: 'timeout',
+          });
+          return;
+        }
+
+        if (state === 'DONE' && exitCode !== null) {
+          resolve({
+            stdout: capturedStdout,
+            stderr: '',
+            exitCode,
+            category: exitCode === 0 ? undefined : 'remote_exit',
+          });
+          return;
+        }
+
+        // Did not reach DONE — classify based on stderr content
+        const category: ErrorCategory = failRe.test(stdoutTail + capturedStderr)
+          ? 'auth'
+          : (classifyError(code, capturedStderr) ?? 'transport');
+        resolve({
+          stdout: capturedStdout,
+          stderr: capturedStderr || stdoutTail,
+          exitCode: code ?? null,
+          signal: signal ?? undefined,
+          category,
+        });
+      });
+    });
+  }
+}
+
+/**
+ * Map SSH exit code + stderr to structured ErrorCategory.
+ *
+ *   exit 0                → undefined  (success)
+ *   exit 1-254            → remote_exit (remote command's own non-zero exit)
+ *   exit 255              → inspect stderr for SSH-layer failure type
+ *   exit null             → treated as transport failure
+ */
+export function classifyError(code: number | null, stderr: string): ErrorCategory | undefined {
+  if (code === 0) return undefined;
+  if (code === null) return 'transport';
+  if (code !== 255) return 'remote_exit';
+
+  const s = stderr.toLowerCase();
+  if (/permission denied/.test(s)) return 'auth';
+  if (/authentication failed|authentication failure/.test(s)) return 'auth';
+  if (/no credentials cache|no credential/.test(s)) return 'auth';
+  if (/ticket expired/.test(s)) return 'auth';
+  if (/gss.*credential|gssapi.*failure|gssapi.*unspecified/.test(s)) return 'auth';
+  if (/clock skew too great/.test(s)) return 'auth';
+  if (/server not found in kerberos database/.test(s)) return 'auth';
+  if (/host key verification failed/.test(s)) return 'host_key';
+  if (/remote host identification has changed/.test(s)) return 'host_key';
+  if (/connection refused/.test(s)) return 'connect';
+  if (/connection timed out/.test(s)) return 'connect';
+  if (/connection reset/.test(s)) return 'connect';
+  if (/could not resolve|name or service not known/.test(s)) return 'connect';
+  if (/no route to host|network unreachable/.test(s)) return 'connect';
+  return 'transport';
+}

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -1,4 +1,5 @@
 import { ISshTransport, ServerConfig } from './types.js';
+import type { ResolvedSource } from '../approval/types.js';
 import { createTransport } from './factory.js';
 
 /**
@@ -50,6 +51,17 @@ export class TransportRegistry {
 
   getDefaultName(): string | null {
     return this.defaultName;
+  }
+
+  /** Resolved approval profile for a given connection name. */
+  profile(name?: string): ResolvedSource {
+    const resolved = this.resolveName(name);
+    const cfg = this.configs.get(resolved)!;
+    return {
+      id: resolved,
+      description: cfg.description,
+      approval: cfg.approval,
+    };
   }
 
   /** Resolve name argument → canonical name. Falls back to default. */

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -100,8 +100,12 @@ export class TransportRegistry {
     );
   }
 
-  /** Resolve name argument → canonical name. Falls back to default. */
-  private resolveName(name?: string): string {
+  /**
+   * Resolve name argument → canonical name without initializing a transport.
+   * Useful when a caller must validate target selection before doing other
+   * work (for example, before prompting for approval).
+   */
+  resolveRegisteredName(name?: string): string {
     if (name && this.configs.has(name)) return name;
     if (name && !this.configs.has(name)) {
       throw new Error(
@@ -123,6 +127,11 @@ export class TransportRegistry {
       );
     }
     return this.defaultName;
+  }
+
+  /** Resolve name argument → canonical name. Falls back to default. */
+  private resolveName(name?: string): string {
+    return this.resolveRegisteredName(name);
   }
 
   /** Get (or lazily create+init) the transport for a given name. */

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -145,6 +145,17 @@ export class TransportRegistry {
     const defaultUsable = this.defaultExplicit || this.configs.size === 1;
     const out = [];
     for (const [name, cfg] of this.configs) {
+      // A cached transport is "initialized" — but for OpenSSH that only means
+      // the local ssh binary/askpass setup passed; no live connection is proven
+      // until a command actually runs (openssh spawns per-exec, has no
+      // persistent socket). Prefer the transport's own isConnected() liveness
+      // probe when present so list-servers does not report an initialized-only
+      // OpenSSH host as connected when it has never answered. Fall back to
+      // "cached after successful init" only for transports without a probe.
+      const cached = this.transports.get(name);
+      const connected = cached
+        ? (typeof cached.isConnected === 'function' ? cached.isConnected() : true)
+        : false;
       out.push({
         name,
         host: cfg.host,
@@ -152,7 +163,7 @@ export class TransportRegistry {
         username: cfg.username,
         transport: (cfg.transport ?? (cfg.kerberos ? 'openssh' : 'ssh2')) as 'ssh2' | 'openssh',
         authMode: cfg.authMode ?? (cfg.kerberos ? 'kerberos' : cfg.keyPath || cfg.privateKey ? 'key' : cfg.password ? 'password' : 'unspecified'),
-        connected: this.transports.has(name),
+        connected,
         isDefault: defaultUsable && this.defaultName === name,
       });
     }

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -19,6 +19,16 @@ export class TransportRegistry {
   /** True only when setDefault() was called; first-registered fallback leaves this false. */
   private defaultExplicit = false;
 
+  /**
+   * @param prepareConfig Optional per-host preparation run lazily on first
+   *   get(name), inside the init path — NOT at register() time. Used to defer
+   *   expensive/failure-prone work (e.g. reading an ssh2 key file from disk)
+   *   until the host is actually selected, so one secondary host with a
+   *   missing/unmounted key path does not break startup or block list-servers
+   *   and commands against otherwise-healthy hosts.
+   */
+  constructor(private prepareConfig?: (cfg: ServerConfig) => Promise<void>) {}
+
   register(config: ServerConfig): void {
     if (!config.name) {
       throw new Error('ServerConfig.name is required');
@@ -91,18 +101,24 @@ export class TransportRegistry {
 
     const cfg = this.configs.get(resolved)!;
     const initPromise = (async () => {
-      const t = createTransport(cfg);
       try {
+        // Lazy per-host prep (e.g. reading the ssh2 key file). Deferred to here
+        // so a missing key on this host fails only when the host is used, not at
+        // startup. Kept inside the try so the finally below clears the in-flight
+        // entry on a prep failure too — a later get() retries instead of
+        // replaying the cached rejection (same contract as a rejected init).
+        if (this.prepareConfig) await this.prepareConfig(cfg);
+        const t = createTransport(cfg);
         await t.init();
         // Cache the live transport only on successful init.
         this.transports.set(resolved, t);
         return t;
       } finally {
-        // Always clear the in-flight entry so a rejected init (e.g. a transient
-        // connect timeout to a temporarily-unreachable host) is NOT cached.
-        // Otherwise every later get() would replay the same rejection via the
-        // pending-promise return above, and the connection could never retry
-        // without a process restart.
+        // Always clear the in-flight entry so a rejected prep/init (e.g. a
+        // missing key file, or a transient connect timeout to a temporarily-
+        // unreachable host) is NOT cached. Otherwise every later get() would
+        // replay the same rejection via the pending-promise return above, and
+        // the connection could never retry without a process restart.
         this.initPromises.delete(resolved);
       }
     })();
@@ -121,6 +137,12 @@ export class TransportRegistry {
     connected: boolean;
     isDefault: boolean;
   }> {
+    // A name is only a *usable* default when it can actually be selected with an
+    // omitted connectionName: either it's the lone server, or setDefault() was
+    // called. In the normal multi-host case (>1 server, no explicit default)
+    // resolveName() rejects an omitted name, so advertising the first-registered
+    // host as "(default)" would be misleading — report isDefault=false there.
+    const defaultUsable = this.defaultExplicit || this.configs.size === 1;
     const out = [];
     for (const [name, cfg] of this.configs) {
       out.push({
@@ -131,7 +153,7 @@ export class TransportRegistry {
         transport: (cfg.transport ?? (cfg.kerberos ? 'openssh' : 'ssh2')) as 'ssh2' | 'openssh',
         authMode: cfg.authMode ?? (cfg.kerberos ? 'kerberos' : cfg.keyPath || cfg.privateKey ? 'key' : cfg.password ? 'password' : 'unspecified'),
         connected: this.transports.has(name),
-        isDefault: this.defaultName === name,
+        isDefault: defaultUsable && this.defaultName === name,
       });
     }
     return out;

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -18,6 +18,14 @@ export class TransportRegistry {
   private defaultName: string | null = null;
   /** True only when setDefault() was called; first-registered fallback leaves this false. */
   private defaultExplicit = false;
+  /**
+   * Multi-source connection guard toggle. When true (default, safe), a tool
+   * call that omits/blanks connectionName against a multi-source registry with
+   * no explicit default is rejected. Set false to opt out and restore the
+   * legacy silent-default fallback (the `[server].require_connection = false`
+   * escape hatch — wired from the resolver via setRequireConnectionWhenMulti).
+   */
+  private requireConnectionWhenMulti = true;
 
   register(config: ServerConfig): void {
     if (!config.name) {
@@ -40,6 +48,16 @@ export class TransportRegistry {
     }
     this.defaultName = name;
     this.defaultExplicit = true;
+  }
+
+  /**
+   * Toggle the multi-source omit-name guard. Pass `false` to opt out (restore
+   * the legacy silent-default fallback) or `true` to keep it enforced. The boot
+   * path injects this from the resolved `[server].require_connection` value;
+   * absent any config the registry stays safe (guard ON).
+   */
+  setRequireConnectionWhenMulti(required: boolean): void {
+    this.requireConnectionWhenMulti = required;
   }
 
   /** Returns names of all registered servers in registration order. */
@@ -70,8 +88,14 @@ export class TransportRegistry {
     // refuse to silently pick the first-registered host — the command could
     // land on the wrong machine. The connectionName tool arg is advertised as
     // optional only for the single-server case (see connectionNameSchema in
-    // index.ts). A deliberate setDefault() re-enables the omit-name shortcut.
-    if (!name && this.configs.size > 1 && !this.defaultExplicit) {
+    // index.ts). A deliberate setDefault() re-enables the omit-name shortcut,
+    // and setRequireConnectionWhenMulti(false) opts out of the guard entirely.
+    if (
+      this.requireConnectionWhenMulti &&
+      !name &&
+      this.configs.size > 1 &&
+      !this.defaultExplicit
+    ) {
       throw new Error(
         `connectionName is required when multiple servers are configured: ${this.names().join(', ')}`
       );

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -73,6 +73,23 @@ export class TransportRegistry {
     return this.defaultName;
   }
 
+  /**
+   * True when resolveName() would REJECT an omitted/blank connectionName:
+   * multiple sources are registered, no explicit default was set, and the
+   * multi-source guard is on. Callers that compute gating/audit attribution
+   * BEFORE calling get() use this to avoid misattributing a guard-rejected
+   * call to the first-registered host — the call never actually lands on a
+   * host, so attributing it to one corrupts audit profile for exactly the
+   * guard case.
+   */
+  wouldRejectOmittedName(): boolean {
+    return (
+      this.requireConnectionWhenMulti &&
+      this.configs.size > 1 &&
+      !this.defaultExplicit
+    );
+  }
+
   /** Resolve name argument → canonical name. Falls back to default. */
   private resolveName(name?: string): string {
     if (name && this.configs.has(name)) return name;
@@ -90,12 +107,7 @@ export class TransportRegistry {
     // optional only for the single-server case (see connectionNameSchema in
     // index.ts). A deliberate setDefault() re-enables the omit-name shortcut,
     // and setRequireConnectionWhenMulti(false) opts out of the guard entirely.
-    if (
-      this.requireConnectionWhenMulti &&
-      !name &&
-      this.configs.size > 1 &&
-      !this.defaultExplicit
-    ) {
+    if (!name && this.wouldRejectOmittedName()) {
       throw new Error(
         `connectionName is required when multiple servers are configured: ${this.names().join(', ')}`
       );

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -1,0 +1,127 @@
+import { ISshTransport, ServerConfig } from './types.js';
+import { createTransport } from './factory.js';
+
+/**
+ * Registry of named SSH transports for multi-host MCP mode.
+ *
+ * Transports are lazily created on first use (so startup cost is O(1)
+ * regardless of how many hosts are configured). Each transport is reused
+ * across subsequent tool calls to the same connection name.
+ *
+ * When only a single config is registered, its name becomes the default
+ * — callers may omit connectionName from tool arguments.
+ */
+export class TransportRegistry {
+  private configs = new Map<string, ServerConfig>();
+  private transports = new Map<string, ISshTransport>();
+  private initPromises = new Map<string, Promise<ISshTransport>>();
+  private defaultName: string | null = null;
+
+  register(config: ServerConfig): void {
+    if (!config.name) {
+      throw new Error('ServerConfig.name is required');
+    }
+    if (this.configs.has(config.name)) {
+      throw new Error(`Duplicate server name: ${config.name}`);
+    }
+    this.configs.set(config.name, config);
+    // First registered becomes the default unless explicitly overridden.
+    if (this.defaultName === null) {
+      this.defaultName = config.name;
+    }
+  }
+
+  /** Override which name is used when tool calls omit connectionName. */
+  setDefault(name: string): void {
+    if (!this.configs.has(name)) {
+      throw new Error(`Cannot set default to unknown server: ${name}`);
+    }
+    this.defaultName = name;
+  }
+
+  /** Returns names of all registered servers in registration order. */
+  names(): string[] {
+    return Array.from(this.configs.keys());
+  }
+
+  hasAny(): boolean {
+    return this.configs.size > 0;
+  }
+
+  getDefaultName(): string | null {
+    return this.defaultName;
+  }
+
+  /** Resolve name argument → canonical name. Falls back to default. */
+  private resolveName(name?: string): string {
+    if (name && this.configs.has(name)) return name;
+    if (name && !this.configs.has(name)) {
+      throw new Error(
+        `Unknown connection name: ${name}. Registered: ${this.names().join(', ') || '(none)'}`
+      );
+    }
+    if (this.defaultName === null) {
+      throw new Error('No servers registered');
+    }
+    return this.defaultName;
+  }
+
+  /** Get (or lazily create+init) the transport for a given name. */
+  async get(name?: string): Promise<ISshTransport> {
+    const resolved = this.resolveName(name);
+    const existing = this.transports.get(resolved);
+    if (existing) return existing;
+
+    // Serialize concurrent init requests for the same name
+    const pending = this.initPromises.get(resolved);
+    if (pending) return pending;
+
+    const cfg = this.configs.get(resolved)!;
+    const initPromise = (async () => {
+      const t = createTransport(cfg);
+      await t.init();
+      this.transports.set(resolved, t);
+      this.initPromises.delete(resolved);
+      return t;
+    })();
+    this.initPromises.set(resolved, initPromise);
+    return initPromise;
+  }
+
+  /** Snapshot status for list-servers tool. */
+  list(): Array<{
+    name: string;
+    host: string;
+    port: number;
+    username: string;
+    transport: 'ssh2' | 'openssh';
+    authMode: string;
+    connected: boolean;
+    isDefault: boolean;
+  }> {
+    const out = [];
+    for (const [name, cfg] of this.configs) {
+      out.push({
+        name,
+        host: cfg.host,
+        port: cfg.port,
+        username: cfg.username,
+        transport: (cfg.transport ?? (cfg.kerberos ? 'openssh' : 'ssh2')) as 'ssh2' | 'openssh',
+        authMode: cfg.authMode ?? (cfg.kerberos ? 'kerberos' : cfg.keyPath || cfg.privateKey ? 'key' : cfg.password ? 'password' : 'unspecified'),
+        connected: this.transports.has(name),
+        isDefault: this.defaultName === name,
+      });
+    }
+    return out;
+  }
+
+  async closeAll(): Promise<void> {
+    const tasks: Promise<void>[] = [];
+    for (const t of this.transports.values()) {
+      tasks.push(t.close().catch(() => { /* best effort */ }));
+    }
+    this.transports.clear();
+    this.initPromises.clear();
+    await Promise.allSettled(tasks);
+  }
+}

--- a/src/transports/registry.ts
+++ b/src/transports/registry.ts
@@ -16,6 +16,8 @@ export class TransportRegistry {
   private transports = new Map<string, ISshTransport>();
   private initPromises = new Map<string, Promise<ISshTransport>>();
   private defaultName: string | null = null;
+  /** True only when setDefault() was called; first-registered fallback leaves this false. */
+  private defaultExplicit = false;
 
   register(config: ServerConfig): void {
     if (!config.name) {
@@ -37,6 +39,7 @@ export class TransportRegistry {
       throw new Error(`Cannot set default to unknown server: ${name}`);
     }
     this.defaultName = name;
+    this.defaultExplicit = true;
   }
 
   /** Returns names of all registered servers in registration order. */
@@ -63,6 +66,16 @@ export class TransportRegistry {
     if (this.defaultName === null) {
       throw new Error('No servers registered');
     }
+    // When connectionName is omitted and more than one server is configured,
+    // refuse to silently pick the first-registered host — the command could
+    // land on the wrong machine. The connectionName tool arg is advertised as
+    // optional only for the single-server case (see connectionNameSchema in
+    // index.ts). A deliberate setDefault() re-enables the omit-name shortcut.
+    if (!name && this.configs.size > 1 && !this.defaultExplicit) {
+      throw new Error(
+        `connectionName is required when multiple servers are configured: ${this.names().join(', ')}`
+      );
+    }
     return this.defaultName;
   }
 
@@ -79,10 +92,19 @@ export class TransportRegistry {
     const cfg = this.configs.get(resolved)!;
     const initPromise = (async () => {
       const t = createTransport(cfg);
-      await t.init();
-      this.transports.set(resolved, t);
-      this.initPromises.delete(resolved);
-      return t;
+      try {
+        await t.init();
+        // Cache the live transport only on successful init.
+        this.transports.set(resolved, t);
+        return t;
+      } finally {
+        // Always clear the in-flight entry so a rejected init (e.g. a transient
+        // connect timeout to a temporarily-unreachable host) is NOT cached.
+        // Otherwise every later get() would replay the same rejection via the
+        // pending-promise return above, and the connection could never retry
+        // without a process restart.
+        this.initPromises.delete(resolved);
+      }
     })();
     this.initPromises.set(resolved, initPromise);
     return initPromise;

--- a/src/transports/ssh2.ts
+++ b/src/transports/ssh2.ts
@@ -1,0 +1,414 @@
+import { Client, ClientChannel } from 'ssh2';
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ISshTransport,
+  ExecOptions,
+  ExecElevatedOptions,
+  ExecResult,
+  TransportConfig,
+} from './types.js';
+import { escapeCommandForShell } from '../utils/shell.js';
+
+/**
+ * Connection manager extracted verbatim from upstream src/index.ts. Behaviour
+ * is preserved byte-for-byte. It is re-exported from src/index.ts so existing
+ * tests (persistent-connection.test.ts) continue to import it.
+ */
+export interface SSHConfig {
+  host: string;
+  port: number;
+  username: string;
+  password?: string;
+  privateKey?: string;
+  suPassword?: string;
+  sudoPassword?: string;
+}
+
+export class SSHConnectionManager {
+  private conn: Client | null = null;
+  private sshConfig: SSHConfig;
+  private isConnecting = false;
+  private connectionPromise: Promise<void> | null = null;
+  private suShell: any = null;
+  private suPromise: Promise<void> | null = null;
+  private isElevated = false;
+
+  constructor(config: SSHConfig) {
+    this.sshConfig = config;
+  }
+
+  async connect(): Promise<void> {
+    if (this.conn && this.isConnected()) {
+      return;
+    }
+    if (this.isConnecting && this.connectionPromise) {
+      return this.connectionPromise;
+    }
+
+    this.isConnecting = true;
+    this.connectionPromise = new Promise((resolve, reject) => {
+      this.conn = new Client();
+
+      const timeoutId = setTimeout(() => {
+        this.conn?.end();
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+        reject(new McpError(ErrorCode.InternalError, 'SSH connection timeout'));
+      }, 30000);
+
+      this.conn.on('ready', async () => {
+        clearTimeout(timeoutId);
+        this.isConnecting = false;
+        if (this.sshConfig.suPassword && !process.env.SSH_MCP_TEST) {
+          try {
+            await this.ensureElevated();
+          } catch (err) {
+            // Do not reject connection; commands fall back to non-elevated.
+          }
+        }
+        resolve();
+      });
+
+      this.conn.on('error', (err: Error) => {
+        clearTimeout(timeoutId);
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+        reject(new McpError(ErrorCode.InternalError, `SSH connection error: ${err.message}`));
+      });
+
+      this.conn.on('end', () => {
+        console.error('SSH connection ended');
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+      });
+
+      this.conn.on('close', () => {
+        console.error('SSH connection closed');
+        this.conn = null;
+        this.isConnecting = false;
+        this.connectionPromise = null;
+      });
+
+      this.conn.connect(this.sshConfig);
+    });
+
+    return this.connectionPromise;
+  }
+
+  isConnected(): boolean {
+    return this.conn !== null && (this.conn as any)._sock && !(this.conn as any)._sock.destroyed;
+  }
+
+  getSudoPassword(): string | undefined {
+    return this.sshConfig.sudoPassword;
+  }
+
+  getSuPassword(): string | undefined {
+    return this.sshConfig.suPassword;
+  }
+
+  async setSuPassword(pwd?: string): Promise<void> {
+    this.sshConfig.suPassword = pwd;
+    if (pwd) {
+      try {
+        await this.ensureElevated();
+      } catch (err) {
+        console.error('setSuPassword: failed to elevate to su shell:', err);
+      }
+    } else {
+      if (this.suShell) {
+        try { this.suShell.end(); } catch (e) { /* ignore */ }
+        this.suShell = null;
+        this.isElevated = false;
+      }
+    }
+  }
+
+  async ensureElevated(): Promise<void> {
+    if (this.isElevated && this.suShell) return;
+    if (!this.sshConfig.suPassword) return;
+    if (this.suPromise) return this.suPromise;
+
+    this.suPromise = new Promise((resolve, reject) => {
+      const conn = this.getConnection();
+
+      const timeoutId = setTimeout(() => {
+        this.suPromise = null;
+        reject(new McpError(ErrorCode.InternalError, 'su elevation timed out'));
+      }, 10000);
+
+      conn.shell({ term: 'xterm', cols: 80, rows: 24 }, (err: Error | undefined, stream: ClientChannel) => {
+        if (err) {
+          clearTimeout(timeoutId);
+          this.suPromise = null;
+          reject(new McpError(ErrorCode.InternalError, `Failed to start interactive shell for su: ${err.message}`));
+          return;
+        }
+
+        let buffer = '';
+        let passwordSent = false;
+        const cleanup = () => {
+          try { stream.removeAllListeners('data'); } catch (e) { /* ignore */ }
+        };
+
+        const onData = (data: Buffer) => {
+          const text = data.toString();
+          buffer += text;
+
+          if (!passwordSent && /password[: ]/i.test(buffer)) {
+            passwordSent = true;
+            stream.write(this.sshConfig.suPassword + '\n');
+          }
+
+          if (passwordSent) {
+            if (/#/.test(buffer)) {
+              clearTimeout(timeoutId);
+              cleanup();
+              this.suShell = stream;
+              this.isElevated = true;
+              this.suPromise = null;
+              resolve();
+              return;
+            }
+          }
+
+          if (/authentication failure|incorrect password|su: .*failed|su: failure/i.test(buffer)) {
+            clearTimeout(timeoutId);
+            cleanup();
+            this.suPromise = null;
+            reject(new McpError(ErrorCode.InternalError, `su authentication failed: ${buffer}`));
+            return;
+          }
+        };
+
+        stream.on('data', onData);
+        stream.on('close', () => {
+          clearTimeout(timeoutId);
+          if (!this.isElevated) {
+            this.suPromise = null;
+            reject(new McpError(ErrorCode.InternalError, 'su shell closed before elevation completed'));
+          }
+        });
+
+        stream.write('su -\n');
+      });
+    });
+
+    return this.suPromise;
+  }
+
+  async ensureConnected(): Promise<void> {
+    if (!this.isConnected()) {
+      await this.connect();
+    }
+  }
+
+  getConnection(): Client {
+    if (!this.conn) {
+      throw new McpError(ErrorCode.InternalError, 'SSH connection not established');
+    }
+    return this.conn;
+  }
+
+  /** Internal accessor used by execSshCommandWithConnection and Ssh2Transport. */
+  getSuShell(): any {
+    return this.suShell;
+  }
+
+  /** Internal mutator used by tool handlers that update config after construction. */
+  updateSudoPassword(pwd?: string): void {
+    this.sshConfig.sudoPassword = pwd;
+  }
+
+  close(): void {
+    if (this.conn) {
+      if (this.suShell) {
+        try { this.suShell.end(); } catch (e) { /* ignore */ }
+        this.suShell = null;
+        this.isElevated = false;
+      }
+      this.conn.end();
+      this.conn = null;
+    }
+  }
+}
+
+/**
+ * Ssh2Transport — ISshTransport adapter around SSHConnectionManager.
+ *
+ * Behaviour: preserves the upstream implementation exactly. If the underlying
+ * manager has an active `suShell` (created by ensureElevated), exec()
+ * routes through it. Otherwise it uses `conn.exec()`.
+ */
+export class Ssh2Transport implements ISshTransport {
+  readonly name = 'ssh2' as const;
+  private manager: SSHConnectionManager;
+
+  constructor(private cfg: TransportConfig) {
+    const sshCfg: SSHConfig = {
+      host: cfg.host,
+      port: cfg.port,
+      username: cfg.username,
+      password: cfg.password,
+      privateKey: cfg.privateKey,
+      suPassword: cfg.suPassword,
+      sudoPassword: cfg.sudoPassword,
+    };
+    this.manager = new SSHConnectionManager(sshCfg);
+  }
+
+  /** Exposed for legacy tests and tool handlers that need direct manager access. */
+  getManager(): SSHConnectionManager {
+    return this.manager;
+  }
+
+  async init(): Promise<void> {
+    await this.manager.connect();
+  }
+
+  async exec(command: string, opts: ExecOptions): Promise<ExecResult> {
+    await this.manager.ensureConnected();
+
+    // Mirror upstream behaviour: if suPassword was configured, ensure elevation
+    // before executing. Idempotent; no-op if already elevated.
+    if (this.manager.getSuPassword()) {
+      try {
+        await Promise.race([
+          this.manager.ensureElevated(),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('Elevation timeout')), 5000)),
+        ]);
+      } catch (err) {
+        // Fall back to non-elevated execution on elevation failure.
+      }
+    }
+
+    return this.runOnConnection(command, opts);
+  }
+
+  async execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult> {
+    if (opts.mode === 'sudo') {
+      const pwd = opts.password ?? this.manager.getSudoPassword();
+      const wrapped = buildSudoWrapper(command, pwd);
+      return this.exec(wrapped, opts);
+    }
+    // mode === 'su' — configure password on manager, ensure elevation, then exec
+    if (opts.password) {
+      await this.manager.setSuPassword(opts.password);
+    }
+    return this.exec(command, opts);
+  }
+
+  async close(): Promise<void> {
+    this.manager.close();
+  }
+
+  private runOnConnection(command: string, opts: ExecOptions): Promise<ExecResult> {
+    return new Promise((resolve) => {
+      let timeoutId: NodeJS.Timeout;
+      let isResolved = false;
+      const timeoutMs = opts.timeoutMs;
+
+      const conn = this.manager.getConnection();
+      const shell = this.manager.getSuShell();
+
+      timeoutId = setTimeout(() => {
+        if (!isResolved) {
+          isResolved = true;
+          resolve({
+            stdout: '',
+            stderr: `Command execution timed out after ${timeoutMs}ms`,
+            exitCode: null,
+            category: 'timeout',
+          });
+        }
+      }, timeoutMs);
+
+      if (shell) {
+        let buffer = '';
+        const dataHandler = (data: Buffer) => {
+          const text = data.toString();
+          buffer += text;
+
+          if (/#/.test(buffer)) {
+            if (!isResolved) {
+              isResolved = true;
+              clearTimeout(timeoutId);
+              const lines = buffer.split('\n');
+              const output = lines.slice(1, -1).join('\n');
+              resolve({
+                stdout: output + (output ? '\n' : ''),
+                stderr: '',
+                exitCode: 0,
+              });
+            }
+            shell.removeListener('data', dataHandler);
+          }
+        };
+
+        shell.on('data', dataHandler);
+        shell.write(command + '\n');
+        return;
+      }
+
+      conn.exec(command, (err: Error | undefined, stream: ClientChannel) => {
+        if (err) {
+          if (!isResolved) {
+            isResolved = true;
+            clearTimeout(timeoutId);
+            resolve({
+              stdout: '',
+              stderr: `SSH exec error: ${err.message}`,
+              exitCode: null,
+              category: 'transport',
+            });
+          }
+          return;
+        }
+
+        let stdout = '';
+        let stderr = '';
+
+        if (opts.stdin && opts.stdin.length > 0) {
+          try {
+            stream.write(opts.stdin);
+          } catch (e) {
+            console.error('Error writing to stdin:', e);
+          }
+        }
+        try { stream.end(); } catch (e) { /* ignore */ }
+
+        stream.on('data', (data: Buffer) => {
+          stdout += data.toString();
+        });
+        stream.stderr.on('data', (data: Buffer) => {
+          stderr += data.toString();
+        });
+        stream.on('close', (code: number, _signal: string) => {
+          if (!isResolved) {
+            isResolved = true;
+            clearTimeout(timeoutId);
+            resolve({
+              stdout,
+              stderr,
+              exitCode: code ?? 0,
+              category: stderr ? 'remote_exit' : undefined,
+            });
+          }
+        });
+      });
+    });
+  }
+}
+
+/** Build a sudo-wrapped command exactly the way upstream sudo-exec tool does. */
+export function buildSudoWrapper(command: string, sudoPassword?: string): string {
+  const escaped = command.replace(/'/g, "'\\''");
+  if (!sudoPassword) {
+    return `sudo -n sh -c '${escaped}'`;
+  }
+  const pwdEscaped = sudoPassword.replace(/'/g, "'\\''");
+  return `printf '%s\\n' '${pwdEscaped}' | sudo -p "" -S sh -c '${escaped}'`;
+}

--- a/src/transports/ssh2.ts
+++ b/src/transports/ssh2.ts
@@ -305,6 +305,14 @@ export class Ssh2Transport implements ISshTransport {
     this.manager.close();
   }
 
+  /**
+   * ssh2 keeps a persistent Client socket established at init() time, so live
+   * connection status is the underlying manager's socket state.
+   */
+  isConnected(): boolean {
+    return this.manager.isConnected();
+  }
+
   private runOnConnection(command: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       let timeoutId: NodeJS.Timeout;

--- a/src/transports/ssh2.ts
+++ b/src/transports/ssh2.ts
@@ -390,11 +390,12 @@ export class Ssh2Transport implements ISshTransport {
           if (!isResolved) {
             isResolved = true;
             clearTimeout(timeoutId);
+            const exitCode = code ?? 0;
             resolve({
               stdout,
               stderr,
-              exitCode: code ?? 0,
-              category: stderr ? 'remote_exit' : undefined,
+              exitCode,
+              category: exitCode !== 0 ? 'remote_exit' : undefined,
             });
           }
         });

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -94,3 +94,13 @@ export interface TransportConfig {
   knownHostsFile?: string;
   strictHostKeyChecking?: 'yes' | 'no' | 'accept-new';
 }
+
+/**
+ * Named server configuration for multi-host mode. Emits TransportConfig
+ * at registry time, plus a required `name` that the MCP tools reference
+ * via `connectionName`.
+ */
+export interface ServerConfig extends TransportConfig {
+  /** Unique identifier referenced by MCP tools' connectionName argument. */
+  name: string;
+}

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -103,4 +103,10 @@ export interface TransportConfig {
 export interface ServerConfig extends TransportConfig {
   /** Unique identifier referenced by MCP tools' connectionName argument. */
   name: string;
+  /** Human-readable host/profile policy description supplied to approval engines. */
+  description?: string;
+  /** Per-source approval override. */
+  approval?: {
+    mode?: import('../approval/types.js').ApprovalMode;
+  };
 }

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -63,6 +63,24 @@ export interface ISshTransport {
 
   /** Release resources. Idempotent — safe to call multiple times. */
   close(): Promise<void>;
+
+  /**
+   * Optional liveness probe. When present, list-servers uses it to distinguish
+   * a transport that is merely *initialized* (cached after init()) from one
+   * with a *proven live connection*.
+   *
+   *   - ssh2 keeps a persistent Client socket, so init() establishes a real
+   *     connection; isConnected() reflects the live socket state.
+   *   - openssh has NO persistent connection — init() only verifies the local
+   *     ssh binary/askpass setup and each command spawns a fresh process. Being
+   *     initialized therefore does not prove the host is reachable (the first
+   *     command can still fail with connection refused). isConnected() reports
+   *     whether at least one command has actually run over a live SSH session.
+   *
+   * When a transport does not implement this, the registry falls back to
+   * treating "cached after successful init" as connected.
+   */
+  isConnected?(): boolean;
 }
 
 /** Auth mode for OpenSshTransport. Ssh2Transport selects auth from SshConfig fields. */

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Pluggable SSH transport abstraction.
+ *
+ * Two implementations:
+ *   - Ssh2Transport   (default; uses mscdex/ssh2 library)
+ *   - OpenSshTransport (opt-in via --transport=openssh or --kerberos; spawns ssh binary)
+ *
+ * Transport chosen at startup via factory. Tool handlers consume ExecResult
+ * and map to MCP responses.
+ */
+
+export type ErrorCategory =
+  | 'auth'        // bad password / bad key / Kerberos ticket missing or expired
+  | 'host_key'    // StrictHostKeyChecking rejection
+  | 'connect'     // TCP/DNS failure
+  | 'timeout'     // exec exceeded deadline
+  | 'remote_exit' // ran but exited non-zero
+  | 'transport';  // ssh2/openssh internal error (spawn failed, etc.)
+
+export interface ExecOptions {
+  /** Hard ceiling; transport must enforce and return category='timeout' on breach. */
+  timeoutMs: number;
+  /** Piped into remote stdin (e.g. sudo password). */
+  stdin?: string;
+  /** Request TTY allocation (needed for su -tt flow). */
+  pty?: boolean;
+}
+
+export type ElevationMode = 'sudo' | 'su';
+
+export interface ExecElevatedOptions extends ExecOptions {
+  mode: ElevationMode;
+  /** sudo -S stdin password, or su password. Optional for passwordless sudo. */
+  password?: string;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  /** Non-null only when killed by signal (POSIX). Always null on Windows. */
+  signal?: string;
+  /** Set when exec failed in a classifiable way. Undefined on success. */
+  category?: ErrorCategory;
+}
+
+/**
+ * Transport contract. Implementations decide connection-lifetime strategy
+ * internally (ssh2 keeps one persistent Client; openssh spawns per command
+ * because ControlMaster is unsupported on Windows).
+ */
+export interface ISshTransport {
+  readonly name: 'ssh2' | 'openssh';
+
+  /** Prepare resources. Connect ssh2 Client, verify ssh binary exists, etc. */
+  init(): Promise<void>;
+
+  /** Run a single remote command. */
+  exec(command: string, opts: ExecOptions): Promise<ExecResult>;
+
+  /** Elevated (sudo or su) exec. Transport handles the elevation mechanics. */
+  execElevated(command: string, opts: ExecElevatedOptions): Promise<ExecResult>;
+
+  /** Release resources. Idempotent — safe to call multiple times. */
+  close(): Promise<void>;
+}
+
+/** Auth mode for OpenSshTransport. Ssh2Transport selects auth from SshConfig fields. */
+export type AuthMode = 'kerberos' | 'key' | 'password';
+
+/**
+ * Unified config shared by both transports. Supersedes the original SSHConfig.
+ * Backwards-compatible: ssh2 path reads the legacy fields (host/port/username/
+ * password/privateKey/suPassword/sudoPassword) unchanged.
+ */
+export interface TransportConfig {
+  // Connection
+  host: string;
+  port: number;
+  username: string;
+
+  // Auth (legacy, used by both transports)
+  password?: string;
+  privateKey?: string;  // private-key contents (not path)
+  suPassword?: string;
+  sudoPassword?: string;
+
+  // OpenSshTransport only
+  transport?: 'ssh2' | 'openssh';
+  authMode?: AuthMode;
+  keyPath?: string;     // path to key file (openssh uses -i)
+  kerberos?: boolean;
+  gssapiDelegateCredentials?: 'yes' | 'no';
+  knownHostsFile?: string;
+  strictHostKeyChecking?: 'yes' | 'no' | 'accept-new';
+}

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -103,4 +103,6 @@ export interface TransportConfig {
 export interface ServerConfig extends TransportConfig {
   /** Unique identifier referenced by MCP tools' connectionName argument. */
   name: string;
+  /** Optional human-readable source description from TOML, used by approval prompts. */
+  description?: string;
 }

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,44 @@
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Validate and trim a command string. Enforces maxChars if finite.
+ * Shared by both transports so limit semantics are identical.
+ */
+export function sanitizeCommand(command: string, maxChars: number): string {
+  if (typeof command !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'Command must be a string');
+  }
+
+  const trimmedCommand = command.trim();
+  if (!trimmedCommand) {
+    throw new McpError(ErrorCode.InvalidParams, 'Command cannot be empty');
+  }
+
+  if (Number.isFinite(maxChars) && trimmedCommand.length > maxChars) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Command is too long (max ${maxChars} characters)`
+    );
+  }
+
+  return trimmedCommand;
+}
+
+/**
+ * Return undefined for empty/non-string; otherwise the raw password.
+ * No content mutation, no logging.
+ */
+export function sanitizePassword(password: string | undefined): string | undefined {
+  if (typeof password !== 'string') return undefined;
+  if (password.length === 0) return undefined;
+  return password;
+}
+
+/**
+ * Escape a command for safe embedding inside a single-quoted POSIX shell
+ * context on the remote side, e.g. `sh -c '<escaped>'`. Applies the canonical
+ * `'\''` technique: close-quote, escape a single quote, re-open-quote.
+ */
+export function escapeCommandForShell(command: string): string {
+  return command.replace(/'/g, "'\"'\"'");
+}

--- a/ssh-mcp.toml.example
+++ b/ssh-mcp.toml.example
@@ -10,6 +10,11 @@
 [server]
 audit_dir = "~/.ssh-mcp"
 audit_max_bytes = 10000
+# Multi-source safety guard: when more than one [[sources]] is configured and
+# no source is marked `default = true`, a tool call that omits connectionName is
+# rejected (it could land on the wrong host). Set to false to opt out and
+# restore the legacy "first source wins" behavior. Defaults to true (guard ON).
+# require_connection = true
 
 [webui]
 enabled = false

--- a/ssh-mcp.toml.example
+++ b/ssh-mcp.toml.example
@@ -3,6 +3,9 @@
 # Equivalent CLI multi-host shape:
 #   --ssh='{"name":"prod-bastion","host":"bastion.example.com","port":22,"user":"aduser@EXAMPLE.INTERNAL","auth":"kerberos"}'
 #   --ssh='{"name":"lab","host":"lab.internal","user":"root","auth":"key","keyPath":"~/.ssh/lab_ed25519","sudoPassword":"..."}'
+#
+# Note: per-source `description` is reserved — it is validated on load but not
+# yet surfaced anywhere; a later web-UI task consumes it. Safe to set now.
 
 [server]
 audit_dir = "~/.ssh-mcp"

--- a/ssh-mcp.toml.example
+++ b/ssh-mcp.toml.example
@@ -1,0 +1,47 @@
+# ssh-mcp first-class TOML config example.
+#
+# Equivalent CLI multi-host shape:
+#   --ssh='{"name":"prod-bastion","host":"bastion.example.com","port":22,"user":"aduser@EXAMPLE.INTERNAL","auth":"kerberos"}'
+#   --ssh='{"name":"lab","host":"lab.internal","user":"root","auth":"key","keyPath":"~/.ssh/lab_ed25519","sudoPassword":"..."}'
+
+[server]
+audit_dir = "~/.ssh-mcp"
+audit_max_bytes = 10000
+
+[webui]
+enabled = false
+host = "127.0.0.1"
+port = 8088
+# auth_token = "env:SSHMCP_WEBUI_TOKEN"  # required when host is non-loopback
+
+[approval]
+mode = "manual"
+fail_closed = true
+
+[approval.llm]
+endpoint = "https://api.openai.com/v1/chat/completions"
+api_key = "env:OPENAI_API_KEY"
+model = "gpt-4o-mini"
+timeout_ms = 8000
+
+[[sources]]
+id = "prod-bastion"
+description = "Production jump host. Allowed: read-only diagnostics."
+host = "bastion.example.com"
+port = 22
+user = "aduser@EXAMPLE.INTERNAL"
+auth = "kerberos"
+default = true
+
+[[sources]]
+id = "lab"
+description = "Lab box for experiments."
+host = "lab.internal"
+user = "root"
+auth = "key"
+key_path = "~/.ssh/lab_ed25519"
+sudo_password = "env:LAB_SUDO_PASS"
+
+# Optional per-source approval override for the immediately preceding source.
+[sources.approval]
+mode = "yolo"

--- a/ssh-mcp.toml.example
+++ b/ssh-mcp.toml.example
@@ -23,7 +23,11 @@ port = 8088
 # auth_token = "env:SSHMCP_WEBUI_TOKEN"  # required when host is non-loopback
 
 [approval]
-mode = "manual"
+# The approval-engine lane can run standalone before the WebUI approval
+# resolver lands. Keep the copy-paste example bootable with WebUI disabled;
+# switch to mode = "manual" only when [webui].enabled = true (or --webui) and
+# a resolver is wired.
+mode = "yolo"
 fail_closed = true
 
 [approval.llm]

--- a/test/approval/audit-seam.test.ts
+++ b/test/approval/audit-seam.test.ts
@@ -9,8 +9,8 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 
-import { isOptionalAuditStoreMissing, loadAuditSink } from '../audit-seam.js';
-import type { ApprovalDecision } from '../types.js';
+import { isOptionalAuditStoreMissing, loadAuditSink } from '../../src/approval/audit-seam.js';
+import type { ApprovalDecision } from '../../src/approval/types.js';
 
 describe('optional audit seam', () => {
   it('loadAuditSink resolves to a usable sink even when src/audit/ is absent', async () => {
@@ -79,6 +79,43 @@ describe('optional audit seam', () => {
       decided_by: 'approval:not-run',
     });
     expect(appended.approval.reason).toContain('approval gate was not reached');
+  });
+
+  it('preserves mapper error context when a failed ExecResult is audited', async () => {
+    let appended: any;
+    const approval: ApprovalDecision = {
+      decision: 'allow',
+      reason: 'manual approved',
+      decided_by: 'user',
+      decided_at: new Date().toISOString(),
+      mode: 'manual',
+    };
+    const sink = await loadAuditSink({}, async () => ({
+      resolveAuditDir: () => '/tmp/ssh-mcp-audit-test',
+      AuditStore: class {
+        append(record: unknown): unknown {
+          appended = record;
+          return record;
+        }
+      },
+    }));
+
+    sink.record({
+      tool: 'exec',
+      profile: 'default',
+      command: 'false',
+      startedAt: Date.now(),
+      result: { stdout: '', stderr: '', exitCode: 7 },
+      error: new Error('Error (code 7):\nCommand exited with status 7'),
+      approval,
+    });
+
+    expect(appended.exec).toMatchObject({
+      stdout: '',
+      exitCode: 7,
+    });
+    expect(appended.exec.stderr).toContain('execution error:');
+    expect(appended.exec.stderr).toContain('Command exited with status 7');
   });
 
   it('classifies only the optional store module itself as absent', () => {

--- a/test/approval/audit-seam.test.ts
+++ b/test/approval/audit-seam.test.ts
@@ -53,7 +53,7 @@ describe('optional audit seam', () => {
     ).not.toThrow();
   });
 
-  it('uses an explicit not-run marker instead of yolo allow when no approval decision exists', async () => {
+  it('preserves the configured mode in the not-run marker when no approval decision exists', async () => {
     let appended: any;
     const sink = await loadAuditSink({}, async () => ({
       resolveAuditDir: () => '/tmp/ssh-mcp-audit-test',
@@ -71,10 +71,11 @@ describe('optional audit seam', () => {
       command: 'uptime',
       startedAt: Date.now(),
       error: new Error('transport init failed before approval'),
+      approvalMode: 'smart',
     });
 
     expect(appended.approval).toMatchObject({
-      mode: 'manual',
+      mode: 'smart',
       decision: 'deny',
       decided_by: 'approval:not-run',
     });
@@ -148,6 +149,43 @@ describe('optional audit seam', () => {
       const sink = await loadAuditSink({}, async () => { throw err; });
       expect(typeof sink.record).toBe('function');
       expect(spy).toHaveBeenCalledWith(expect.stringContaining('audit module present but failed to load'));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it.each([
+    ['missing resolveAuditDir', {
+      AuditStore: class { append(): void {} },
+    }],
+    ['throwing resolveAuditDir', {
+      resolveAuditDir: () => { throw new Error('bad audit dir'); },
+      AuditStore: class { append(): void {} },
+    }],
+    ['throwing AuditStore constructor', {
+      resolveAuditDir: () => '/tmp/ssh-mcp-audit-test',
+      AuditStore: class { constructor() { throw new Error('store init failed'); } },
+    }],
+    ['store without append', {
+      resolveAuditDir: () => '/tmp/ssh-mcp-audit-test',
+      AuditStore: class {},
+    }],
+  ])('degrades an invalid audit module/store shape to a no-op: %s', async (_label, moduleShape) => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const sink = await loadAuditSink({}, async () => moduleShape);
+      expect(typeof sink.record).toBe('function');
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('audit module present but failed to initialize'),
+      );
+      expect(() => sink.record({
+        tool: 'exec',
+        profile: 'default',
+        command: 'uptime',
+        startedAt: Date.now(),
+        error: new Error('pre-gate failure'),
+        approvalMode: 'yolo',
+      })).not.toThrow();
     } finally {
       spy.mockRestore();
     }

--- a/test/bootstrap-connection-policy.unit.test.ts
+++ b/test/bootstrap-connection-policy.unit.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ISshTransport, ServerConfig } from '../src/transports/types';
+import type { ResolvedConfig } from '../src/config/types';
+
+// Mock the transport factory so a successful get() never opens a real SSH
+// connection. We only care about WHICH name resolveName() lands on and whether
+// the multi-source omit-name guard fires.
+const { createTransportMock } = vi.hoisted(() => ({ createTransportMock: vi.fn() }));
+vi.mock('../src/transports/factory.js', () => ({ createTransport: createTransportMock }));
+
+import { TransportRegistry } from '../src/transports/registry';
+import { applyRegistryConnectionPolicy } from '../src/index';
+
+function makeConfig(name: string): ServerConfig {
+  return { name, host: `${name}.example`, port: 22, username: 'u', transport: 'ssh2', authMode: 'password', password: 'pw' };
+}
+
+function stub(): ISshTransport {
+  return {
+    name: 'ssh2',
+    init: vi.fn().mockResolvedValue(undefined),
+    exec: vi.fn(),
+    execElevated: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ISshTransport;
+}
+
+/**
+ * Build a registry with the given source names registered, then apply the real
+ * boot-time connection policy from a ResolvedConfig-shaped object. This is the
+ * exact composition bootstrapRegistry() performs in src/index.ts, minus the
+ * SSH/key side effects — so it pins the security contract end-to-end.
+ *
+ * `requireConnection` is attached via cast so this test compiles on the base
+ * branch (whose ResolvedConfig predates the field — the helper reads it
+ * defensively) and stays valid once the field lands downstream.
+ */
+function bootstrap(
+  names: string[],
+  policy: { defaultName?: string; defaultExplicit: boolean; requireConnection?: boolean },
+): TransportRegistry {
+  const r = new TransportRegistry();
+  const sources = names.map(makeConfig);
+  for (const c of sources) r.register(c);
+  const config = {
+    sources,
+    perSourceApproval: {},
+    defaultName: policy.defaultName,
+    defaultExplicit: policy.defaultExplicit,
+    ...(policy.requireConnection !== undefined
+      ? { requireConnection: policy.requireConnection }
+      : {}),
+  } as ResolvedConfig;
+  applyRegistryConnectionPolicy(r, config);
+  return r;
+}
+
+describe('applyRegistryConnectionPolicy — boot-time connection guard wiring', () => {
+  // A1 (headline fix): multi-source, NO explicit default, omit name → throws.
+  it('A1: multi-source + no explicit default + omitted name THROWS', async () => {
+    const r = bootstrap(['a', 'b'], { defaultName: 'a', defaultExplicit: false });
+    await expect(r.get()).rejects.toThrow(
+      /connectionName is required when multiple servers are configured: a, b/,
+    );
+  });
+
+  // A2: multi-source WITH an explicit user-chosen default, omit name → routes
+  // to that default, no throw.
+  it('A2: multi-source + explicit default + omitted name routes to the default (no throw)', async () => {
+    const s = stub();
+    createTransportMock.mockReturnValue(s);
+    const r = bootstrap(['a', 'b'], { defaultName: 'b', defaultExplicit: true });
+    await expect(r.get()).resolves.toBe(s);
+    expect(r.getDefaultName()).toBe('b');
+  });
+
+  // A3: single-source, omit name → routes to it, no throw (unchanged behavior).
+  it('A3: single-source + omitted name routes to the lone source (no throw)', async () => {
+    const s = stub();
+    createTransportMock.mockReturnValue(s);
+    const r = bootstrap(['solo'], { defaultName: 'solo', defaultExplicit: false });
+    await expect(r.get()).resolves.toBe(s);
+  });
+
+  // A4: require_connection = false (opt-out), multi-source + omit → guard
+  // disabled, routes to first/default, no throw.
+  it('A4: require_connection=false opt-out disables the guard (multi-source omit routes to first)', async () => {
+    const s = stub();
+    createTransportMock.mockReturnValue(s);
+    const r = bootstrap(['a', 'b'], {
+      defaultName: 'a',
+      defaultExplicit: false,
+      requireConnection: false,
+    });
+    await expect(r.get()).resolves.toBe(s);
+  });
+
+  // A5: require_connection = true (or absent), multi-source + omit, no explicit
+  // default → throws (safe default posture).
+  it('A5a: require_connection=true (explicit) + multi-source + no default + omit THROWS', async () => {
+    const r = bootstrap(['a', 'b'], {
+      defaultName: 'a',
+      defaultExplicit: false,
+      requireConnection: true,
+    });
+    await expect(r.get()).rejects.toThrow(/connectionName is required/);
+  });
+
+  it('A5b: require_connection ABSENT defaults to safe (multi-source + no default + omit THROWS)', async () => {
+    // Mirrors the older ResolvedConfig shape that carries no requireConnection
+    // field — the policy helper must default to guard ON.
+    const r = bootstrap(['a', 'b'], { defaultName: 'a', defaultExplicit: false });
+    await expect(r.get()).rejects.toThrow(/connectionName is required/);
+  });
+
+  // Cross-check: an explicit name always resolves regardless of guard state.
+  it('explicit connectionName resolves under every policy', async () => {
+    const s = stub();
+    createTransportMock.mockReturnValue(s);
+    const guarded = bootstrap(['a', 'b'], { defaultName: 'a', defaultExplicit: false });
+    await expect(guarded.get('b')).resolves.toBe(s);
+  });
+});

--- a/test/config/resolver.test.ts
+++ b/test/config/resolver.test.ts
@@ -120,6 +120,42 @@ audit_dir = "~/audit-only"
     expect(cfg.configPath).toBe(p);
   });
 
+  it('does not inherit require_connection=false from auto-discovered TOML for CLI sources', () => {
+    const xdgRoot = path.join(tmp, 'xdg-cli-guard');
+    const discovered = writeToml(xdgRoot, 'ssh-mcp/config.toml', `
+[server]
+require_connection = false
+
+[[sources]]
+id = "stale-toml"
+host = "stale.example"
+user = "u"
+auth = "kerberos"
+`);
+    const cfg = resolveConfig({
+      cliSources: [cliSource('a'), cliSource('b')],
+      env: { XDG_CONFIG_HOME: xdgRoot },
+    });
+    expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
+    expect(cfg.configPath).toBe(discovered);
+    expect(cfg.server?.require_connection).toBe(false);
+    expect(cfg.requireConnection).toBeUndefined();
+  });
+
+  it('honors require_connection=false from an explicit --config with CLI sources', () => {
+    const p = writeToml(tmp, 'explicit-cli-optout.toml', `
+[server]
+require_connection = false
+`);
+    const cfg = resolveConfig({
+      cliSources: [cliSource('a'), cliSource('b')],
+      cliConfigPath: p,
+      env: {},
+    });
+    expect(cfg.sources.map(s => s.name)).toEqual(['a', 'b']);
+    expect(cfg.requireConnection).toBe(false);
+  });
+
   it('still rejects a TOML with no [[sources]] when there are NO CLI sources', () => {
     // Without CLI sources the empty-sources tolerance must NOT apply — an
     // otherwise-empty config is a user error.

--- a/test/config/resolver.test.ts
+++ b/test/config/resolver.test.ts
@@ -164,6 +164,24 @@ auth = "kerberos"
     expect(cfg.configPath).toBe(envPath);
   });
 
+  it('fails closed when SSH_MCP_CONFIG points to a directory instead of falling through (Codex 3551117478)', () => {
+    const envDir = path.join(tmp, 'env-config-dir');
+    fs.mkdirSync(envDir, { recursive: true });
+    const xdgRoot = path.join(tmp, 'xdg-readable');
+    writeToml(xdgRoot, 'ssh-mcp/config.toml', `
+[[sources]]
+id = "xdg"
+host = "xdg.example"
+user = "u"
+auth = "kerberos"
+`);
+
+    expect(() => resolveConfig({
+      cliSources: [],
+      env: { SSH_MCP_CONFIG: envDir, XDG_CONFIG_HOME: xdgRoot },
+    })).toThrow(/not a regular file|cannot access/);
+  });
+
   it('fails closed when SSH_MCP_CONFIG is inaccessible instead of falling through (Codex 3549260453)', () => {
     const blockedDir = path.join(tmp, 'blocked');
     fs.mkdirSync(blockedDir, { recursive: true });

--- a/test/config/resolver.test.ts
+++ b/test/config/resolver.test.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { resolveConfig } from '../resolver.js';
-import type { ServerConfig } from '../../transports/types.js';
+import { resolveConfig } from '../../src/config/resolver.js';
+import type { ServerConfig } from '../../src/transports/types.js';
 
 function cliSource(name = 'cli'): ServerConfig {
   return {
@@ -162,6 +162,36 @@ auth = "kerberos"
     const cfg = resolveConfig({ cliSources: [], env: { SSH_MCP_CONFIG: envPath } });
     expect(cfg.sources[0].name).toBe('env');
     expect(cfg.configPath).toBe(envPath);
+  });
+
+  it('fails closed when SSH_MCP_CONFIG is inaccessible instead of falling through (Codex 3549260453)', () => {
+    const blockedDir = path.join(tmp, 'blocked');
+    fs.mkdirSync(blockedDir, { recursive: true });
+    const blockedPath = writeToml(blockedDir, 'config.toml', `
+[[sources]]
+id = "blocked"
+host = "blocked.example"
+user = "u"
+auth = "kerberos"
+`);
+    const xdgRoot = path.join(tmp, 'xdg-readable');
+    writeToml(xdgRoot, 'ssh-mcp/config.toml', `
+[[sources]]
+id = "xdg"
+host = "xdg.example"
+user = "u"
+auth = "kerberos"
+`);
+
+    fs.chmodSync(blockedDir, 0o000);
+    try {
+      expect(() => resolveConfig({
+        cliSources: [],
+        env: { SSH_MCP_CONFIG: blockedPath, XDG_CONFIG_HOME: xdgRoot },
+      })).toThrow(/cannot access|cannot read|EACCES|permission/i);
+    } finally {
+      fs.chmodSync(blockedDir, 0o700);
+    }
   });
 
   it('a set-but-missing SSH_MCP_CONFIG falls through to XDG discovery instead of hard-failing', () => {

--- a/test/config/toml-loader.test.ts
+++ b/test/config/toml-loader.test.ts
@@ -500,6 +500,33 @@ timeout_ms = 1234
     expect(cfg.approval?.llm?.timeout_ms).toBe(1234);
   });
 
+  it('rejects a scalar top-level approval value instead of enabling manual mode', () => {
+    expect(() => parseTomlConfig(`
+approval = "yolo"
+
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+`)).toThrow(/\[approval\] must be a table/);
+  });
+
+  it.each([
+    ['server', 'server = "invalid"'],
+    ['webui', 'webui = false'],
+  ])('rejects a scalar top-level %s value instead of silently ignoring it', (section, assignment) => {
+    expect(() => parseTomlConfig(`
+${assignment}
+
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+`)).toThrow(new RegExp(`\\[${section}\\] must be a table`));
+  });
+
   it('parses per-source approval override', () => {
     const cfg = parseTomlConfig(`
 [[sources]]

--- a/test/config/toml-loader.test.ts
+++ b/test/config/toml-loader.test.ts
@@ -9,7 +9,7 @@ import {
   expandHome,
   resolveEnvRef,
   defaultDiscoveryPaths,
-} from '../toml-loader.js';
+} from '../../src/config/toml-loader.js';
 
 describe('expandHome', () => {
   it('expands a leading ~ alone', () => {
@@ -172,6 +172,25 @@ password = "env:NOT_SET"
 });
 
 describe('parseTomlConfig: validation', () => {
+  it('redacts secret assignment lines from TOML parser errors (Codex 3549260449)', () => {
+    try {
+      parseTomlConfig(`
+[[sources]]
+id = "p"
+host = "h"
+user = "u"
+auth = "password"
+password = "super-secret-value
+`);
+      throw new Error('should have thrown');
+    } catch (e: any) {
+      expect(e.message).toMatch(/TOML parse failed/);
+      expect(e.message).toContain('password');
+      expect(e.message).toContain('[REDACTED]');
+      expect(e.message).not.toContain('super-secret-value');
+    }
+  });
+
   it('rejects empty source list', () => {
     expect(() => parseTomlConfig(`[server]\naudit_dir = "/tmp"`)).toThrow(/sources/);
   });
@@ -424,6 +443,19 @@ mode = "yolo"
     // object exists (it is always initialized to `{}`).
     expect(cfg.perSourceApproval).toEqual({ x: 'yolo' });
   });
+
+  it('rejects an empty per-source approval override mode (Codex 3549260472)', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[sources.approval]
+mode = ""
+`)).toThrow(/sources\.x\.approval\.mode must be one of/);
+  });
 });
 
 describe('parseTomlConfig: [server].require_connection wiring', () => {
@@ -568,6 +600,17 @@ key_path = "/k"
 `);
     expect(cfg.sources[0].keyPath).toBe('/k');
     expect(cfg.sources[0].transport).toBe('openssh');
+  });
+
+  it('rejects an unquoted numeric key_path before home expansion (Codex 3549260462)', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+key_path = 123
+`)).toThrow(/key_path must be a quoted string/);
   });
 
   it('still accepts inline private_key on the ssh2 transport', () => {

--- a/test/config/toml-loader.test.ts
+++ b/test/config/toml-loader.test.ts
@@ -254,6 +254,17 @@ auth = "bogus"
 `)).toThrow(/auth/);
   });
 
+  it('rejects a non-string source description instead of silently dropping it', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+description = 123
+`)).toThrow(/sources\.x\.description must be a quoted string/);
+  });
+
   it('rejects key auth with no key_path or private_key', () => {
     expect(() => parseTomlConfig(`
 [[sources]]

--- a/test/config/toml-loader.test.ts
+++ b/test/config/toml-loader.test.ts
@@ -9,6 +9,7 @@ import {
   expandHome,
   resolveEnvRef,
   defaultDiscoveryPaths,
+  discoverConfigPath,
 } from '../../src/config/toml-loader.js';
 
 describe('expandHome', () => {
@@ -63,6 +64,24 @@ describe('defaultDiscoveryPaths', () => {
     const paths = defaultDiscoveryPaths({ XDG_CONFIG_HOME: '/x/conf' });
     expect(paths).toContain('/x/conf/ssh-mcp/config.toml');
     expect(paths[paths.length - 1].endsWith(path.join('.ssh-mcp', 'config.toml'))).toBe(true);
+  });
+
+  it('rejects a non-file SSH_MCP_CONFIG instead of falling through (Codex 3551117478)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-mcp-discover-'));
+    try {
+      const envDir = path.join(tmp, 'env-config-dir');
+      const xdgRoot = path.join(tmp, 'xdg');
+      fs.mkdirSync(envDir, { recursive: true });
+      fs.mkdirSync(path.join(xdgRoot, 'ssh-mcp'), { recursive: true });
+      fs.writeFileSync(path.join(xdgRoot, 'ssh-mcp', 'config.toml'), '[[sources]]\n');
+
+      expect(() => discoverConfigPath({
+        SSH_MCP_CONFIG: envDir,
+        XDG_CONFIG_HOME: xdgRoot,
+      })).toThrow(/not a regular file|cannot access/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });
 
@@ -366,6 +385,38 @@ port = 8080
     expect(cfg.webui?.auth_token).toBeUndefined();
   });
 
+  it('does NOT resolve auth_token env refs when webui is disabled (Codex 3551117490)', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[webui]
+enabled = false
+host = "0.0.0.0"
+auth_token = "env:WEBUI_TOKEN_UNSET"
+`, { env: {} });
+    expect(cfg.webui?.enabled).toBe(false);
+    expect(cfg.webui?.auth_token).toBeUndefined();
+  });
+
+  it('still resolves auth_token env refs when webui is enabled', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[webui]
+enabled = true
+host = "127.0.0.1"
+auth_token = "env:WEBUI_TOKEN_UNSET"
+`, { env: {} })).toThrow(/WEBUI_TOKEN_UNSET/);
+  });
+
   it('does NOT require auth_token for a non-loopback webui with enabled omitted (defaults off)', () => {
     // [webui] with a host but no `enabled` key is off by default, so the token
     // gate must not fire.
@@ -562,6 +613,17 @@ strict_host_key_checking = "accept-new"
     expect(cfg.sources[0].strictHostKeyChecking).toBe('accept-new');
   });
 
+  it('rejects an unquoted numeric known_hosts_file before home expansion (Codex 3551117485)', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u@EX"
+auth = "kerberos"
+known_hosts_file = 123
+`)).toThrow(/known_hosts_file must be a quoted string/);
+  });
+
   it('accepts host-key fields on a kerberos source (implies openssh)', () => {
     const cfg = parseTomlConfig(`
 [[sources]]
@@ -600,6 +662,39 @@ key_path = "/k"
 `);
     expect(cfg.sources[0].keyPath).toBe('/k');
     expect(cfg.sources[0].transport).toBe('openssh');
+  });
+
+  it('ignores unsupported openssh private_key env refs when key_path is present (Codex 3551117493)', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+transport = "openssh"
+key_path = "/k"
+private_key = "env:SSH_KEY_UNSET"
+`, { env: {} });
+    expect(cfg.sources[0].keyPath).toBe('/k');
+    expect(cfg.sources[0].privateKey).toBeUndefined();
+  });
+
+  it('reports the openssh key_path requirement before resolving unsupported private_key env refs', () => {
+    try {
+      parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+transport = "openssh"
+private_key = "env:SSH_KEY_UNSET"
+`, { env: {} });
+      throw new Error('should have thrown');
+    } catch (e: any) {
+      expect(e.message).toMatch(/requires key_path/);
+      expect(e.message).not.toContain('SSH_KEY_UNSET');
+    }
   });
 
   it('rejects an unquoted numeric key_path before home expansion (Codex 3549260462)', () => {
@@ -677,6 +772,31 @@ password = 987654
       expect(e.message).toContain('sources.p.password');
       expect(e.message).not.toContain('987654');
     }
+  });
+
+  it('does not resolve inactive password env refs on key or kerberos sources (Codex 3551117501)', () => {
+    const keyCfg = parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u"
+auth = "key"
+key_path = "/k"
+password = "env:PASSWORD_UNSET"
+`, { env: {} });
+    expect(keyCfg.sources[0].authMode).toBe('key');
+    expect(keyCfg.sources[0].password).toBeUndefined();
+
+    const kerberosCfg = parseTomlConfig(`
+[[sources]]
+id = "krb"
+host = "h"
+user = "u@EX"
+auth = "kerberos"
+password = "env:PASSWORD_UNSET"
+`, { env: {} });
+    expect(kerberosCfg.sources[0].authMode).toBe('kerberos');
+    expect(kerberosCfg.sources[0].password).toBeUndefined();
   });
 
   it('allowEmptySources tolerates a TOML with only top-level sections', () => {

--- a/test/config/toml-loader.test.ts
+++ b/test/config/toml-loader.test.ts
@@ -175,6 +175,20 @@ sudo_password = "env:LAB_SUDO"
     expect(cfg.sources[0].sudoPassword).toBe('secret-sudo');
   });
 
+  it('treats an empty TOML sudo_password as unset instead of feeding blank sudo stdin (Codex 3551304734)', () => {
+    const cfg = parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+sudo_password = ""
+su_password = "root-pw"
+`);
+    expect(cfg.sources[0].sudoPassword).toBeUndefined();
+    expect(cfg.sources[0].suPassword).toBe('root-pw');
+  });
+
   it('errors when env var missing', () => {
     expect(() => parseTomlConfig(
       `
@@ -950,6 +964,38 @@ mode = "smart"
 api_key = "env:KEY"
 `, { env: { KEY: 'sk-xyz' } });
     expect(cfg.approval?.llm?.api_key).toBe('sk-xyz');
+  });
+
+  it('rejects a non-string smart approval api_key instead of coercing it (Codex 3551304740)', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[approval]
+mode = "smart"
+
+[approval.llm]
+api_key = 123
+`)).toThrow(/api_key must be a string/);
+  });
+
+  it('rejects array-shaped smart approval api_key env refs instead of coercing them (Codex 3551304740)', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "x"
+host = "h"
+user = "u"
+auth = "kerberos"
+
+[approval]
+mode = "smart"
+
+[approval.llm]
+api_key = ["env:KEY"]
+`, { env: { KEY: 'sk-xyz' } })).toThrow(/api_key must be a string/);
   });
 
   // Finding: ignoreSources skips validating suppressed [[sources]] entirely.

--- a/test/config/toml-loader.test.ts
+++ b/test/config/toml-loader.test.ts
@@ -638,6 +638,17 @@ known_hosts_file = 123
 `)).toThrow(/known_hosts_file must be a quoted string/);
   });
 
+  it('rejects an empty known_hosts_file instead of silently dropping host-key pinning', () => {
+    expect(() => parseTomlConfig(`
+[[sources]]
+id = "k"
+host = "h"
+user = "u@EX"
+auth = "kerberos"
+known_hosts_file = ""
+`)).toThrow(/known_hosts_file must be a non-empty string/);
+  });
+
   it('accepts host-key fields on a kerberos source (implies openssh)', () => {
     const cfg = parseTomlConfig(`
 [[sources]]

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -10,10 +10,13 @@ import {
   hasLegacyCliFlags,
   buildApprovalProfile,
   appendDescriptionComment,
+  resolveApprovalEngineInput,
+  approvalResolverWarningFromInput,
   validateConfig,
   resolveCliConfigPath,
 } from '../src/index';
 import type { ExecResult } from '../src/transports/types';
+import type { ResolvedConfig } from '../src/config/types';
 
 // Pure-function unit tests for the CLI config/result mapping layer. These
 // import from src/index, which is safe because the test runner sets
@@ -191,6 +194,13 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
 });
 
 describe('approval command/context helpers', () => {
+  const resolvedConfig = (partial: Partial<ResolvedConfig> = {}): ResolvedConfig => ({
+    sources: [],
+    perSourceApproval: {},
+    defaultExplicit: false,
+    ...partial,
+  });
+
   it('threads per-source approval mode and source description into the approval profile', () => {
     const profile = buildApprovalProfile(
       'prod',
@@ -215,6 +225,37 @@ describe('approval command/context helpers', () => {
     expect(assembled).toMatch(/^true # /);
     expect(assembled).toContain('rm -rf /tmp/should-not-run');
     expect(assembled).not.toMatch(/[\r\n]/);
+  });
+
+  it('treats no [approval] and no per-source overrides as approval inactive', () => {
+    const input = resolveApprovalEngineInput(resolvedConfig());
+    expect(input).toBeNull();
+    expect(approvalResolverWarningFromInput(input, {
+      webuiEnabled: true,
+      resolverWired: false,
+    })).toBeNull();
+  });
+
+  it('uses yolo as the default only for per-source-only approval configs', () => {
+    expect(resolveApprovalEngineInput(resolvedConfig({
+      perSourceApproval: { lab: 'manual' },
+    }))?.defaultMode).toBe('yolo');
+  });
+
+  it('keeps yolo default for [approval.llm]-only configs that support per-source smart', () => {
+    expect(resolveApprovalEngineInput(resolvedConfig({
+      approval: { llm: { endpoint: 'https://api.example/v1/c', model: 'm-1', api_key: 'sk-test' } },
+      perSourceApproval: { lab: 'smart' },
+    }))?.defaultMode).toBe('yolo');
+  });
+
+  it('preserves the documented manual default when a top-level approval option is configured', () => {
+    const input = resolveApprovalEngineInput(resolvedConfig({
+      approval: { fail_closed: true },
+      perSourceApproval: { lab: 'yolo' },
+    }));
+    expect(input?.defaultMode).toBeUndefined();
+    expect(input?.fail_closed).toBe(true);
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -8,6 +8,8 @@ import {
   resolveAuthMode,
   buildTransportConfig,
   hasLegacyCliFlags,
+  buildApprovalProfile,
+  appendDescriptionComment,
 } from '../src/index';
 import type { ExecResult } from '../src/transports/types';
 
@@ -122,6 +124,34 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
     expect(cfg.transport).toBe('openssh');
     expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
     expect(cfg.privateKey).toBeUndefined();
+  });
+});
+
+describe('approval command/context helpers', () => {
+  it('threads per-source approval mode and source description into the approval profile', () => {
+    const profile = buildApprovalProfile(
+      'prod',
+      { prod: 'manual' },
+      { description: 'production host; maintenance window required' },
+    );
+
+    expect(profile).toEqual({
+      id: 'prod',
+      description: 'production host; maintenance window required',
+      approval: { mode: 'manual' },
+    });
+  });
+
+  it('does not leak another source approval mode into the default profile', () => {
+    const profile = buildApprovalProfile('default', { prod: 'smart' });
+    expect(profile).toEqual({ id: 'default' });
+  });
+
+  it('neutralizes description newlines before appending the shell comment', () => {
+    const assembled = appendDescriptionComment('true', 'safe note\nrm -rf /tmp/should-not-run # nested');
+    expect(assembled).toMatch(/^true # /);
+    expect(assembled).toContain('rm -rf /tmp/should-not-run');
+    expect(assembled).not.toMatch(/[\r\n]/);
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -8,6 +8,7 @@ import {
   resolveAuthMode,
   buildTransportConfig,
   getOrCreateInitializedTransport,
+  validateConfig,
 } from '../src/index';
 import type { ExecResult, ISshTransport } from '../src/transports/types';
 
@@ -86,6 +87,35 @@ describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
         resultToMcpContent({ stdout: '', stderr: 'x', exitCode: 0, category }),
       ).toThrow(McpError);
     }
+  });
+
+  it('preserves the timeout context even when stderr was written before the deadline', () => {
+    // A build/tool that prints progress or diagnostics to stderr and then hangs
+    // must NOT be reported as an ordinary error that hides the timeout; the
+    // timeout message stays, with stderr kept as trailing context.
+    let caught: unknown;
+    try {
+      resultToMcpContent({
+        stdout: '',
+        stderr: 'Building... step 3/9\nlinking objects',
+        exitCode: null,
+        category: 'timeout',
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(McpError);
+    const msg = (caught as McpError).message;
+    expect(msg).toMatch(/timed out after \d+ms/);
+    // stderr diagnostics are retained as context, not dropped.
+    expect(msg).toContain('Building... step 3/9');
+    expect(msg).toContain('linking objects');
+  });
+
+  it('reports a bare timeout message when no stderr was captured', () => {
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: '', exitCode: null, category: 'timeout' }),
+    ).toThrow(/timed out after \d+ms/);
   });
 });
 
@@ -205,5 +235,51 @@ describe('getOrCreateInitializedTransport (Codex P2: do not publish before init 
     await expect(getOrCreateInitializedTransport(cache, createInitializedTransport)).resolves.toMatchObject({ name: 'openssh' });
     expect(createInitializedTransport).toHaveBeenCalledTimes(2);
     expect(cache.activeTransport?.name).toBe('openssh');
+  });
+});
+
+describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', () => {
+  const baseCfg = { host: 'h', user: 'u', transport: 'openssh' };
+
+  it('rejects a value-less --strictHostKeyChecking (parsed as null) instead of silently defaulting', () => {
+    // parseArgv records `null` for `--strictHostKeyChecking` with no `=value`.
+    // A truthiness guard would skip validation and let the option be dropped,
+    // silently weakening the host-key policy to the default.
+    expect(() =>
+      validateConfig({ ...baseCfg, strictHostKeyChecking: null }),
+    ).toThrow(/--strictHostKeyChecking must be one of: yes, no, accept-new/);
+  });
+
+  it('rejects a value-less --gssapiDelegateCredentials (parsed as null)', () => {
+    expect(() =>
+      validateConfig({ ...baseCfg, gssapiDelegateCredentials: null }),
+    ).toThrow(/--gssapiDelegateCredentials must be yes or no/);
+  });
+
+  it('rejects a value-less --knownHostsFile (parsed as null)', () => {
+    expect(() =>
+      validateConfig({ ...baseCfg, knownHostsFile: null }),
+    ).toThrow(/--knownHostsFile requires a file path/);
+  });
+
+  it('rejects an invalid explicit --strictHostKeyChecking value', () => {
+    expect(() =>
+      validateConfig({ ...baseCfg, strictHostKeyChecking: 'maybe' }),
+    ).toThrow(/--strictHostKeyChecking must be one of/);
+  });
+
+  it('accepts valid explicit OpenSSH option values', () => {
+    expect(() =>
+      validateConfig({
+        ...baseCfg,
+        strictHostKeyChecking: 'yes',
+        gssapiDelegateCredentials: 'no',
+        knownHostsFile: '/etc/ssh/known_hosts',
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not require OpenSSH option values when the flags are absent', () => {
+    expect(() => validateConfig({ ...baseCfg })).not.toThrow();
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -7,6 +7,7 @@ import {
   resultToMcpContent,
   resolveAuthMode,
   buildTransportConfig,
+  hasLegacyCliFlags,
 } from '../src/index';
 import type { ExecResult } from '../src/transports/types';
 
@@ -121,5 +122,28 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
     expect(cfg.transport).toBe('openssh');
     expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
     expect(cfg.privateKey).toBeUndefined();
+  });
+});
+
+describe('hasLegacyCliFlags (finding 2: --disableSudo is not a legacy trigger)', () => {
+  it('returns false for --disableSudo alone (valid in --config / --ssh modes)', () => {
+    // --disableSudo only controls sudo-tool registration and is allowed in
+    // every mode. It must NOT force the legacy single-host validation branch
+    // (which would demand --host/--user). Regression guard for
+    // `ssh-mcp --config cfg.toml --disableSudo`.
+    expect(hasLegacyCliFlags({ disableSudo: null })).toBe(false);
+  });
+
+  it('still returns true for a genuine legacy flag like --host', () => {
+    expect(hasLegacyCliFlags({ host: 'h' })).toBe(true);
+  });
+
+  it('still returns true for --port (single-host-only flag)', () => {
+    expect(hasLegacyCliFlags({ port: '2222' })).toBe(true);
+  });
+
+  it('returns false for an empty / config-only argv', () => {
+    expect(hasLegacyCliFlags({})).toBe(false);
+    expect(hasLegacyCliFlags({ config: '/etc/ssh-mcp/config.toml' })).toBe(false);
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -371,6 +371,11 @@ describe('resolveCliConfigPath (Codex R2 P2: reject value-less --config)', () =>
       .toBe('/etc/ssh-mcp/config.toml');
   });
 
+  it('expands a leading home marker for --config=~/... (Codex 3549260475)', () => {
+    expect(resolveCliConfigPath({ config: '~/ssh-mcp/config.toml' }))
+      .toBe(path.join(os.homedir(), 'ssh-mcp/config.toml'));
+  });
+
   it('rejects a present-but-value-less --config (parsed as null) instead of silently ignoring it', () => {
     // parseArgv records `null` for `--config` with no `=path`. Coercing that to
     // undefined would fall back to SSH_MCP_CONFIG/default discovery, so a

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -249,6 +249,9 @@ describe('prepareKeyContents (Codex 3549295046: skip deferred key reads when pas
       };
       await prepareKeyContents(cfg);
       expect(cfg.privateKey).toBe('KEYDATA');
+      await fs.writeFile(keyPath, 'ROTATED');
+      await prepareKeyContents(cfg);
+      expect(cfg.privateKey).toBe('ROTATED');
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -12,6 +12,7 @@ import {
   prepareKeyContents,
   validateConfig,
   resolveCliConfigPath,
+  validateSshCliFlag,
 } from '../src/index';
 import type { ExecResult, ServerConfig } from '../src/transports/types';
 
@@ -72,6 +73,40 @@ describe('CLI bootstrap validation order', () => {
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it('rejects bare --ssh before falling back to an auto-discovered TOML source', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-cli-bare-ssh-'));
+    const validToml = path.join(dir, 'config.toml');
+    await fs.writeFile(validToml, `
+[[sources]]
+id = "toml-fallback"
+host = "toml.example"
+user = "u"
+auth = "kerberos"
+`);
+    try {
+      const result = await runCliStartup(['--ssh'], {
+        SSH_MCP_CONFIG: validToml,
+        XDG_CONFIG_HOME: path.join(dir, 'xdg'),
+        HOME: dir,
+      });
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('--ssh requires a value (--ssh=<JSON>)');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('validateSshCliFlag', () => {
+  it('rejects the null marker produced by a bare --ssh', () => {
+    expect(() => validateSshCliFlag({ ssh: null }))
+      .toThrow(/--ssh requires a value/);
+  });
+
+  it('leaves absent --ssh handling to the selected legacy or TOML mode', () => {
+    expect(() => validateSshCliFlag({})).not.toThrow();
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -28,6 +28,28 @@ describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
     expect(out.content[0]).toEqual({ type: 'text', text: 'ok' });
   });
 
+  it('appends genuine stderr diagnostics on success (exit 0), filtering only the benign host-key warning', () => {
+    // Tools like git clone / curl / build systems write progress + warnings to
+    // stderr while still exiting 0; that output must reach the caller.
+    const out = resultToMcpContent({
+      stdout: 'cloned',
+      stderr: "Warning: Permanently added 'h' (ED25519) to the list of known hosts.\nCloning into 'repo'...\nReceiving objects: 100%",
+      exitCode: 0,
+      category: undefined,
+    });
+    expect(out.content[0].text).toBe("cloned\nCloning into 'repo'...\nReceiving objects: 100%");
+  });
+
+  it('returns only stdout when stderr is nothing but the benign host-key warning', () => {
+    const out = resultToMcpContent({
+      stdout: 'done',
+      stderr: "Warning: Permanently added '[h]:2222' (RSA) to the list of known hosts.",
+      exitCode: 0,
+      category: undefined,
+    });
+    expect(out.content[0].text).toBe('done');
+  });
+
   it('returns content for a plain success (exit 0, no stderr)', () => {
     const out = resultToMcpContent({ stdout: 'hello', stderr: '', exitCode: 0 });
     expect(out.content[0].text).toBe('hello');

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -9,6 +9,7 @@ import {
   buildTransportConfig,
   hasLegacyCliFlags,
   validateConfig,
+  resolveCliConfigPath,
 } from '../src/index';
 import type { ExecResult } from '../src/transports/types';
 
@@ -278,5 +279,25 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
     expect(() =>
       validateConfig({ host: 'h', user: 'u', kerberos: null, gssapiDelegateCredentials: 'yes' }),
     ).not.toThrow();
+  });
+});
+
+describe('resolveCliConfigPath (Codex R2 P2: reject value-less --config)', () => {
+  it('returns undefined when --config is absent', () => {
+    expect(resolveCliConfigPath({})).toBeUndefined();
+    expect(resolveCliConfigPath({ host: 'h', user: 'u' })).toBeUndefined();
+  });
+
+  it('returns the path for --config=<path>', () => {
+    expect(resolveCliConfigPath({ config: '/etc/ssh-mcp/config.toml' }))
+      .toBe('/etc/ssh-mcp/config.toml');
+  });
+
+  it('rejects a present-but-value-less --config (parsed as null) instead of silently ignoring it', () => {
+    // parseArgv records `null` for `--config` with no `=path`. Coercing that to
+    // undefined would fall back to SSH_MCP_CONFIG/default discovery, so a
+    // mistyped explicit flag could start against the wrong configured source.
+    expect(() => resolveCliConfigPath({ config: null }))
+      .toThrow(/--config requires a value/);
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -13,6 +13,7 @@ import {
   buildApprovalProfile,
   appendDescriptionComment,
   resolveApprovalEngineInput,
+  resolveConfiguredApprovalMode,
   approvalResolverWarningFromInput,
   isCliSwitchEnabled,
   prepareKeyContents,
@@ -321,6 +322,11 @@ describe('approval command/context helpers', () => {
     expect(profile).toEqual({ id: 'default' });
   });
 
+  it('does not treat inherited Object.prototype members as approval overrides', () => {
+    expect(buildApprovalProfile('constructor', {})).toEqual({ id: 'constructor' });
+    expect(buildApprovalProfile('toString', {})).toEqual({ id: 'toString' });
+  });
+
   it('neutralizes description newlines before appending the shell comment', () => {
     const assembled = appendDescriptionComment('true', 'safe note\nrm -rf /tmp/should-not-run # nested');
     expect(assembled).toMatch(/^true # /);
@@ -370,6 +376,18 @@ describe('approval command/context helpers', () => {
     }));
     expect(input?.defaultMode).toBeUndefined();
     expect(input?.fail_closed).toBe(true);
+  });
+
+  it('resolves the effective configured mode for audit failures before the gate decides', () => {
+    const config = resolvedConfig({
+      approval: { mode: 'smart' },
+      perSourceApproval: { lab: 'yolo' },
+    });
+
+    expect(resolveConfiguredApprovalMode('lab', config)).toBe('yolo');
+    expect(resolveConfiguredApprovalMode('unknown', config)).toBe('smart');
+    expect(resolveConfiguredApprovalMode('constructor', config)).toBe('smart');
+    expect(resolveConfiguredApprovalMode('legacy', resolvedConfig())).toBe('yolo');
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -7,9 +7,10 @@ import {
   resultToMcpContent,
   resolveAuthMode,
   buildTransportConfig,
+  prepareKeyContents,
   validateConfig,
 } from '../src/index';
-import type { ExecResult } from '../src/transports/types';
+import type { ExecResult, ServerConfig } from '../src/transports/types';
 
 // Pure-function unit tests for the CLI config/result mapping layer. These
 // import from src/index, which is safe because the test runner sets
@@ -213,6 +214,53 @@ describe('buildTransportConfig (Codex 3541767256: deferKeyRead keeps legacy key 
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('prepareKeyContents (Codex 3549295046: skip deferred key reads when password auth wins)', () => {
+  it('does NOT read a stale keyPath when the resolved authMode is password', async () => {
+    // The registry hook must mirror buildTransportConfig()'s eager-read guard:
+    // a `--password=... --key=/stale` config records keyPath but authMode is
+    // 'password', so the first tool call must use the password, not ENOENT on
+    // the stale/nonexistent key file.
+    const cfg: ServerConfig = {
+      name: 'n',
+      host: 'h',
+      port: 22,
+      username: 'u',
+      authMode: 'password',
+      transport: 'ssh2',
+      password: 'pw',
+      keyPath: '/nonexistent/path/to/stale-key',
+    };
+    await prepareKeyContents(cfg);
+    expect(cfg.privateKey).toBeUndefined();
+    expect(cfg.password).toBe('pw');
+  });
+
+  it('reads the ssh2 keyPath when the resolved authMode is key', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-test-'));
+    const keyPath = path.join(dir, 'id_test');
+    await fs.writeFile(keyPath, 'KEYDATA');
+    try {
+      const cfg: ServerConfig = {
+        name: 'n', host: 'h', port: 22, username: 'u',
+        authMode: 'key', transport: 'ssh2', keyPath,
+      };
+      await prepareKeyContents(cfg);
+      expect(cfg.privateKey).toBe('KEYDATA');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read the key for an openssh key config (uses -i path instead)', async () => {
+    const cfg: ServerConfig = {
+      name: 'n', host: 'h', port: 22, username: 'u',
+      authMode: 'key', transport: 'openssh', keyPath: '/nonexistent/path/to/key',
+    };
+    await prepareKeyContents(cfg);
+    expect(cfg.privateKey).toBeUndefined();
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -14,6 +14,7 @@ import {
   appendDescriptionComment,
   resolveApprovalEngineInput,
   approvalResolverWarningFromInput,
+  isCliSwitchEnabled,
   prepareKeyContents,
   validateConfig,
   resolveCliConfigPath,
@@ -312,6 +313,19 @@ describe('approval command/context helpers', () => {
       approval: { llm: { endpoint: 'https://api.example/v1/c', model: 'm-1', api_key: 'sk-test' } },
       perSourceApproval: { lab: 'smart' },
     }))?.defaultMode).toBe('yolo');
+  });
+
+  it('keeps [approval.llm]-only config inactive without a smart mode selection', () => {
+    expect(resolveApprovalEngineInput(resolvedConfig({
+      approval: { llm: { endpoint: 'https://api.example/v1/c', model: 'm-1' } },
+    }))).toBeNull();
+  });
+
+  it('parses --webui=false as disabled while preserving the bare flag', () => {
+    expect(isCliSwitchEnabled({ webui: 'false' }, 'webui')).toBe(false);
+    expect(isCliSwitchEnabled({ webui: 'FALSE' }, 'webui')).toBe(false);
+    expect(isCliSwitchEnabled({ webui: null }, 'webui')).toBe(true);
+    expect(isCliSwitchEnabled({}, 'webui')).toBe(false);
   });
 
   it('preserves the documented manual default when a top-level approval option is configured', () => {

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -14,6 +14,7 @@ import {
   appendDescriptionComment,
   resolveApprovalEngineInput,
   resolveConfiguredApprovalMode,
+  preResolutionProfileName,
   approvalResolverWarningFromInput,
   isCliSwitchEnabled,
   prepareKeyContents,
@@ -388,6 +389,12 @@ describe('approval command/context helpers', () => {
     expect(resolveConfiguredApprovalMode('unknown', config)).toBe('smart');
     expect(resolveConfiguredApprovalMode('constructor', config)).toBe('smart');
     expect(resolveConfiguredApprovalMode('legacy', resolvedConfig())).toBe('yolo');
+  });
+
+  it('keeps a whitespace connection name unresolved instead of attributing it to the default profile', () => {
+    expect(preResolutionProfileName('   ', 'prod', false)).toBe('   ');
+    expect(preResolutionProfileName('', 'prod', false)).toBe('prod');
+    expect(preResolutionProfileName(undefined, 'prod', true)).toBe('(unresolved)');
   });
 });
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -186,6 +186,36 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
   });
 });
 
+describe('buildTransportConfig (Codex 3541767256: deferKeyRead keeps legacy key reads lazy)', () => {
+  it('does NOT read the ssh2 key file at build time when deferKeyRead is set', async () => {
+    // The legacy single-host bootstrap passes deferKeyRead so startup never
+    // reads the key file — a key mounted after process launch must still work,
+    // matching the pre-registry behavior (read on first tool call, not startup).
+    const cfg = await buildTransportConfig(
+      { host: 'h', port: 22, username: 'u', key: '/nonexistent/path/to/key' },
+      { deferKeyRead: true },
+    );
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.authMode).toBe('key');
+    // keyPath is recorded so the registry's lazy prepareKeyContents can read it
+    // on first use, but the (nonexistent) file must NOT be read now.
+    expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
+    expect(cfg.privateKey).toBeUndefined();
+  });
+
+  it('still reads the ssh2 key eagerly when deferKeyRead is not set (default)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-test-'));
+    const keyPath = path.join(dir, 'id_test');
+    await fs.writeFile(keyPath, 'KEYDATA');
+    try {
+      const cfg = await buildTransportConfig({ host: 'h', port: 22, username: 'u', key: keyPath });
+      expect(cfg.privateKey).toBe('KEYDATA');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', () => {
   const baseCfg = { host: 'h', user: 'u', transport: 'openssh' };
 

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -252,7 +252,7 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
 
   it('rejects a value-less --gssapiDelegateCredentials (parsed as null)', () => {
     expect(() =>
-      validateConfig({ ...baseCfg, gssapiDelegateCredentials: null }),
+      validateConfig({ ...baseCfg, kerberos: null, gssapiDelegateCredentials: null }),
     ).toThrow(/--gssapiDelegateCredentials must be yes or no/);
   });
 
@@ -272,6 +272,7 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
     expect(() =>
       validateConfig({
         ...baseCfg,
+        kerberos: null, // --kerberos alone; required for gssapiDelegateCredentials
         strictHostKeyChecking: 'yes',
         gssapiDelegateCredentials: 'no',
         knownHostsFile: '/etc/ssh/known_hosts',
@@ -281,5 +282,29 @@ describe('validateConfig (Codex P2: reject value-less OpenSSH option flags)', ()
 
   it('does not require OpenSSH option values when the flags are absent', () => {
     expect(() => validateConfig({ ...baseCfg })).not.toThrow();
+  });
+
+  it('rejects a value-less --transport (parsed as null) instead of silently defaulting to ssh2', () => {
+    // parseArgv records `null` for `--transport` with no `=value`; the nullish
+    // fallback would treat it as absent and run the default ssh2 transport,
+    // silently ignoring a mistyped OpenSSH selection.
+    expect(() =>
+      validateConfig({ host: 'h', user: 'u', transport: null }),
+    ).toThrow(/--transport requires a value/);
+  });
+
+  it('rejects --gssapiDelegateCredentials without --kerberos (delegation would be silently dropped)', () => {
+    // buildArgs only emits GSSAPIDelegateCredentials in the kerberos auth
+    // branch, so accepting it without --kerberos would silently omit it and
+    // break second-hop SSO.
+    expect(() =>
+      validateConfig({ ...baseCfg, gssapiDelegateCredentials: 'yes' }),
+    ).toThrow(/--gssapiDelegateCredentials requires --kerberos/);
+  });
+
+  it('accepts --gssapiDelegateCredentials when --kerberos is present', () => {
+    expect(() =>
+      validateConfig({ host: 'h', user: 'u', kerberos: null, gssapiDelegateCredentials: 'yes' }),
+    ).not.toThrow();
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
@@ -7,8 +7,9 @@ import {
   resultToMcpContent,
   resolveAuthMode,
   buildTransportConfig,
+  getOrCreateInitializedTransport,
 } from '../src/index';
-import type { ExecResult } from '../src/transports/types';
+import type { ExecResult, ISshTransport } from '../src/transports/types';
 
 // Pure-function unit tests for the CLI config/result mapping layer. These
 // import from src/index, which is safe because the test runner sets
@@ -128,5 +129,59 @@ describe('buildTransportConfig (finding 2: no unconditional key read for passwor
     expect(cfg.transport).toBe('openssh');
     expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
     expect(cfg.privateKey).toBeUndefined();
+  });
+});
+
+describe('getOrCreateInitializedTransport (Codex P2: do not publish before init resolves)', () => {
+  function fakeTransport(): ISshTransport {
+    return {
+      name: 'openssh',
+      init: vi.fn(),
+      exec: vi.fn(),
+      execElevated: vi.fn(),
+      close: vi.fn(),
+    };
+  }
+
+  it('shares an in-flight initialization promise and publishes only after it resolves', async () => {
+    const cache = { activeTransport: null as ISshTransport | null, initPromise: null as Promise<ISshTransport> | null };
+    const transport = fakeTransport();
+    let resolveInit!: (value: ISshTransport) => void;
+    const createInitializedTransport = vi.fn(() => new Promise<ISshTransport>((resolve) => {
+      resolveInit = resolve;
+    }));
+
+    const p1 = getOrCreateInitializedTransport(cache, createInitializedTransport);
+    const p2 = getOrCreateInitializedTransport(cache, createInitializedTransport);
+
+    expect(createInitializedTransport).toHaveBeenCalledTimes(1);
+    expect(p2).toBe(p1);
+    // Critical regression guard: no half-initialized transport is visible while
+    // init is still pending, so concurrent OpenSSH/password calls cannot enter
+    // runSsh before SSH_ASKPASS exists.
+    expect(cache.activeTransport).toBeNull();
+    expect(cache.initPromise).toBe(p1);
+
+    resolveInit(transport);
+    await expect(p1).resolves.toBe(transport);
+    await expect(p2).resolves.toBe(transport);
+    expect(cache.activeTransport).toBe(transport);
+    expect(cache.initPromise).toBeNull();
+  });
+
+  it('clears the cached init promise after initialization failure so a retry can initialize', async () => {
+    const cache = { activeTransport: null as ISshTransport | null, initPromise: null as Promise<ISshTransport> | null };
+    const createInitializedTransport = vi
+      .fn<() => Promise<ISshTransport>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(fakeTransport());
+
+    await expect(getOrCreateInitializedTransport(cache, createInitializedTransport)).rejects.toThrow('boom');
+    expect(cache.activeTransport).toBeNull();
+    expect(cache.initPromise).toBeNull();
+
+    await expect(getOrCreateInitializedTransport(cache, createInitializedTransport)).resolves.toMatchObject({ name: 'openssh' });
+    expect(createInitializedTransport).toHaveBeenCalledTimes(2);
+    expect(cache.activeTransport?.name).toBe('openssh');
   });
 });

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  resultToMcpContent,
+  resolveAuthMode,
+  buildTransportConfig,
+} from '../src/index';
+import type { ExecResult } from '../src/transports/types';
+
+// Pure-function unit tests for the CLI config/result mapping layer. These
+// import from src/index, which is safe because the test runner sets
+// SSH_MCP_DISABLE_MAIN=1 (isCliEnabled=false) so no server/CLI side effects run
+// on import.
+
+describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
+  it('treats exit 0 as success even when stderr carries an OpenSSH host-key warning', () => {
+    const result: ExecResult = {
+      stdout: 'ok',
+      stderr: "Warning: Permanently added 'h' (ED25519) to the list of known hosts.",
+      exitCode: 0,
+      category: undefined,
+    };
+    const out = resultToMcpContent(result);
+    expect(out.content[0]).toEqual({ type: 'text', text: 'ok' });
+  });
+
+  it('returns content for a plain success (exit 0, no stderr)', () => {
+    const out = resultToMcpContent({ stdout: 'hello', stderr: '', exitCode: 0 });
+    expect(out.content[0].text).toBe('hello');
+  });
+
+  it('still throws for a genuine non-zero exit with stderr', () => {
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: 'boom', exitCode: 2, category: 'remote_exit' as any }),
+    ).toThrow(McpError);
+  });
+
+  it('throws for a non-zero exit even without a category set', () => {
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: 'segfault', exitCode: 139 }),
+    ).toThrow(/Error \(code 139\)/);
+  });
+
+  it('throws on auth/host_key/connect/transport/timeout categories regardless of exit code', () => {
+    for (const category of ['auth', 'host_key', 'connect', 'transport', 'timeout'] as const) {
+      expect(() =>
+        resultToMcpContent({ stdout: '', stderr: 'x', exitCode: 0, category }),
+      ).toThrow(McpError);
+    }
+  });
+});
+
+describe('resolveAuthMode (finding 2: password-over-key precedence)', () => {
+  it('ranks password above key when both are present', () => {
+    expect(resolveAuthMode({ password: 'pw', key: '/path/to/key' })).toBe('password');
+  });
+
+  it('resolves key when only a key is present', () => {
+    expect(resolveAuthMode({ key: '/path/to/key' })).toBe('key');
+  });
+
+  it('resolves password when only a password is present', () => {
+    expect(resolveAuthMode({ password: 'pw' })).toBe('password');
+  });
+
+  it('ranks kerberos above everything', () => {
+    expect(resolveAuthMode({ kerberos: true, password: 'pw', key: '/k' })).toBe('kerberos');
+  });
+
+  it('returns undefined when no credentials are supplied', () => {
+    expect(resolveAuthMode({})).toBeUndefined();
+  });
+});
+
+describe('buildTransportConfig (finding 2: no unconditional key read for password configs)', () => {
+  it('does NOT read the key file when a password config carries a stale --key (ssh2)', async () => {
+    const cfg = await buildTransportConfig({
+      host: 'h',
+      port: 22,
+      username: 'u',
+      password: 'pw',
+      key: '/nonexistent/path/to/stale-key',
+      // transport defaults to ssh2
+    });
+    expect(cfg.authMode).toBe('password');
+    expect(cfg.password).toBe('pw');
+    // keyPath is still recorded, but the (nonexistent) file must not be read.
+    expect(cfg.privateKey).toBeUndefined();
+  });
+
+  it('reads the key contents when key is the resolved auth mode (ssh2)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-test-'));
+    const keyPath = path.join(dir, 'id_test');
+    await fs.writeFile(keyPath, 'KEYDATA');
+    try {
+      const cfg = await buildTransportConfig({ host: 'h', port: 22, username: 'u', key: keyPath });
+      expect(cfg.authMode).toBe('key');
+      expect(cfg.privateKey).toBe('KEYDATA');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not read the key file for the openssh transport (uses -i path instead)', async () => {
+    const cfg = await buildTransportConfig({
+      host: 'h',
+      port: 22,
+      username: 'u',
+      key: '/nonexistent/path/to/key',
+      transportFlag: 'openssh',
+    });
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.keyPath).toBe('/nonexistent/path/to/key');
+    expect(cfg.privateKey).toBeUndefined();
+  });
+});

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -18,6 +19,61 @@ import type { ExecResult, ServerConfig } from '../src/transports/types';
 // import from src/index, which is safe because the test runner sets
 // SSH_MCP_DISABLE_MAIN=1 (isCliEnabled=false) so no server/CLI side effects run
 // on import.
+
+function runCliStartup(args: string[], envOverrides: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.SSH_MCP_DISABLE_MAIN;
+  delete env.SSH_MCP_TEST;
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) delete env[key];
+    else env[key] = value;
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', 'src/index.ts', ...args], {
+      cwd: process.cwd(),
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`CLI startup did not exit within timeout. stdout=${stdout} stderr=${stderr}`));
+    }, 10000);
+
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+describe('CLI bootstrap validation order', () => {
+  it('reports incomplete legacy CLI args before loading auto-discovered TOML (Codex 3551304743)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ssh-mcp-cli-order-'));
+    const badToml = path.join(dir, 'bad.toml');
+    await fs.writeFile(badToml, '[[sources]]\nid = "broken"\npassword = "unterminated\n');
+    try {
+      const result = await runCliStartup(['--host=h'], {
+        SSH_MCP_CONFIG: badToml,
+        XDG_CONFIG_HOME: path.join(dir, 'xdg'),
+        HOME: dir,
+      });
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('Missing required --user');
+      expect(result.stderr).not.toContain('TOML parse failed');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
   it('treats exit 0 as success even when stderr carries an OpenSSH host-key warning', () => {

--- a/test/index.unit.test.ts
+++ b/test/index.unit.test.ts
@@ -44,6 +44,19 @@ describe('resultToMcpContent (finding 1: exit-0 stderr must not error)', () => {
     ).toThrow(/Error \(code 139\)/);
   });
 
+  it('throws for a non-zero exit with EMPTY stderr (e.g. `false`, `test -f missing`)', () => {
+    // Regression for the openssh transport: `false` / `test -f missing` exit
+    // non-zero with no stderr, and must NOT be reported as success.
+    expect(() =>
+      resultToMcpContent({ stdout: '', stderr: '', exitCode: 1, category: 'remote_exit' as any }),
+    ).toThrow(/Error \(code 1\)[\s\S]*Command exited with status 1/);
+  });
+
+  it('treats a null exit code with no error category as success (handshake-less success path)', () => {
+    const out = resultToMcpContent({ stdout: 'done', stderr: '', exitCode: null });
+    expect(out.content[0].text).toBe('done');
+  });
+
   it('throws on auth/host_key/connect/transport/timeout categories regardless of exit code', () => {
     for (const category of ['auth', 'host_key', 'connect', 'transport', 'timeout'] as const) {
       expect(() =>

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { parseServerConfigJson, validateConfig } from '../src/index';
+
+// Unit tests for the multi-host (--ssh=<JSON>) config layer. Imported from
+// src/index, which is safe because the runner sets SSH_MCP_DISABLE_MAIN=1
+// (isCliEnabled=false) so no server/CLI side effects run on import.
+
+describe('parseServerConfigJson (happy path)', () => {
+  it('parses a password/ssh2 config with name/host/user', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'web1', host: 'web1.example', user: 'deploy', auth: 'password', password: 'pw',
+    }));
+    expect(cfg.name).toBe('web1');
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.authMode).toBe('password');
+    expect(cfg.password).toBe('pw');
+    expect(cfg.port).toBe(22);
+  });
+
+  it('accepts "username" as an alias for "user"', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'k', host: 'k.example', username: 'svc', auth: 'kerberos',
+    }));
+    expect(cfg.username).toBe('svc');
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.kerberos).toBe(true);
+  });
+
+  it('throws on missing name / host / user / auth', () => {
+    expect(() => parseServerConfigJson('{}')).toThrow(/missing required "name"/);
+    expect(() => parseServerConfigJson(JSON.stringify({ name: 'a' }))).toThrow(/missing required "host"/);
+    expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h' }))).toThrow(/missing required "user"/);
+    expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h', user: 'u' }))).toThrow(/requires "auth"/);
+  });
+
+  it('throws on invalid JSON', () => {
+    expect(() => parseServerConfigJson('{not json')).toThrow(/--ssh JSON parse error/);
+  });
+});
+
+describe('parseServerConfigJson (finding 4: ssh2 must not silently drop host-key enforcement)', () => {
+  it('rejects strictHostKeyChecking on an ssh2 (default) key config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'key', keyPath: '/k', strictHostKeyChecking: 'yes',
+    }))).toThrow(/require "transport": "openssh"/);
+  });
+
+  it('rejects knownHostsFile on an ssh2 (default) password config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'password', password: 'pw', knownHostsFile: '/tmp/known',
+    }))).toThrow(/require "transport": "openssh"/);
+  });
+
+  it('accepts strictHostKeyChecking when transport is explicitly openssh', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'key', keyPath: '/k', transport: 'openssh', strictHostKeyChecking: 'yes',
+    }));
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.strictHostKeyChecking).toBe('yes');
+  });
+
+  it('accepts knownHostsFile for a kerberos config (implies openssh)', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'h', host: 'h', user: 'u', auth: 'kerberos', knownHostsFile: '/tmp/known',
+    }));
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.knownHostsFile).toBe('/tmp/known');
+  });
+});
+
+describe('validateConfig multi-host (finding 2: legacy flags must be rejected)', () => {
+  it('rejects --port mixed with --ssh', () => {
+    expect(() => validateConfig({ port: '2222' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);
+  });
+
+  it('rejects --sudoPassword mixed with --ssh', () => {
+    expect(() => validateConfig({ sudoPassword: 'x' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);
+  });
+
+  it('rejects --suPassword mixed with --ssh', () => {
+    expect(() => validateConfig({ suPassword: 'x' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);
+  });
+
+  it('names the offending flag(s) in the error', () => {
+    expect(() => validateConfig({ port: '2222', sudoPassword: 'x' }, true)).toThrow(/--port/);
+    expect(() => validateConfig({ port: '2222', sudoPassword: 'x' }, true)).toThrow(/--sudoPassword/);
+  });
+
+  it('passes for a clean multi-host invocation (no legacy flags)', () => {
+    expect(() => validateConfig({}, true)).not.toThrow();
+  });
+});

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -27,7 +27,7 @@ describe('parseServerConfigJson (happy path)', () => {
   });
 
   it('throws on missing name / host / user / auth', () => {
-    expect(() => parseServerConfigJson('{}')).toThrow(/missing required "name"/);
+    expect(() => parseServerConfigJson('{}')).toThrow(/non-empty string "name"/);
     expect(() => parseServerConfigJson(JSON.stringify({ name: 'a' }))).toThrow(/missing required "host"/);
     expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h' }))).toThrow(/missing required "user"/);
     expect(() => parseServerConfigJson(JSON.stringify({ name: 'a', host: 'h', user: 'u' }))).toThrow(/requires "auth"/);
@@ -65,6 +65,100 @@ describe('parseServerConfigJson (finding 4: ssh2 must not silently drop host-key
     }));
     expect(cfg.transport).toBe('openssh');
     expect(cfg.knownHostsFile).toBe('/tmp/known');
+  });
+});
+
+describe('parseServerConfigJson (round-2: input validation hardening)', () => {
+  it('does not echo the raw config in a JSON parse error (no secret leak)', () => {
+    const raw = '{"name":"x","password":"s3cret",}'; // trailing comma -> parse error
+    try {
+      parseServerConfigJson(raw);
+      throw new Error('expected parse to throw');
+    } catch (e: any) {
+      expect(e.message).toMatch(/--ssh JSON parse error/);
+      expect(e.message).not.toMatch(/s3cret/);
+    }
+  });
+
+  it('requires name to be a non-empty string (rejects numeric name)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 1, host: 'h', user: 'u', auth: 'password', password: 'pw',
+    }))).toThrow(/non-empty string "name"/);
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: '', host: 'h', user: 'u', auth: 'password', password: 'pw',
+    }))).toThrow(/non-empty string "name"/);
+  });
+
+  it('rejects a non-integer / out-of-range port', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 'abc',
+    }))).toThrow(/invalid "port"/);
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 70000,
+    }))).toThrow(/invalid "port"/);
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 0,
+    }))).toThrow(/invalid "port"/);
+  });
+
+  it('accepts a valid numeric port (and a numeric-string port)', () => {
+    expect(parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 2222,
+    })).port).toBe(2222);
+    expect(parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: '2200',
+    })).port).toBe(2200);
+  });
+
+  it('rejects an invalid transport value (typo)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', keyPath: '/k', transport: 'opnssh',
+    }))).toThrow(/invalid "transport"/);
+  });
+
+  it('rejects a kerberos config whose explicit transport is not openssh', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'kerberos', transport: 'ssh2',
+    }))).toThrow(/implies transport "openssh"/);
+  });
+
+  it('rejects an inline privateKey for an openssh key config (buildArgs ignores it)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', transport: 'openssh', privateKey: '-----BEGIN...',
+    }))).toThrow(/inline "privateKey" is not supported for transport "openssh"/);
+  });
+
+  it('still accepts an inline privateKey for an ssh2 key config', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', privateKey: '-----BEGIN...',
+    }));
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.privateKey).toBe('-----BEGIN...');
+  });
+
+  it('rejects an invalid gssapiDelegateCredentials value', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'kerberos', gssapiDelegateCredentials: 'maybe',
+    }))).toThrow(/gssapiDelegateCredentials must be "yes" or "no"/);
+  });
+
+  it('rejects gssapiDelegateCredentials on a non-kerberos config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', gssapiDelegateCredentials: 'yes',
+    }))).toThrow(/gssapiDelegateCredentials requires auth "kerberos"/);
+  });
+
+  it('accepts a valid gssapiDelegateCredentials on a kerberos config', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'kerberos', gssapiDelegateCredentials: 'yes',
+    }));
+    expect(cfg.gssapiDelegateCredentials).toBe('yes');
+  });
+
+  it('rejects an invalid strictHostKeyChecking value (on an openssh config)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', keyPath: '/k', transport: 'openssh', strictHostKeyChecking: 'maybe',
+    }))).toThrow(/strictHostKeyChecking must be one of: yes, no, accept-new/);
   });
 });
 

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -203,6 +203,43 @@ describe('parseServerConfigJson (Codex 3541767246: key auth requires key materia
   });
 });
 
+describe('parseServerConfigJson (Codex 3549295040: password auth requires a non-empty password)', () => {
+  it('rejects a password config with a missing password', () => {
+    // Without password material the server still registers as password-authed
+    // but fails on first use: OpenSshTransport.init() throws, and the ssh2 path
+    // connects without the promised credential. Fail at parse time instead.
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password',
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('rejects a password config with an empty-string password', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: '',
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('rejects a password config with a non-string password', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 123,
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('rejects a missing password for an explicit openssh password config', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', transport: 'openssh',
+    }))).toThrow(/auth "password" requires a non-empty "password"/);
+  });
+
+  it('still accepts a password config with a non-empty password', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw',
+    }));
+    expect(cfg.authMode).toBe('password');
+    expect(cfg.password).toBe('pw');
+  });
+});
+
 describe('validateConfig multi-host (finding 2: legacy flags must be rejected)', () => {
   it('rejects --port mixed with --ssh', () => {
     expect(() => validateConfig({ port: '2222' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -89,6 +89,34 @@ describe('parseServerConfigJson (round-2: input validation hardening)', () => {
     }))).toThrow(/non-empty string "name"/);
   });
 
+  it('requires host and user aliases to be non-empty strings', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw' };
+    for (const host of [123, {}, '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, host })))
+        .toThrow(/required "host".*non-empty string/);
+    }
+    for (const user of [123, {}, '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, user })))
+        .toThrow(/required "user".*non-empty string/);
+    }
+    for (const username of [123, {}, '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, user: undefined, username })))
+        .toThrow(/required "user".*non-empty string/);
+    }
+  });
+
+  it('requires keyPath and privateKey to be non-empty strings when provided', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'key' };
+    for (const keyPath of [123, {}, [], '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, keyPath })))
+        .toThrow(/"keyPath".*non-empty string/);
+    }
+    for (const privateKey of [123, {}, [], '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, privateKey })))
+        .toThrow(/"privateKey".*non-empty string/);
+    }
+  });
+
   it('rejects a non-integer / out-of-range port', () => {
     expect(() => parseServerConfigJson(JSON.stringify({
       name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 'abc',

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -162,6 +162,47 @@ describe('parseServerConfigJson (round-2: input validation hardening)', () => {
   });
 });
 
+describe('parseServerConfigJson (Codex 3541767246: key auth requires key material)', () => {
+  it('rejects an ssh2 key config with no keyPath and no privateKey', () => {
+    // Without key material the ssh2 transport has no key and openssh omits -i,
+    // so the connection silently falls back to an ambient agent/default
+    // identity. Fail at parse time instead.
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key',
+    }))).toThrow(/auth "key" requires "keyPath" or inline "privateKey"/);
+  });
+
+  it('rejects an openssh key config with no keyPath (inline privateKey is unsupported there)', () => {
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', transport: 'openssh',
+    }))).toThrow(/auth "key" requires "keyPath"/);
+  });
+
+  it('rejects a legacy-shaped top-level "key" field (read by neither transport)', () => {
+    // The multi-host schema uses keyPath/privateKey; a legacy `key` field is
+    // ignored, leaving the config with no usable key material.
+    expect(() => parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', key: '/home/u/.ssh/id_ed25519',
+    }))).toThrow(/uses "keyPath" \(or "privateKey" for ssh2\), not "key"/);
+  });
+
+  it('accepts an ssh2 key config with keyPath', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', keyPath: '/home/u/.ssh/id_ed25519',
+    }));
+    expect(cfg.transport).toBe('ssh2');
+    expect(cfg.keyPath).toBe('/home/u/.ssh/id_ed25519');
+  });
+
+  it('accepts an openssh key config with keyPath', () => {
+    const cfg = parseServerConfigJson(JSON.stringify({
+      name: 'n', host: 'h', user: 'u', auth: 'key', transport: 'openssh', keyPath: '/home/u/.ssh/id_ed25519',
+    }));
+    expect(cfg.transport).toBe('openssh');
+    expect(cfg.keyPath).toBe('/home/u/.ssh/id_ed25519');
+  });
+});
+
 describe('validateConfig multi-host (finding 2: legacy flags must be rejected)', () => {
   it('rejects --port mixed with --ssh', () => {
     expect(() => validateConfig({ port: '2222' }, true)).toThrow(/cannot be mixed with legacy single-host flags/);

--- a/test/multihost-config.unit.test.ts
+++ b/test/multihost-config.unit.test.ts
@@ -117,6 +117,24 @@ describe('parseServerConfigJson (round-2: input validation hardening)', () => {
     }
   });
 
+  it('requires elevation passwords to be strings when provided', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw' };
+    for (const field of ['sudoPassword', 'suPassword'] as const) {
+      for (const value of [123, true, {}, []]) {
+        expect(() => parseServerConfigJson(JSON.stringify({ ...base, [field]: value })))
+          .toThrow(new RegExp(`"${field}".*string`));
+      }
+    }
+  });
+
+  it('requires knownHostsFile to be a non-empty string when provided', () => {
+    const base = { name: 'n', host: 'h', user: 'u', auth: 'kerberos' };
+    for (const knownHostsFile of [123, true, {}, [], '']) {
+      expect(() => parseServerConfigJson(JSON.stringify({ ...base, knownHostsFile })))
+        .toThrow(/"knownHostsFile".*non-empty string/);
+    }
+  });
+
   it('rejects a non-integer / out-of-range port', () => {
     expect(() => parseServerConfigJson(JSON.stringify({
       name: 'n', host: 'h', user: 'u', auth: 'password', password: 'pw', port: 'abc',

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -178,6 +178,25 @@ describe('runSuViaPty auth-failure scoping (finding 5: limit failRe to login pha
     expect(res.stdout).toContain('authentication failure');
   });
 
+  it('preserves merged PTY diagnostics as stderr on non-zero command exit', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('ls /missing', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+    emit(fc, 'ls /missing\n');
+    emit(fc, "ls: cannot access '/missing': No such file or directory\n");
+    emit(fc, `${endMark}2\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(2);
+    expect(res.category).toBe('remote_exit');
+    expect(res.stderr).toContain("ls: cannot access '/missing'");
+  });
+
   it('still detects an auth failure during the su login phase', async () => {
     const fc = new FakeChild();
     spawnMock.mockReturnValue(fc);

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -106,4 +106,92 @@ describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling
     const res = await p;
     expect(res.category).toBe('timeout');
   });
+
+  it('escalates to SIGKILL when the process ignores SIGTERM past the grace window (P2: track real exit, not child.killed)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    (t as any).runSuViaPty('sleep 999', 'pw', { timeoutMs: 5000 });
+
+    // Hit the overall deadline → SIGTERM sent.
+    vi.advanceTimersByTime(5000);
+    expect(fc.kill).toHaveBeenCalledWith('SIGTERM');
+    // The process does NOT exit (no close event). The old code gated the
+    // fallback on `child.killed`, which FakeChild.kill sets true, so SIGKILL
+    // was wrongly skipped. The fix gates on a real `exited` flag.
+    vi.advanceTimersByTime(2000);
+    expect(fc.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+});
+
+describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su results)', () => {
+  it('removes the echoed user command and sentinel-emit lines from captured stdout', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('id -un', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // `ssh -tt` echoes every stdin line back onto stdout: the user command,
+    // then the real output, then the echoed `echo <endMark>$?` line, then the
+    // sentinel itself.
+    emit(fc, 'id -un\n');
+    emit(fc, 'root\n');
+    emit(fc, `echo ${endMark}$?\n`);
+    emit(fc, `${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    // Only the real command output should remain — no echoed input.
+    expect(res.stdout.trim()).toBe('root');
+    expect(res.stdout).not.toContain('id -un');
+    expect(res.stdout).not.toContain(`echo ${endMark}`);
+  });
+});
+
+describe('runSuViaPty auth-failure scoping (finding 5: limit failRe to login phase)', () => {
+  it('does NOT treat command output containing "authentication failure" as an auth error during EXEC', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('grep failure /var/log/auth.log', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // Legitimate root command output that literally contains the failure
+    // phrases. The old unconditional failRe match killed SSH here and reported
+    // an auth error; the fix scopes failRe to the pre-EXEC login states.
+    emit(fc, 'grep failure /var/log/auth.log\n');
+    emit(fc, 'pam_unix(su:auth): authentication failure; logname=...\n');
+    emit(fc, 'sshd: incorrect password attempt for baduser\n');
+    emit(fc, `${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    expect(res.category).toBeUndefined();
+    expect(res.stdout).toContain('authentication failure');
+  });
+
+  it('still detects an auth failure during the su login phase', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'wrong' });
+
+    const p = (t as any).runSuViaPty('whoami', 'wrong', { timeoutMs: 60000 }) as Promise<any>;
+
+    // SU_PROMPT: send password, then the remote rejects it before any EXEC.
+    emit(fc, 'Password: ');
+    emit(fc, '\nsu: Authentication failure\n');
+    expect(fc.kill).toHaveBeenCalledWith('SIGTERM');
+
+    fc.emit('close', 1, null);
+    const res = await p;
+    expect(res.category).toBe('auth');
+  });
 });

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -84,6 +84,42 @@ describe('runSuViaPty large output (finding 3: no ~4KB truncation)', () => {
   });
 });
 
+describe('OpenSSH command sentinels', () => {
+  it('puts the su closing subshell and sentinel after a command comment', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+    const p = (t as any).runSuViaPty('echo ok # described command', 'pw', { timeoutMs: 60000 });
+
+    const { endMark } = driveToExec(fc);
+    const execInput = fc.writes.at(-1)!;
+    expect(execInput).toContain('echo ok # described command\n)\necho ' + endMark);
+    emit(fc, execInput.replace(/\n$/, '') + '\n' + 'ok\n' + endMark + '0\n');
+    fc.emit('close', 0, null);
+
+    await expect(p).resolves.toMatchObject({ exitCode: 0, stdout: 'ok\n' });
+  });
+
+  it('uses the remote sentinel to classify a command exit 255 as remote_exit', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u' });
+    const p = (t as any).runSsh("echo Permission denied >&2; exit 255", { timeoutMs: 60000 });
+
+    const command = spawnMock.mock.calls[0][1].at(-1) as string;
+    const endMark = command.match(/(__SSH_MCP_END_[0-9a-f]+__)/)![1];
+    fc.stderr.emit('data', Buffer.from('Permission denied\n'));
+    emit(fc, `\n${endMark}255\n`);
+    fc.emit('close', 0, null);
+
+    await expect(p).resolves.toMatchObject({
+      exitCode: 255,
+      category: 'remote_exit',
+      stderr: 'Permission denied\n',
+    });
+  });
+});
+
 describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling)', () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
@@ -135,10 +171,9 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
 
     const { endMark } = driveToExec(fc);
 
-    // The command and sentinel-emit are combined into ONE input line; with
-    // `ssh -tt` the remote PTY echoes exactly that line back onto stdout.
-    const execInput = `( id -un ); echo ${endMark}$?`;
-    emit(fc, execInput + '\r\n');
+    // `ssh -tt` echoes the multiline input written to the root shell.
+    const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('id -un'))!;
+    emit(fc, execInput.replace(/\n$/, '') + '\r\n');
     emit(fc, 'root\n');
     emit(fc, `${endMark}0\n`);
     fc.emit('close', 0, null);
@@ -165,7 +200,7 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
     // terminates the subshell; the control shell survives to emit the sentinel.
     const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('echo'));
     expect(execInput).toBeDefined();
-    expect(execInput!.trim()).toBe(`( echo ok; exit 0 ); echo ${endMark}$?`);
+    expect(execInput!.trim()).toBe(`(\necho ok; exit 0\n)\necho ${endMark}$?`);
 
     emit(fc, execInput!.replace(/\n$/, '') + '\r\n');
     emit(fc, 'ok\n');
@@ -189,12 +224,10 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
 
     const { endMark } = driveToExec(fc);
 
-    // `printf foo` emits no trailing newline, so the echoed sentinel would glue
-    // directly after the real output. With the combined single input line and
-    // the digit-anchored end regex, only the real sentinel output is consumed
-    // and the caller sees exactly `foo` — not `foo__SSH_MCP_END_...$?`.
-    const execInput = `( printf foo ); echo ${endMark}$?`;
-    emit(fc, execInput + '\r\n');
+    // The multiline command wrapper is echoed first. The real `printf foo`
+    // output remains unterminated and therefore glues directly to the marker.
+    const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('printf foo'))!;
+    emit(fc, execInput.replace(/\n$/, '') + '\r\n');
     emit(fc, `foo${endMark}0\r\n`);
     fc.emit('close', 0, null);
 

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -126,7 +126,7 @@ describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling
 });
 
 describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su results)', () => {
-  it('removes the echoed user command and sentinel-emit lines from captured stdout', async () => {
+  it('removes the echoed combined command+sentinel input line from captured stdout', async () => {
     const fc = new FakeChild();
     spawnMock.mockReturnValue(fc);
     const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
@@ -135,12 +135,11 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
 
     const { endMark } = driveToExec(fc);
 
-    // `ssh -tt` echoes every stdin line back onto stdout: the user command,
-    // then the real output, then the echoed `echo <endMark>$?` line, then the
-    // sentinel itself.
-    emit(fc, 'id -un\n');
+    // The command and sentinel-emit are combined into ONE input line; with
+    // `ssh -tt` the remote PTY echoes exactly that line back onto stdout.
+    const execInput = `( id -un ); echo ${endMark}$?`;
+    emit(fc, execInput + '\r\n');
     emit(fc, 'root\n');
-    emit(fc, `echo ${endMark}$?\n`);
     emit(fc, `${endMark}0\n`);
     fc.emit('close', 0, null);
 
@@ -150,6 +149,60 @@ describe('runSuViaPty echo stripping (finding 1: strip echoed PTY input from su 
     expect(res.stdout.trim()).toBe('root');
     expect(res.stdout).not.toContain('id -un');
     expect(res.stdout).not.toContain(`echo ${endMark}`);
+  });
+
+  it('wraps the user command in a subshell so its own exit does not kill the sentinel (P2)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('echo ok; exit 0', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // The EXEC input written to the root shell must run the command in a
+    // subshell `( ... )` so a command that exits/exec-replaces its shell only
+    // terminates the subshell; the control shell survives to emit the sentinel.
+    const execInput = fc.writes.find((w) => w.includes(endMark) && w.includes('echo'));
+    expect(execInput).toBeDefined();
+    expect(execInput!.trim()).toBe(`( echo ok; exit 0 ); echo ${endMark}$?`);
+
+    emit(fc, execInput!.replace(/\n$/, '') + '\r\n');
+    emit(fc, 'ok\n');
+    emit(fc, `${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    // Because the sentinel still runs, the real exit status is reported and the
+    // output is preserved instead of being dropped as a transport failure.
+    expect(res.exitCode).toBe(0);
+    expect(res.category).toBeUndefined();
+    expect(res.stdout.trim()).toBe('ok');
+  });
+
+  it('strips the echoed sentinel even when command output is unterminated (P2: printf foo)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('printf foo', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    // `printf foo` emits no trailing newline, so the echoed sentinel would glue
+    // directly after the real output. With the combined single input line and
+    // the digit-anchored end regex, only the real sentinel output is consumed
+    // and the caller sees exactly `foo` — not `foo__SSH_MCP_END_...$?`.
+    const execInput = `( printf foo ); echo ${endMark}$?`;
+    emit(fc, execInput + '\r\n');
+    emit(fc, `foo${endMark}0\r\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe('foo');
+    expect(res.stdout).not.toContain(endMark);
+    expect(res.stdout).not.toContain('echo ');
   });
 });
 

--- a/test/openssh.suvia.unit.test.ts
+++ b/test/openssh.suvia.unit.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { spawn } from 'node:child_process';
+import { OpenSshTransport } from '../src/transports/openssh';
+
+// These tests drive the private runSuViaPty PTY state machine with a mocked
+// `spawn`, so they need no live sshd. They cover:
+//   - finding 3: large EXEC output must not be truncated to the ~4KB scan window
+//   - finding 4: the overall hard deadline must equal opts.timeoutMs (no +30000)
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+  execFile: vi.fn(),
+}));
+
+const spawnMock = spawn as unknown as Mock;
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  writes: string[] = [];
+  killed = false;
+  stdin = {
+    write: (s: string) => {
+      this.writes.push(s);
+      return true;
+    },
+  };
+  kill = vi.fn((_sig?: string) => {
+    this.killed = true;
+    return true;
+  });
+}
+
+function emit(fc: FakeChild, s: string) {
+  fc.stdout.emit('data', Buffer.from(s, 'utf8'));
+}
+
+/** Parse the random nonce out of the `export PS1='__SSH_MCP_READY_<nonce>...'` line. */
+function nonceFromWrites(fc: FakeChild): string {
+  const line = fc.writes.find((w) => w.includes('export PS1='));
+  if (!line) throw new Error('PS1 export not written: ' + JSON.stringify(fc.writes));
+  const m = line.match(/__SSH_MCP_READY_([0-9a-f]+)__/);
+  if (!m) throw new Error('no nonce in PS1 line: ' + line);
+  return m[1];
+}
+
+/** Drive the state machine SU_PROMPT -> PASSWORD_SENT -> ROOT_SHELL -> EXEC. */
+function driveToExec(fc: FakeChild): { readyMark: string; endMark: string } {
+  emit(fc, 'Password: ');           // SU_PROMPT -> PASSWORD_SENT
+  emit(fc, '\nLast login: today\n'); // PASSWORD_SENT -> ROOT_SHELL (writes PS1 export)
+  const nonce = nonceFromWrites(fc);
+  const readyMark = `__SSH_MCP_READY_${nonce}__`;
+  const endMark = `__SSH_MCP_END_${nonce}__`;
+  emit(fc, readyMark + '$ ');       // ROOT_SHELL -> EXEC (writes command + echo endMark)
+  return { readyMark, endMark };
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+});
+
+describe('runSuViaPty large output (finding 3: no ~4KB truncation)', () => {
+  it('preserves the full head of command output exceeding the scan window', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('big', 'pw', { timeoutMs: 60000 }) as Promise<any>;
+
+    const { endMark } = driveToExec(fc);
+
+    const big = 'A'.repeat(20000); // >> the 8KB/4KB scan-buffer cap
+    emit(fc, big);
+    emit(fc, `\n${endMark}0\n`);
+    fc.emit('close', 0, null);
+
+    const res = await p;
+    expect(res.exitCode).toBe(0);
+    // Old code derived stdout from the truncated ~4KB scan buffer and would lose
+    // the head. The fix keeps an unbounded EXEC capture, so all 20000 bytes survive.
+    expect(res.stdout.length).toBeGreaterThanOrEqual(20000);
+    expect(res.stdout.startsWith(big)).toBe(true);
+  });
+});
+
+describe('runSuViaPty overall deadline (finding 4: timeoutMs is the hard ceiling)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('kills the process at exactly opts.timeoutMs (not timeoutMs + 30000)', async () => {
+    const fc = new FakeChild();
+    spawnMock.mockReturnValue(fc);
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', suPassword: 'pw' });
+
+    const p = (t as any).runSuViaPty('sleep 999', 'pw', { timeoutMs: 5000 }) as Promise<any>;
+
+    // Advance to exactly the contract deadline. Under the old +30000 budget the
+    // overall timer would not have fired yet (and the 10s state timer is also
+    // still pending), so the process would NOT be killed at 5000ms.
+    vi.advanceTimersByTime(5000);
+    expect(fc.kill).toHaveBeenCalledWith('SIGTERM');
+
+    // Process exits in response to the signal; resolve as a timeout.
+    fc.emit('close', null, 'SIGTERM');
+    const res = await p;
+    expect(res.category).toBe('timeout');
+  });
+});

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -306,6 +306,20 @@ describe('OpenSshTransport.isConnected (Codex 3541767250: initialized != connect
     expect(t.isConnected()).toBe(false);
   });
 
+  it('stays NOT connected after authentication is rejected', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'password', password: 'wrong' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'Permission denied', exitCode: 255, category: 'auth' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('stays NOT connected after host-key verification is rejected', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'key', keyPath: '/tmp/id_test' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'Host key verification failed.', exitCode: 255, category: 'host_key' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
   it('reports connected once a later command succeeds after an initial connect failure', async () => {
     const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
     runSsh

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { classifyError, OpenSshTransport } from '../src/transports/openssh';
+
+describe('classifyError', () => {
+  it('returns undefined for success (exit 0)', () => {
+    expect(classifyError(0, '')).toBeUndefined();
+  });
+
+  it('returns transport for null exit code', () => {
+    expect(classifyError(null, '')).toBe('transport');
+  });
+
+  it('returns remote_exit for non-255 non-zero codes', () => {
+    expect(classifyError(1, 'something')).toBe('remote_exit');
+    expect(classifyError(127, 'command not found')).toBe('remote_exit');
+    expect(classifyError(254, '')).toBe('remote_exit');
+  });
+
+  describe('SSH layer (exit 255) classification', () => {
+    it('classifies auth failures', () => {
+      expect(classifyError(255, 'Permission denied (publickey).')).toBe('auth');
+      expect(classifyError(255, 'Authentication failed.')).toBe('auth');
+      expect(classifyError(255, 'No credentials cache found')).toBe('auth');
+      expect(classifyError(255, 'Ticket expired')).toBe('auth');
+      expect(classifyError(255, 'GSSAPI Error: Unspecified GSS failure')).toBe('auth');
+      expect(classifyError(255, 'Clock skew too great')).toBe('auth');
+      expect(classifyError(255, 'Server not found in Kerberos database')).toBe('auth');
+    });
+
+    it('classifies host-key failures', () => {
+      expect(classifyError(255, 'Host key verification failed.')).toBe('host_key');
+      expect(classifyError(255, 'WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!')).toBe('host_key');
+    });
+
+    it('classifies connectivity failures', () => {
+      expect(classifyError(255, 'ssh: connect to host foo port 22: Connection refused')).toBe('connect');
+      expect(classifyError(255, 'ssh: connect to host foo port 22: Connection timed out')).toBe('connect');
+      expect(classifyError(255, 'ssh: connect to host foo port 22: Connection reset')).toBe('connect');
+      expect(classifyError(255, 'ssh: Could not resolve hostname foo')).toBe('connect');
+      expect(classifyError(255, 'Name or service not known')).toBe('connect');
+      expect(classifyError(255, 'No route to host')).toBe('connect');
+      expect(classifyError(255, 'Network unreachable')).toBe('connect');
+    });
+
+    it('falls back to transport for unknown 255 stderr', () => {
+      expect(classifyError(255, 'some unknown ssh error')).toBe('transport');
+      expect(classifyError(255, '')).toBe('transport');
+    });
+  });
+});
+
+describe('OpenSshTransport.buildArgs', () => {
+  const baseCfg = {
+    host: 'ubuntu-dev.example.internal',
+    port: 22,
+    username: 'aduser@EXAMPLE.INTERNAL',
+  };
+
+  it('emits Kerberos-specific flags when authMode=kerberos', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('GSSAPIAuthentication=yes');
+    expect(args).toContain('GSSAPIDelegateCredentials=no');
+    expect(args).toContain('PreferredAuthentications=gssapi-with-mic');
+    expect(args).toContain('PubkeyAuthentication=no');
+    expect(args).toContain('PasswordAuthentication=no');
+    expect(args.at(-1)).toBe('aduser@EXAMPLE.INTERNAL@ubuntu-dev.example.internal');
+  });
+
+  it('honors --gssapiDelegateCredentials', () => {
+    const t = new OpenSshTransport({
+      ...baseCfg,
+      authMode: 'kerberos',
+      gssapiDelegateCredentials: 'yes',
+    });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('GSSAPIDelegateCredentials=yes');
+  });
+
+  it('emits key-specific flags when authMode=key', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'key', keyPath: '/home/user/.ssh/id_ed25519' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('-i');
+    expect(args).toContain('/home/user/.ssh/id_ed25519');
+    expect(args).toContain('PreferredAuthentications=publickey');
+    expect(args).toContain('PasswordAuthentication=no');
+    expect(args).toContain('GSSAPIAuthentication=no');
+  });
+
+  it('emits password-specific flags when authMode=password', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'password', password: 'hunter2' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('PreferredAuthentications=password,keyboard-interactive');
+    expect(args).toContain('PubkeyAuthentication=no');
+    expect(args).toContain('GSSAPIAuthentication=no');
+  });
+
+  it('respects custom strictHostKeyChecking and knownHostsFile', () => {
+    const t = new OpenSshTransport({
+      ...baseCfg,
+      authMode: 'kerberos',
+      strictHostKeyChecking: 'yes',
+      knownHostsFile: '/etc/ssh/managed_known_hosts',
+    });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('StrictHostKeyChecking=yes');
+    expect(args).toContain('UserKnownHostsFile=/etc/ssh/managed_known_hosts');
+  });
+
+  it('defaults StrictHostKeyChecking to accept-new', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('StrictHostKeyChecking=accept-new');
+  });
+
+  it('scales ConnectTimeout with opts.timeoutMs', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    expect(t.buildArgs({ timeoutMs: 5000 })).toContain('ConnectTimeout=5');
+    expect(t.buildArgs({ timeoutMs: 120000 })).toContain('ConnectTimeout=120');
+  });
+
+  it('appends -tt when opts.pty is true', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000, pty: true });
+    expect(args).toContain('-tt');
+  });
+
+  it('includes port via -p', () => {
+    const t = new OpenSshTransport({ ...baseCfg, port: 2222, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    const pIdx = args.indexOf('-p');
+    expect(pIdx).toBeGreaterThanOrEqual(0);
+    expect(args[pIdx + 1]).toBe('2222');
+  });
+
+  it('includes ServerAlive keepalive options', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('ServerAliveInterval=30');
+    expect(args).toContain('ServerAliveCountMax=3');
+  });
+});

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -42,9 +42,13 @@ describe('classifyError', () => {
       expect(classifyError(255, 'Network unreachable')).toBe('connect');
     });
 
-    it('falls back to transport for unknown 255 stderr', () => {
-      expect(classifyError(255, 'some unknown ssh error')).toBe('transport');
-      expect(classifyError(255, '')).toBe('transport');
+    it('falls back to remote_exit for unknown 255 stderr (ssh(1): 255 is also a valid remote command exit)', () => {
+      // When no SSH-layer signature matches, a 255 exit is surfaced as the
+      // remote command's own non-zero exit (Error (code 255)) rather than a
+      // generic SSH transport error, so legitimate remote `exit 255` is not
+      // masked. See classifyError + resultToMcpContent.
+      expect(classifyError(255, 'some unknown ssh error')).toBe('remote_exit');
+      expect(classifyError(255, '')).toBe('remote_exit');
     });
   });
 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -251,3 +251,69 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     expect(runOpts.stdin).toBe('callpw\n');
   });
 });
+
+describe('OpenSshTransport.isConnected (Codex 3541767250: initialized != connected)', () => {
+  function makeTransport(cfg: any) {
+    const t = new OpenSshTransport({ host: 'h', port: 22, username: 'u', ...cfg });
+    const runSsh = vi.fn();
+    const runSuViaPty = vi.fn();
+    (t as any).runSsh = runSsh;
+    (t as any).runSuViaPty = runSuViaPty;
+    return { t, runSsh, runSuViaPty };
+  }
+
+  it('reports NOT connected before any command runs (init-only, no live session)', () => {
+    // OpenSSH init() only verifies the local ssh binary/askpass setup; no SSH
+    // session is established until the first exec. A merely-initialized
+    // transport must not claim a live connection.
+    const { t } = makeTransport({ authMode: 'kerberos' });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('reports connected after a command completes a live session (exit 0)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(true);
+  });
+
+  it('reports connected after a non-zero REMOTE exit (host answered, command failed)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'nope', exitCode: 1, category: 'remote_exit' });
+    await t.exec('false', { timeoutMs: 60000 });
+    // A remote command's own non-zero exit still proves the host is live.
+    expect(t.isConnected()).toBe(true);
+  });
+
+  it('stays NOT connected after a connect-layer failure (e.g. connection refused)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'Connection refused', exitCode: 255, category: 'connect' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('stays NOT connected after a transport-layer failure (ssh spawn error)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: 'spawn error', exitCode: null, category: 'transport' });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('stays NOT connected after a bare timeout (no proof the host answered)', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh.mockResolvedValue({ stdout: '', stderr: '', exitCode: null, category: 'timeout' });
+    await t.exec('sleep 100', { timeoutMs: 10 });
+    expect(t.isConnected()).toBe(false);
+  });
+
+  it('reports connected once a later command succeeds after an initial connect failure', async () => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh
+      .mockResolvedValueOnce({ stdout: '', stderr: 'Connection refused', exitCode: 255, category: 'connect' })
+      .mockResolvedValueOnce({ stdout: 'ok', stderr: '', exitCode: 0 });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(true);
+  });
+});

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
-import { buildOpenSshSudoWrapper, classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
+import {
+  buildOpenSshSudoWrapper,
+  classifyError,
+  OpenSshTransport,
+  renderAskpassHelper,
+  renderAskpassSshConfig,
+} from '../src/transports/openssh';
 
 describe('classifyError', () => {
   it('returns undefined for success (exit 0)', () => {
@@ -113,6 +119,16 @@ describe('OpenSshTransport.buildArgs', () => {
     expect(args).toContain('PreferredAuthentications=password,keyboard-interactive');
     expect(args).toContain('PubkeyAuthentication=no');
     expect(args).toContain('GSSAPIAuthentication=no');
+  });
+
+  it('uses a post-user-config SendEnv guard for initialized askpass auth', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'password', password: 'hunter2' });
+    (t as any).askpassConfigPath = '/tmp/ssh-mcp/ssh_config';
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    const fIdx = args.indexOf('-F');
+    expect(fIdx).toBeGreaterThanOrEqual(0);
+    expect(args[fIdx + 1]).toBe('/tmp/ssh-mcp/ssh_config');
+    expect(renderAskpassSshConfig()).toBe('Include ~/.ssh/config\nSendEnv -*\n');
   });
 
   it('respects custom strictHostKeyChecking and knownHostsFile', () => {

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -87,6 +87,22 @@ describe('OpenSshTransport.buildArgs', () => {
     expect(args).toContain('GSSAPIAuthentication=no');
   });
 
+  it('forces IdentitiesOnly=yes when an explicit key is supplied (no agent-key spray)', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'key', keyPath: '/home/user/.ssh/id_ed25519' });
+    const args = t.buildArgs({ timeoutMs: 60000 });
+    expect(args).toContain('IdentitiesOnly=yes');
+    // The -i path and IdentitiesOnly=yes must both be present so ssh uses only
+    // the chosen key instead of offering every ssh-agent identity first.
+    const iIdx = args.indexOf('-i');
+    expect(iIdx).toBeGreaterThanOrEqual(0);
+    expect(args[iIdx + 1]).toBe('/home/user/.ssh/id_ed25519');
+  });
+
+  it('does not emit IdentitiesOnly for non-key auth modes', () => {
+    const t = new OpenSshTransport({ ...baseCfg, authMode: 'kerberos' });
+    expect(t.buildArgs({ timeoutMs: 60000 })).not.toContain('IdentitiesOnly=yes');
+  });
+
   it('emits password-specific flags when authMode=password', () => {
     const t = new OpenSshTransport({ ...baseCfg, authMode: 'password', password: 'hunter2' });
     const args = t.buildArgs({ timeoutMs: 60000 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
+import { buildOpenSshSudoWrapper, classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
 
 describe('classifyError', () => {
   it('returns undefined for success (exit 0)', () => {
@@ -182,6 +182,19 @@ describe('renderAskpassHelper (finding 5: Windows metachar-safe password echo)',
   });
 });
 
+describe('buildOpenSshSudoWrapper (Codex P1: keep sudo password out of local ssh argv)', () => {
+  it('builds a passwordless sudo command without sudo -S', () => {
+    expect(buildOpenSshSudoWrapper('id -u', false)).toBe("sudo -n sh -c 'id -u'");
+  });
+
+  it('builds a sudo -S command but never embeds the password value', () => {
+    const cmd = buildOpenSshSudoWrapper("printf '%s' ok", true);
+    expect(cmd).toContain('sudo -p "" -S');
+    expect(cmd).toContain("sh -c 'printf '\\''%s'\\'' ok'");
+    expect(cmd).not.toContain('sudopw');
+  });
+});
+
 describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when only suPassword set)', () => {
   function makeTransport(cfg: any) {
     const t = new OpenSshTransport({
@@ -202,11 +215,15 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     expect(runSsh).not.toHaveBeenCalled();
   });
 
-  it('uses the normal sudo wrapper when a sudo password is available', async () => {
+  it('uses a stdin-fed sudo wrapper when a sudo password is available (password never in argv)', async () => {
     const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw', sudoPassword: 'sudopw' });
     await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
     expect(runSsh).toHaveBeenCalledTimes(1);
     expect(runSuViaPty).not.toHaveBeenCalled();
+    const [wrapped, runOpts] = runSsh.mock.calls[0];
+    expect(wrapped).toContain('sudo -p "" -S');
+    expect(wrapped).not.toContain('sudopw');
+    expect(runOpts.stdin).toBe('sudopw\n');
   });
 
   it('uses the normal sudo wrapper (passwordless) when neither su nor sudo password is set', async () => {
@@ -214,6 +231,9 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
     expect(runSsh).toHaveBeenCalledTimes(1);
     expect(runSuViaPty).not.toHaveBeenCalled();
+    const [wrapped, runOpts] = runSsh.mock.calls[0];
+    expect(wrapped).toBe("sudo -n sh -c 'whoami'");
+    expect(runOpts.stdin).toBeUndefined();
   });
 
   it('prefers an explicit per-call sudo password over the su fallback', async () => {
@@ -221,5 +241,9 @@ describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when 
     await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo', password: 'callpw' });
     expect(runSsh).toHaveBeenCalledTimes(1);
     expect(runSuViaPty).not.toHaveBeenCalled();
+    const [wrapped, runOpts] = runSsh.mock.calls[0];
+    expect(wrapped).toContain('sudo -p "" -S');
+    expect(wrapped).not.toContain('callpw');
+    expect(runOpts.stdin).toBe('callpw\n');
   });
 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { classifyError, OpenSshTransport } from '../src/transports/openssh';
+import { describe, it, expect, vi } from 'vitest';
+import { classifyError, OpenSshTransport, renderAskpassHelper } from '../src/transports/openssh';
 
 describe('classifyError', () => {
   it('returns undefined for success (exit 0)', () => {
@@ -138,5 +138,72 @@ describe('OpenSshTransport.buildArgs', () => {
     const args = t.buildArgs({ timeoutMs: 60000 });
     expect(args).toContain('ServerAliveInterval=30');
     expect(args).toContain('ServerAliveCountMax=3');
+  });
+});
+
+describe('renderAskpassHelper (finding 5: Windows metachar-safe password echo)', () => {
+  it('does not use a bare `echo %VAR%` on Windows', () => {
+    const content = renderAskpassHelper('SSH_MCP_PW_1234', true);
+    // The bug was `echo %VAR%`, which CMD re-parses and breaks on & | < > ^ %.
+    expect(content).not.toMatch(/echo\s+%SSH_MCP_PW_1234%/);
+  });
+
+  it('reads the password via PowerShell $env:VAR (no command-line substitution)', () => {
+    const content = renderAskpassHelper('SSH_MCP_PW_1234', true);
+    expect(content).toContain('powershell');
+    expect(content).toContain('$env:SSH_MCP_PW_1234');
+    // Password value itself is never placed in the script text.
+    expect(content).not.toContain('hunter2');
+  });
+
+  it('emits a metacharacter-safe printf on POSIX', () => {
+    const content = renderAskpassHelper('SSH_MCP_PW_1234', false);
+    expect(content).toContain('#!/bin/sh');
+    expect(content).toContain('printf');
+    expect(content).toContain('"$SSH_MCP_PW_1234"');
+    // Must NOT interpolate the value unquoted (would break on metacharacters).
+    expect(content).not.toMatch(/echo\s+\$SSH_MCP_PW_1234/);
+  });
+});
+
+describe('OpenSshTransport.execElevated sudo mode (finding 6: route via su when only suPassword set)', () => {
+  function makeTransport(cfg: any) {
+    const t = new OpenSshTransport({
+      host: 'h', port: 22, username: 'u', ...cfg,
+    });
+    const runSuViaPty = vi.fn().mockResolvedValue({ stdout: 'root-out', stderr: '', exitCode: 0 });
+    const runSsh = vi.fn().mockResolvedValue({ stdout: 'sudo-out', stderr: '', exitCode: 0 });
+    (t as any).runSuViaPty = runSuViaPty;
+    (t as any).runSsh = runSsh;
+    return { t, runSuViaPty, runSsh };
+  }
+
+  it('routes sudo-exec through the su PTY when only suPassword is set (no sudo password)', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw' });
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
+    expect(runSuViaPty).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).toHaveBeenCalledWith('whoami', 'supw', expect.objectContaining({ mode: 'sudo' }));
+    expect(runSsh).not.toHaveBeenCalled();
+  });
+
+  it('uses the normal sudo wrapper when a sudo password is available', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw', sudoPassword: 'sudopw' });
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
+    expect(runSsh).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).not.toHaveBeenCalled();
+  });
+
+  it('uses the normal sudo wrapper (passwordless) when neither su nor sudo password is set', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({});
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo' });
+    expect(runSsh).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).not.toHaveBeenCalled();
+  });
+
+  it('prefers an explicit per-call sudo password over the su fallback', async () => {
+    const { t, runSuViaPty, runSsh } = makeTransport({ suPassword: 'supw' });
+    await t.execElevated('whoami', { timeoutMs: 60000, mode: 'sudo', password: 'callpw' });
+    expect(runSsh).toHaveBeenCalledTimes(1);
+    expect(runSuViaPty).not.toHaveBeenCalled();
   });
 });

--- a/test/openssh.unit.test.ts
+++ b/test/openssh.unit.test.ts
@@ -320,6 +320,23 @@ describe('OpenSshTransport.isConnected (Codex 3541767250: initialized != connect
     expect(t.isConnected()).toBe(false);
   });
 
+  it.each([
+    ['auth', 'Permission denied'],
+    ['host_key', 'Host key verification failed.'],
+    ['connect', 'Connection refused'],
+    ['transport', 'spawn error'],
+    ['timeout', 'timed out'],
+  ] as const)('clears stale connected state after a later %s failure', async (category, stderr) => {
+    const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
+    runSsh
+      .mockResolvedValueOnce({ stdout: 'ok', stderr: '', exitCode: 0 })
+      .mockResolvedValueOnce({ stdout: '', stderr, exitCode: 255, category });
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(true);
+    await t.exec('true', { timeoutMs: 60000 });
+    expect(t.isConnected()).toBe(false);
+  });
+
   it('reports connected once a later command succeeds after an initial connect failure', async () => {
     const { t, runSsh } = makeTransport({ authMode: 'kerberos' });
     runSsh

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -126,6 +126,47 @@ describe('TransportRegistry.get (finding 1: rejected init must not be cached)', 
     expect(init).toHaveBeenCalledTimes(1);
   });
 
+  // finding: per-host key reads must be deferred to get(name), not run at
+  // register()/bootstrap time, so a missing key on one host cannot break
+  // startup or list-servers for the other healthy hosts.
+  it('runs prepareConfig lazily on first get(name), never at register()', async () => {
+    const prepare = vi.fn<[ServerConfig], Promise<void>>().mockResolvedValue(undefined);
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry(prepare);
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    // Not called at register / list time.
+    expect(prepare).not.toHaveBeenCalled();
+    r.list();
+    expect(prepare).not.toHaveBeenCalled();
+
+    // Called exactly once, only for the selected host, on first get.
+    await r.get('a');
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(prepare.mock.calls[0][0].name).toBe('a');
+  });
+
+  it('a prepareConfig failure for one host is not cached and does not affect other hosts', async () => {
+    const prepare = vi.fn<[ServerConfig], Promise<void>>()
+      .mockRejectedValueOnce(new Error('ENOENT: missing key'))
+      .mockResolvedValue(undefined);
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry(prepare);
+    r.register(makeConfig('broken'));
+    r.register(makeConfig('healthy'));
+
+    // First get('broken'): prepare rejects -> get rejects, nothing cached.
+    await expect(r.get('broken')).rejects.toThrow(/missing key/);
+    // The other host is unaffected.
+    await expect(r.get('healthy')).resolves.toBe(stub);
+    // A later get('broken') retries prepare (now resolves).
+    await expect(r.get('broken')).resolves.toBe(stub);
+  });
+
   it('serializes concurrent gets so init runs once for parallel callers', async () => {
     let resolveInit: () => void = () => {};
     const init = vi.fn<() => Promise<void>>().mockImplementation(
@@ -200,13 +241,31 @@ describe('TransportRegistry.list / closeAll', () => {
 
     let rows = r.list();
     expect(rows.map((x) => x.name)).toEqual(['a', 'b']);
-    expect(rows.find((x) => x.name === 'a')!.isDefault).toBe(true);
+    // finding 6: with >1 server and no explicit setDefault(), get() rejects an
+    // omitted connectionName, so NO host is advertised as a usable default.
+    expect(rows.every((x) => x.isDefault === false)).toBe(true);
     expect(rows.every((x) => x.connected === false)).toBe(true);
 
     await r.get('a');
     rows = r.list();
     expect(rows.find((x) => x.name === 'a')!.connected).toBe(true);
     expect(rows.find((x) => x.name === 'b')!.connected).toBe(false);
+  });
+
+  it('marks the lone server as the default (single-server case)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('solo'));
+    expect(r.list().find((x) => x.name === 'solo')!.isDefault).toBe(true);
+  });
+
+  it('marks only the explicitly-set default when multiple servers are configured', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setDefault('b');
+    const rows = r.list();
+    expect(rows.find((x) => x.name === 'a')!.isDefault).toBe(false);
+    expect(rows.find((x) => x.name === 'b')!.isDefault).toBe(true);
   });
 
   it('closeAll closes connected transports and clears state', async () => {

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -279,4 +279,29 @@ describe('TransportRegistry.list / closeAll', () => {
     expect(close).toHaveBeenCalledTimes(1);
     expect(r.list().find((x) => x.name === 'a')!.connected).toBe(false);
   });
+
+  // Codex 3541767250: a cached transport that exposes an isConnected() probe
+  // (OpenSSH) must have list() defer to it, so a merely-initialized transport
+  // with no proven live session is reported as NOT connected.
+  it('defers to a cached transport isConnected() probe for connected status', async () => {
+    let live = false;
+    const stub = {
+      name: 'openssh',
+      init: vi.fn().mockResolvedValue(undefined),
+      exec: vi.fn(),
+      execElevated: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+      isConnected: () => live,
+    } as unknown as ISshTransport;
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('oss'));
+    // After init the transport is cached, but the probe says no live session yet.
+    await r.get('oss');
+    expect(r.list().find((x) => x.name === 'oss')!.connected).toBe(false);
+    // Once a command proves the host is live, the probe flips to true.
+    live = true;
+    expect(r.list().find((x) => x.name === 'oss')!.connected).toBe(true);
+  });
 });

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -140,6 +140,62 @@ describe('TransportRegistry.setRequireConnectionWhenMulti (require_connection op
   });
 });
 
+describe('TransportRegistry.wouldRejectOmittedName (Codex R2: audit/gating attribution guard mirror)', () => {
+  // index.ts resolvedProfileName() calls this BEFORE registry.get() to decide
+  // how to attribute an omitted/blank connectionName for gating + audit. It
+  // must return exactly the condition under which resolveName() rejects an
+  // omitted name, so a guard-rejected call is never attributed to (nor gated
+  // as) the first-registered host.
+  it('true for multi-source, no explicit default, guard ON (the reject case)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    expect(r.wouldRejectOmittedName()).toBe(true);
+  });
+
+  it('false for a single source (omitted name always resolves the lone host)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('solo'));
+    expect(r.wouldRejectOmittedName()).toBe(false);
+  });
+
+  it('false after an explicit setDefault() (omit-name shortcut re-enabled)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setDefault('b');
+    expect(r.wouldRejectOmittedName()).toBe(false);
+  });
+
+  it('false when the guard is opted out via setRequireConnectionWhenMulti(false)', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setRequireConnectionWhenMulti(false);
+    expect(r.wouldRejectOmittedName()).toBe(false);
+  });
+
+  it('false for an empty registry', () => {
+    const r = new TransportRegistry();
+    expect(r.wouldRejectOmittedName()).toBe(false);
+  });
+
+  it('matches resolveName(): predicate true <=> get() rejects an omitted name', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    // Guard armed: predicate true AND get() rejects.
+    expect(r.wouldRejectOmittedName()).toBe(true);
+    await expect(r.get()).rejects.toThrow(/connectionName is required/);
+    // Explicit default flips both to the resolve path.
+    r.setDefault('a');
+    expect(r.wouldRejectOmittedName()).toBe(false);
+    await expect(r.get()).resolves.toBe(stub);
+  });
+});
+
 describe('TransportRegistry.get (finding 1: rejected init must not be cached)', () => {
   it('retries init on a later get() after the first init rejects', async () => {
     const init = vi

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ISshTransport, ServerConfig } from '../src/transports/types';
+
+// The registry lazily builds transports via the factory's createTransport. Mock
+// it so we can drive init() success/failure deterministically without any real
+// SSH connection. vi.hoisted keeps the mock fn available inside the hoisted
+// vi.mock factory.
+const { createTransportMock } = vi.hoisted(() => ({ createTransportMock: vi.fn() }));
+vi.mock('../src/transports/factory.js', () => ({ createTransport: createTransportMock }));
+
+import { TransportRegistry } from '../src/transports/registry';
+
+function makeConfig(name: string): ServerConfig {
+  return { name, host: `${name}.example`, port: 22, username: 'u', transport: 'ssh2', authMode: 'password', password: 'pw' };
+}
+
+function makeStub(init: () => Promise<void>): ISshTransport {
+  return {
+    name: 'ssh2',
+    init,
+    exec: vi.fn(),
+    execElevated: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ISshTransport;
+}
+
+beforeEach(() => {
+  createTransportMock.mockReset();
+});
+
+describe('TransportRegistry.register / names / duplicate', () => {
+  it('registers configs and lists names in registration order', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    expect(r.names()).toEqual(['a', 'b']);
+    expect(r.hasAny()).toBe(true);
+    expect(r.getDefaultName()).toBe('a'); // first registered is the default
+  });
+
+  it('rejects a config with no name', () => {
+    const r = new TransportRegistry();
+    expect(() => r.register({ ...makeConfig('x'), name: '' })).toThrow(/name is required/);
+  });
+
+  it('rejects a duplicate server name', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    expect(() => r.register(makeConfig('a'))).toThrow(/Duplicate server name: a/);
+  });
+});
+
+describe('TransportRegistry.resolveName (finding 3: omitted name in multi-host)', () => {
+  it('throws when name omitted and >1 server configured with no explicit default', async () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    await expect(r.get()).rejects.toThrow(/connectionName is required when multiple servers are configured: a, b/);
+  });
+
+  it('still resolves by explicit name when multiple servers are configured', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    await expect(r.get('b')).resolves.toBe(stub);
+  });
+
+  it('allows omitted name after an explicit setDefault() even with multiple servers', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setDefault('b');
+    await expect(r.get()).resolves.toBe(stub);
+  });
+
+  it('resolves the lone server when only one is configured and name is omitted', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('solo'));
+    await expect(r.get()).resolves.toBe(stub);
+  });
+
+  it('throws a descriptive error for an unknown name', async () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    await expect(r.get('nope')).rejects.toThrow(/Unknown connection name: nope\. Registered: a/);
+  });
+});
+
+describe('TransportRegistry.get (finding 1: rejected init must not be cached)', () => {
+  it('retries init on a later get() after the first init rejects', async () => {
+    const init = vi
+      .fn<[], Promise<void>>()
+      .mockRejectedValueOnce(new Error('connect timeout'))
+      .mockResolvedValue(undefined);
+    const stub = makeStub(init);
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('flaky'));
+
+    // First get(): init rejects.
+    await expect(r.get('flaky')).rejects.toThrow(/connect timeout/);
+    // Second get(): the rejected promise must NOT be cached, so init runs again
+    // and now resolves.
+    await expect(r.get('flaky')).resolves.toBe(stub);
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches the live transport on success (init runs once across repeated gets)', async () => {
+    const init = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const stub = makeStub(init);
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('stable'));
+
+    const a = await r.get('stable');
+    const b = await r.get('stable');
+    expect(a).toBe(b);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent gets so init runs once for parallel callers', async () => {
+    let resolveInit: () => void = () => {};
+    const init = vi.fn<() => Promise<void>>().mockImplementation(
+      () => new Promise<void>((res) => { resolveInit = res; }),
+    );
+    const stub = makeStub(init);
+    createTransportMock.mockReturnValue(stub);
+
+    const r = new TransportRegistry();
+    r.register(makeConfig('p'));
+
+    const p1 = r.get('p');
+    const p2 = r.get('p');
+    resolveInit();
+    const [t1, t2] = await Promise.all([p1, p2]);
+    expect(t1).toBe(stub);
+    expect(t2).toBe(stub);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TransportRegistry.list / closeAll', () => {
+  it('reports connection status and default flag', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+
+    let rows = r.list();
+    expect(rows.map((x) => x.name)).toEqual(['a', 'b']);
+    expect(rows.find((x) => x.name === 'a')!.isDefault).toBe(true);
+    expect(rows.every((x) => x.connected === false)).toBe(true);
+
+    await r.get('a');
+    rows = r.list();
+    expect(rows.find((x) => x.name === 'a')!.connected).toBe(true);
+    expect(rows.find((x) => x.name === 'b')!.connected).toBe(false);
+  });
+
+  it('closeAll closes connected transports and clears state', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const stub = { name: 'ssh2', init: vi.fn().mockResolvedValue(undefined), exec: vi.fn(), execElevated: vi.fn(), close } as unknown as ISshTransport;
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    await r.get('a');
+    await r.closeAll();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(r.list().find((x) => x.name === 'a')!.connected).toBe(false);
+  });
+});

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -51,6 +51,17 @@ describe('TransportRegistry.register / names / duplicate', () => {
 });
 
 describe('TransportRegistry.resolveName (finding 3: omitted name in multi-host)', () => {
+  it('validates target selection synchronously without initializing a transport', () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+
+    expect(r.resolveRegisteredName('b')).toBe('b');
+    expect(() => r.resolveRegisteredName()).toThrow(/connectionName is required when multiple servers are configured: a, b/);
+    expect(() => r.resolveRegisteredName('nope')).toThrow(/Unknown connection name: nope\. Registered: a, b/);
+    expect(createTransportMock).not.toHaveBeenCalled();
+  });
+
   it('throws when name omitted and >1 server configured with no explicit default', async () => {
     const r = new TransportRegistry();
     r.register(makeConfig('a'));

--- a/test/registry.unit.test.ts
+++ b/test/registry.unit.test.ts
@@ -92,6 +92,54 @@ describe('TransportRegistry.resolveName (finding 3: omitted name in multi-host)'
   });
 });
 
+describe('TransportRegistry.setRequireConnectionWhenMulti (require_connection opt-out)', () => {
+  it('opts out of the multi-host omit-name guard when set false (routes to first-registered)', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    // Opt out: the guard must NOT fire, and an omitted name routes to the
+    // first-registered fallback ('a') without throwing.
+    r.setRequireConnectionWhenMulti(false);
+    await expect(r.get()).resolves.toBe(stub);
+  });
+
+  it('keeps the guard armed when set true explicitly (multi-host omit still throws)', async () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setRequireConnectionWhenMulti(true);
+    await expect(r.get()).rejects.toThrow(/connectionName is required when multiple servers are configured: a, b/);
+  });
+
+  it('guard is ON by default (no setter call) for multi-host omit', async () => {
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    await expect(r.get()).rejects.toThrow(/connectionName is required/);
+  });
+
+  it('opt-out does not affect single-source omit (always resolves the lone source)', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('solo'));
+    r.setRequireConnectionWhenMulti(false);
+    await expect(r.get()).resolves.toBe(stub);
+  });
+
+  it('an explicit name still routes correctly even when the guard is opted out', async () => {
+    const stub = makeStub(vi.fn().mockResolvedValue(undefined));
+    createTransportMock.mockReturnValue(stub);
+    const r = new TransportRegistry();
+    r.register(makeConfig('a'));
+    r.register(makeConfig('b'));
+    r.setRequireConnectionWhenMulti(false);
+    await expect(r.get('b')).resolves.toBe(stub);
+  });
+});
+
 describe('TransportRegistry.get (finding 1: rejected init must not be cached)', () => {
   it('retries init on a later get() after the first init rejects', async () => {
     const init = vi

--- a/test/result-mapper.test.ts
+++ b/test/result-mapper.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { resultToMcpContent } from '../src/index';
+import type { ExecResult } from '../src/transports/types';
+
+// Regression: previously any non-empty stderr threw "Error (code 0):" even when
+// the command exited 0. sudo-exec via ssh2 transport reliably tripped this
+// because sudo `-p "" -S` writes a trailing newline to stderr after consuming
+// the password, and many tools (curl/git/apt/dotnet) emit progress on stderr.
+
+describe('resultToMcpContent', () => {
+  const baseOk: ExecResult = { stdout: '', stderr: '', exitCode: 0 };
+
+  it('returns stdout on plain success', () => {
+    const r = resultToMcpContent({ ...baseOk, stdout: 'hello\n' });
+    expect(r.content[0]).toEqual({ type: 'text', text: 'hello\n' });
+  });
+
+  it('does NOT throw on exit 0 with stderr (regression for sudo-exec "Error (code 0):")', () => {
+    const r = resultToMcpContent({
+      stdout: 'uid=0(root)\n',
+      stderr: '\n', // sudo -S trailing newline
+      exitCode: 0,
+    });
+    expect((r.content[0] as any).type).toBe('text');
+    // Whitespace-only stderr is dropped; stdout is returned as-is.
+    expect((r.content[0] as any).text).toBe('uid=0(root)\n');
+  });
+
+  it('appends substantive stderr to stdout on exit 0', () => {
+    const r = resultToMcpContent({
+      stdout: 'apt output\n',
+      stderr: 'WARNING: apt does not have a stable CLI interface.\n',
+      exitCode: 0,
+    });
+    const text = (r.content[0] as any).text as string;
+    expect(text).toContain('apt output');
+    expect(text).toContain('[stderr]');
+    expect(text).toContain('stable CLI interface');
+  });
+
+  it('returns stderr-only output when stdout is empty and exit 0', () => {
+    const r = resultToMcpContent({
+      stdout: '',
+      stderr: 'progress info on stderr\n',
+      exitCode: 0,
+    });
+    expect((r.content[0] as any).text).toBe('progress info on stderr\n');
+  });
+
+  it('throws on non-zero exit with stderr', () => {
+    expect(() => resultToMcpContent({
+      stdout: '',
+      stderr: 'permission denied\n',
+      exitCode: 1,
+    })).toThrow(McpError);
+  });
+
+  it('treats null exitCode as 0 (legacy ssh2 close without code)', () => {
+    const r = resultToMcpContent({
+      stdout: 'data',
+      stderr: '\r\n',
+      exitCode: null,
+    });
+    expect((r.content[0] as any).text).toBe('data');
+  });
+
+  it('routes timeout category to typed error', () => {
+    expect(() => resultToMcpContent({
+      stdout: '',
+      stderr: 'Command execution timed out after 60000ms',
+      exitCode: null,
+      category: 'timeout',
+    })).toThrow(McpError);
+  });
+
+  it('routes auth category to typed error', () => {
+    expect(() => resultToMcpContent({
+      stdout: '',
+      stderr: 'permission denied (publickey)',
+      exitCode: 255,
+      category: 'auth',
+    })).toThrow(/SSH authentication error/);
+  });
+});


### PR DESCRIPTION
## Summary
Extend the approval system with per-profile description and approval settings so each configured SSH source can present its own policy and metadata.

## Compatibility / safety
This builds on the approval engine and keeps global defaults intact while allowing more specific per-profile overrides.

## Test plan
- npm run test -- --runInBand src/approval/__tests__/*.test.ts src/registry/__tests__/*.test.ts
- npm run build

## Stack note
This PR is part of a staged stack from fork branches. GitHub displays cumulative diffs because fork branches cannot be used as upstream PR bases; merge/read in the order below.

1. `pr/connection-name-guard`
2. `pr/toml-config`
3. `pr/audit-log`
4. `pr/connection-name-toml-optout` — builds on pr/connection-name-guard, pr/toml-config
5. `pr/approval-engine` — builds on pr/toml-config
6. `pr/per-source-approval` — builds on pr/approval-engine
7. `pr/webui-readonly` — builds on pr/audit-log, pr/approval-engine
8. `pr/webui-manual-approval` — builds on pr/webui-readonly
9. `pr/webui-mode-switch` — builds on pr/webui-manual-approval
10. `pr/webui-description-edit` — builds on pr/per-source-approval, pr/webui-mode-switch
11. `pr/config-watch-reload` — builds on pr/webui-description-edit

## Dependency notes
This PR builds on: `pr/approval-engine`.
