### PR TITLE
fix(ci): changesets publish input must be a single command

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -40,7 +40,17 @@ jobs:
         with:
           # No --provenance: trusted publishing generates provenance
           # attestations automatically for a public package from a public repo.
-          publish: npm run build && npm publish --access public
+          #
+          # One command only. The action splits this string on whitespace and
+          # execs it directly rather than handing it to a shell, so a `cmd-a &&
+          # cmd-b` form does not chain: npm receives `&&` and everything after
+          # it as extra arguments and appends them to the script body as escaped
+          # literals, which is how `npm run build && npm publish` turned into
+          # `shx chmod +x build/*.js '&&' 'npm' 'publish'` and failed with
+          # "File not found: &&". The build is already covered twice — by the
+          # Build step above and by the `prepare` lifecycle script, which npm
+          # runs before packing on publish.
+          publish: npm publish --access public
           version: npm run version
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'


### PR DESCRIPTION
The 2.0.0 publish failed. Nothing was released: no git tag was pushed and npm
still serves 1.5.0, so the registry state is clean.

## Cause

`changesets/action` splits the `publish` input on whitespace and execs it
rather than passing it to a shell, so `&&` does not chain commands. npm read
`run build && npm publish --access public` as `npm run build` plus four extra
arguments and appended them to the script body as escaped literals:

```
tsc && shx chmod +x build/*.js '&&' 'npm' 'publish' '--access' 'public'
```

`shx chmod` then treated `&&` as a filename:

```
chmod: File not found: /home/runner/work/ssh-mcp/ssh-mcp/&&
##[error]Publish command exited with code 1
```

`version: npm run version` was unaffected because it is a single command.

## Fix

Reduce the input to `npm publish --access public`. The build is covered twice
over — the workflow's own Build step, and npm's `prepare` script, which runs
before packing on publish.

Once this lands, the publish job re-runs on the push to main and 2.0.0 goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)