### PR TITLE
fix(ci): pin npm to 11.x — npm 12 changed npm info --json output

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -22,15 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # No registry-url on purpose. It makes setup-node write a temporary .npmrc
-      # containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`, and
-      # NODE_AUTH_TOKEN is deliberately unset here because publishing is done
-      # through OIDC. npm then sends that empty token on every request to the
-      # registry — including the `npm info` that `changeset publish` runs to
-      # decide what still needs publishing. The lookup came back unauthorised,
-      # changesets read that as "2.0.0 is not on npm", and tried to publish it
-      # again on a push that should have been a no-op. Publishing itself was
-      # unaffected, since OIDC supplies that identity separately.
+      # No registry-url: publishing goes through OIDC against the default
+      # registry, so the .npmrc setup-node would write for it — carrying an
+      # authToken line for a token we deliberately do not set — has nothing to
+      # contribute.
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
@@ -39,9 +34,18 @@ jobs:
       # npm 10.9.x. Without this the CLI never detects the OIDC environment and
       # silently falls back to token auth — which, with no token configured,
       # means the publish fails at the last step of a release.
-      - name: Upgrade npm for trusted publishing
+      #
+      # Pinned to 11.x rather than @latest. npm 12 changed the shape of
+      # `npm info <pkg> --json`: 11 returns an object carrying a `versions`
+      # array, 12 returns an array. @changesets/cli reads `pkgInfo.versions`,
+      # which is undefined on an array, so under npm 12 it decided an already
+      # published version had never shipped and tried to publish over it. Its
+      # own guard for that case did not catch it either, because npm 12 also
+      # dropped `code` from the error JSON the guard matches on. Publishing was
+      # never affected — 2.0.0 went out under npm 12 — only the read was.
+      - name: Install npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
           npm -v
 
       - run: npm ci


### PR DESCRIPTION
Every push to main fails the release workflow. npm is fine — 2.0.0 is published
and intact — but the job goes red on ordinary commits, which is the quickest way
to make a failing release indistinguishable from background noise.

## Cause

With no changesets pending, the action runs `changeset publish`. That asks the
registry what already shipped before publishing anything. Under npm 12 the
answer is unreadable:

| npm | `npm info ssh-mcp --json` |
|---|---|
| 11.9.0 | object, carrying a `versions` array |
| 12.0.2 | array, no `versions` key |

`@changesets/cli` reads `pkgInfo.versions`. On an array that is `undefined`, so
it falls back to an empty list and concludes the package has never been
published:

```
🦋  info ssh-mcp is being published because our local version (2.0.0)
        has not been published on npm
🦋  error an error occurred while publishing ssh-mcp: undefined
          You cannot publish over the previously published versions: 2.0.0.
```

changesets does guard against this — its own comment says `npm info` "can return
stale data at times" — but the guard matches on `error.code === "E403"`, and npm
12 also dropped `code` from the error JSON. Hence the `undefined` above, and a
hard failure where a skip was intended. Two symptoms, one root cause.

The runner got to npm 12 via `npm@latest`.

## Fix

Pin to `npm@11`. Trusted publishing needs >= 11.5.1, so 11.x satisfies it, and
the release path stops tracking a moving target — `@latest` in a release job is
a dependency that upgrades itself without review, which is what happened here.

## Scope

Publishing was never affected — 2.0.0 shipped under npm 12. Only the registry
read was broken, which is why the release succeeded and every push since has
failed.

Also supersedes the explanation in 937cada, which blamed the `.npmrc` authToken
line. That was wrong: removing it changed nothing and the failure reproduced
identically without it. The comment is corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)