### PR TITLE
fix: determine command success by exit code, not stderr output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -586,13 +586,14 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
         if (!isResolved) {
           isResolved = true;
           clearTimeout(timeoutId);
-          if (stderr) {
-            reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
+          const outcome = buildExecResult(code, signal, stdout, stderr);
+          if (!outcome.ok) {
+            reject(new McpError(ErrorCode.InternalError, outcome.message));
           } else {
             resolve({
               content: [{
                 type: 'text',
-                text: stdout,
+                text: outcome.text,
               }],
             });
           }
@@ -600,6 +601,47 @@ export async function execSshCommandWithConnection(manager: SSHConnectionManager
       });
     });
   });
+}
+
+/**
+ * Decide whether a finished remote command succeeded, and build its output.
+ *
+ * Success is determined by the exit status, not by whether the command wrote
+ * to stderr. Plenty of successful tools write to stderr (git, npm, apt,
+ * systemctl, curl progress), and treating that as failure both hides the real
+ * stdout and reports a false error.
+ *
+ * On success, stderr is appended to stdout so warnings are still visible,
+ * mirroring what `2>&1` would show in a terminal.
+ */
+export function buildExecResult(
+  code: number | null | undefined,
+  signal: string | null | undefined,
+  stdout: string,
+  stderr: string
+): { ok: true; text: string } | { ok: false; message: string } {
+  if (signal) {
+    return { ok: false, message: `Error (signal ${signal}):\n${stderr || stdout || '(no output)'}` };
+  }
+
+  // A missing exit code means the channel closed without reporting status.
+  // Treat that as success only when nothing was written to stderr.
+  if (code === null || code === undefined) {
+    return stderr
+      ? { ok: false, message: `Error (no exit code reported):\n${stderr}` }
+      : { ok: true, text: stdout };
+  }
+
+  if (code !== 0) {
+    return { ok: false, message: `Error (code ${code}):\n${stderr || stdout || '(no output)'}` };
+  }
+
+  if (!stderr) {
+    return { ok: true, text: stdout };
+  }
+
+  const separator = stdout && !stdout.endsWith('\n') ? '\n' : '';
+  return { ok: true, text: `${stdout}${separator}${stderr}` };
 }
 
 // Keep the old function for backward compatibility (used in tests)
@@ -661,13 +703,14 @@ export async function execSshCommand(sshConfig: any, command: string, stdin?: st
             isResolved = true;
             clearTimeout(timeoutId);
             conn.end();
-            if (stderr) {
-              reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
+            const outcome = buildExecResult(code, signal, stdout, stderr);
+            if (!outcome.ok) {
+              reject(new McpError(ErrorCode.InternalError, outcome.message));
             } else {
               resolve({
                 content: [{
                   type: 'text',
-                  text: stdout,
+                  text: outcome.text,
                 }],
               });
             }

--- a/test/exec-result.test.ts
+++ b/test/exec-result.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { buildExecResult } from '../src/index';
+
+describe('buildExecResult', () => {
+  describe('successful commands', () => {
+    it('returns stdout when the command exits 0 with no stderr', () => {
+      const result = buildExecResult(0, null, 'hello\n', '');
+      expect(result).toEqual({ ok: true, text: 'hello\n' });
+    });
+
+    it('still succeeds when a command exits 0 but writes to stderr', () => {
+      // Regression: this used to be reported as an error, and stdout was lost.
+      // Real examples: git, npm, apt, systemctl, curl progress output.
+      const result = buildExecResult(0, null, 'real output\n', 'Warning: deprecated\n');
+      expect(result.ok).toBe(true);
+      expect((result as { text: string }).text).toContain('real output');
+      expect((result as { text: string }).text).toContain('Warning: deprecated');
+    });
+
+    it('separates stdout and stderr with a newline when stdout lacks one', () => {
+      const result = buildExecResult(0, null, 'no trailing newline', 'warning\n');
+      expect((result as { text: string }).text).toBe('no trailing newline\nwarning\n');
+    });
+
+    it('does not add a second newline when stdout already ends with one', () => {
+      const result = buildExecResult(0, null, 'line\n', 'warning\n');
+      expect((result as { text: string }).text).toBe('line\nwarning\n');
+    });
+
+    it('returns stderr alone when the command wrote nothing to stdout', () => {
+      const result = buildExecResult(0, null, '', 'only stderr\n');
+      expect(result).toEqual({ ok: true, text: 'only stderr\n' });
+    });
+  });
+
+  describe('failed commands', () => {
+    it('fails on a non-zero exit code and reports stderr', () => {
+      const result = buildExecResult(1, null, '', 'command not found\n');
+      expect(result.ok).toBe(false);
+      expect((result as { message: string }).message).toContain('code 1');
+      expect((result as { message: string }).message).toContain('command not found');
+    });
+
+    it('fails on a non-zero exit code even when stderr is empty', () => {
+      // Regression: a silent failure used to be reported as success.
+      const result = buildExecResult(1, null, 'partial output\n', '');
+      expect(result.ok).toBe(false);
+      expect((result as { message: string }).message).toContain('code 1');
+      expect((result as { message: string }).message).toContain('partial output');
+    });
+
+    it('reports "(no output)" when a command fails silently', () => {
+      const result = buildExecResult(2, null, '', '');
+      expect(result.ok).toBe(false);
+      expect((result as { message: string }).message).toContain('(no output)');
+    });
+
+    it('fails when the command was killed by a signal', () => {
+      const result = buildExecResult(null, 'SIGKILL', 'partial\n', '');
+      expect(result.ok).toBe(false);
+      expect((result as { message: string }).message).toContain('SIGKILL');
+    });
+  });
+
+  describe('missing exit code', () => {
+    it('succeeds when no exit code is reported and stderr is empty', () => {
+      const result = buildExecResult(null, null, 'output\n', '');
+      expect(result).toEqual({ ok: true, text: 'output\n' });
+    });
+
+    it('fails when no exit code is reported but stderr has content', () => {
+      const result = buildExecResult(undefined, null, '', 'something broke\n');
+      expect(result.ok).toBe(false);
+      expect((result as { message: string }).message).toContain('something broke');
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`exec` treats **any** output on stderr as a command failure, rejects with an `McpError`, and discards stdout:

```ts
stream.on('close', (code, signal) => {
  if (stderr) {
    reject(new McpError(ErrorCode.InternalError, `Error (code ${code}):\n${stderr}`));
  } else {
    resolve({ content: [{ type: 'text', text: stdout }] });
  }
});
```

Many tools write to stderr while succeeding — `git`, `npm`, `apt`, `systemctl`, `curl` progress, `ssh -V`. For those, the caller gets an error and the real output is thrown away. Because the exit code is only interpolated into the message, the error can literally read `Error (code 0)`.

The inverse is broken too: a command that **fails** with nothing on stderr is reported as success. `exit 3` returns an empty result and looks fine.

## Reproduction

Against a real host (Raspberry Pi, Debian 12, OpenSSH 9.2p1), driving the server over stdio:

| command | v1.5.0 | this PR |
|---|---|---|
| `echo REAL_STDOUT; echo warning >&2` | `Error (code 0): warning` — stdout lost | `REAL_STDOUT\nwarning` |
| `ssh -V` | `Error (code 0): OpenSSH_9.2p1…` | `OpenSSH_9.2p1 Debian-2+deb12u9, OpenSSL 3.0.19` |
| `ls /definitely-not-here` | `Error (code 2): cannot access…` | unchanged — still an error |
| `exit 3` | empty success — failure swallowed | `Error (code 3): (no output)` |
| `echo plain` | `plain` | `plain` |

## Fix

Success is decided by exit status. On success, stderr is appended to stdout so warnings stay visible, mirroring `2>&1` in a terminal.

The logic was duplicated in `execSshCommandWithConnection()` and `execSshCommand()`, so it is extracted into a pure `buildExecResult(code, signal, stdout, stderr)` that both call. Being pure, it is unit-testable without an SSH server.

Also handled: kill-by-signal, and a channel that closes without reporting an exit code.

## Tests

`test/exec-result.test.ts` adds 11 unit tests covering both regressions, the newline seam between stdout and stderr, signal termination, and the missing-exit-code cases. These need no Docker and no SSH server.

The existing `should handle command with stderr` test in `test/persistent-connection.test.ts` still passes unchanged — it uses `echo "error" >&2 && exit 1`, which exits non-zero and so is still correctly an error.

I could not run the testcontainers-backed suites locally (no Docker available). Baseline before my change was 29 failed / 21 passed, all failures `ECONNREFUSED 127.0.0.1:2222`; after, 29 failed / 32 passed — same failures, +11 from the new file. The end-to-end verification above was done against a real SSH host instead.

## Scope

The `--suPassword` PTY path is deliberately untouched. It merges streams through a pseudo-terminal and never inspects exit codes, which is a separate concern (and related to #27 / #34).

## Compatibility

This is a behavior change: commands that exit 0 while writing to stderr now succeed rather than erroring. That is the point of the fix, but worth flagging if anyone depends on the old behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oKrJNRnh1iPsquKccUvT4