### PR TITLE
fix: treat non-zero exit code as failure, not stderr presence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -586,7 +586,11 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
         if (!isResolved) {
           isResolved = true;
           clearTimeout(timeoutId);
-          if (stderr) {
+          // Only treat this as a failure when the remote command actually exited
+          // non-zero. sudo/sh can write benign bytes to stderr (e.g. an empty
+          // "-p ''" prompt) even on success, so stderr content alone is not a
+          // reliable failure signal.
+          if (code !== 0) {
             reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
           } else {
             resolve({
@@ -661,7 +665,10 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
             isResolved = true;
             clearTimeout(timeoutId);
             conn.end();
-            if (stderr) {
+            // Only treat this as a failure when the remote command actually exited
+            // non-zero. sudo/sh can write benign bytes to stderr even on success,
+            // so stderr content alone is not a reliable failure signal.
+            if (code !== 0) {
               reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
             } else {
               resolve({


### PR DESCRIPTION
## Summary
`sudo-exec` (and plain `exec`) fail on **every successful** sudo command with a generic `Error (code 0):` even though the remote command actually succeeded (exit code `0`).

## Root cause
Both `execSshCommandWithConnection` and the legacy `execSshCommand` reject whenever the SSH stream produced *any* stderr output, regardless of the actual exit code:

```ts
stream.on('close', (code: number, signal: string) => {
  ...
  if (stderr) {
    reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
  } else {
    resolve(...);
  }
});
```

`sudo -p "" -S sh -c '...'` (the wrapper `sudo-exec` builds when a `sudoPassword` is configured) can write a handful of benign bytes to stderr even on success — e.g. an empty prompt from `-p ""`. That non-empty-but-harmless `stderr` alone triggers the rejection path, so the tool is unusable whenever `sudoPassword`/`suPassword` is configured.

## Fix
Check the actual exit `code` instead of stderr presence:

```ts
if (code !== 0) {
  reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
} else {
  resolve(...);
}
```

Applied to both `execSshCommandWithConnection` (used by `exec`/`sudo-exec`) and `execSshCommand` (legacy, used in tests).

## Repro
```bash
node build/index.js --host=<h> --user=<u> --password=<p> --sudoPassword=<sudo_pass>
```
Then call `sudo-exec` with `command: "whoami"` — fails with `Error (code 0):` before the fix, returns `root` after.

Verified against two real Linux hosts (password + sudo password configured) — `sudo-exec` now returns the command output as expected after the fix, and still correctly rejects when sudo password is wrong / exit code is non-zero.

## Notes
No test changes included — happy to add a unit test asserting the exit-code-based check if useful (e.g. mocking a stream that emits non-fatal stderr with `code=0`).
