### PR TITLE
fix(ci): release workflow — publish via changeset publish, allow manual dispatch

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -3,6 +3,12 @@ name: Changesets
 on:
   push:
     branches: [main]
+  # A release can stop halfway for reasons that live outside the repository —
+  # the npm trusted publisher pointing at the wrong workflow file is what did it
+  # for 2.0.0. Once that is corrected there is nothing to commit, and without a
+  # manual trigger the only ways to retry are re-running a failed job or pushing
+  # an empty commit to main. Neither belongs in a release path.
+  workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -56,7 +56,15 @@ jobs:
           # "File not found: &&". The build is already covered twice — by the
           # Build step above and by the `prepare` lifecycle script, which npm
           # runs before packing on publish.
-          publish: npm publish --access public
+          #
+          # `changeset publish` rather than `npm publish`: the action learns what
+          # shipped from the structured output the changesets CLI writes, and
+          # nothing else produces it. Publishing with npm directly worked — 2.0.0
+          # reached the registry that way — but the action saw no released
+          # packages, so it silently skipped the git tag and the GitHub release
+          # and still reported success. changeset publish skips versions already
+          # on the registry, so a re-run is safe.
+          publish: npx changeset publish
           version: npm run version
           title: 'chore(release): version packages'
           commit: 'chore(release): version packages'


### PR DESCRIPTION
Two fixes to the release workflow, both found while shipping 2.0.0.

## 1. Tags and GitHub releases were silently skipped

2.0.0 is on npm with a signed provenance attestation, but the repo has no `2.0.0`
tag and no GitHub release. `changesets/action` learns which packages shipped
from the structured output the changesets CLI writes; a bare `npm publish` never
writes it, so the action concluded nothing was released, skipped both steps, and
reported success. The publish worked and the bookkeeping vanished — the failure
mode that is hardest to notice.

`publish: npx changeset publish` restores it. Versions already on the registry
are skipped, so this will not try to republish 2.0.0.

## 2. `workflow_dispatch`

The 2.0.0 release also stalled on something with no representation in the repo:
npm's trusted publisher named `publish.yml`, while the workflow that publishes is
`changesets.yml`, so the OIDC identity was rejected and npm answered `404` on the
`PUT`. Correcting that is a change on npm's side — there is no commit to make —
but with push-to-main as the only trigger, retrying meant re-running a failed job
or pushing an empty commit.

Neither change affects what gets published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)