### PR TITLE
fix(ci): drop registry-url so the release workflow's registry lookup works

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -22,10 +22,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No registry-url on purpose. It makes setup-node write a temporary .npmrc
+      # containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, and
+      # NODE_AUTH_TOKEN is deliberately unset here because publishing is done
+      # through OIDC. npm then sends that empty token on every request to the
+      # registry — including the `npm info` that `changeset publish` runs to
+      # decide what still needs publishing. The lookup came back unauthorised,
+      # changesets read that as "2.0.0 is not on npm", and tried to publish it
+      # again on a push that should have been a no-op. Publishing itself was
+      # unaffected, since OIDC supplies that identity separately.
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org/'
 
       # Trusted publishing needs npm >= 11.5.1, and every Node 22 release ships
       # npm 10.9.x. Without this the CLI never detects the OIDC environment and
@@ -62,8 +70,9 @@ jobs:
           # nothing else produces it. Publishing with npm directly worked — 2.0.0
           # reached the registry that way — but the action saw no released
           # packages, so it silently skipped the git tag and the GitHub release
-          # and still reported success. changeset publish skips versions already
-          # on the registry, so a re-run is safe.
+          # and still reported success. changeset publish decides what to ship
+          # by asking the registry first, which is why the .npmrc above matters:
+          # if that lookup cannot be trusted, neither can this step.
           publish: npx changeset publish
           version: npm run version
           title: 'chore(release): version packages'


### PR DESCRIPTION
Every push to main currently fails the Changesets workflow. Nothing is wrong on
npm — 2.0.0 is published and intact — but the release job goes red on ordinary
commits, which is the fastest way to teach everyone to ignore it.

## Cause

With no changesets pending, the action runs `changeset publish`. That command
asks the registry what is already released before shipping anything:

```
🦋  info npm info ssh-mcp
🦋  info ssh-mcp is being published because our local version (2.0.0)
        has not been published on npm
🦋  error You cannot publish over the previously published versions: 2.0.0.
```

`registry-url` on `setup-node` writes a temporary `.npmrc` containing
`//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. `NODE_AUTH_TOKEN` is
deliberately unset — publishing goes through OIDC — so npm attached an empty
token to the `npm info` request and the lookup came back unauthorised.
changesets read that as "not published yet".

`npm publish` was never affected: OIDC supplies that identity separately. Only
the read was broken, which is why 2.0.0 shipped correctly while this check did
not.

## Fix

Drop `registry-url`. Trusted publishing already targets the default registry, so
no `.npmrc` is needed, and the lookup goes out anonymously as it should.

## What this does not prove

The publish path itself only gets exercised by a real release. This change
removes the `.npmrc` that `npm publish` was previously running alongside — OIDC
does not depend on it, but the next release is the first run that demonstrates
it end to end.

Also corrects a comment added in ed76d23 claiming `changeset publish` skips
already-published versions unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)