### PR TITLE
fix(config): refuse to guess the host when several profiles are configured

### DIFF
--- a/.changeset/profile-ambiguity-guard.md
+++ b/.changeset/profile-ambiguity-guard.md
@@ -1,0 +1,28 @@
+---
+'ssh-mcp': patch
+---
+
+Refuse to guess which host to use when several profiles are configured and none is selected.
+
+`getProfile` fell back to `profiles[0]` when a tool call carried no `profile`
+argument and no `defaults.defaultProfile` was set. With several hosts configured
+that meant the command ran against whichever profile happened to be listed
+first — no argument, no warning — and the first one written down tends to be
+production.
+
+It now raises an error naming the configured profiles and both ways to resolve
+the ambiguity:
+
+```
+No profile selected and no default configured, but 3 profiles exist:
+prod, staging, dev. Pass a "profile" argument, or set
+defaults.defaultProfile in the config.
+```
+
+A single configured profile is unambiguous and still resolves without one.
+
+If you run several profiles without `defaultProfile` today, set it (or pass
+`profile` per call) — previously that configuration ran commands against the
+first profile in the file.
+
+Reported by @Isla-Liu in #54.

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -107,6 +107,18 @@ function normalizeConfig(raw: RawConfig): AppConfig {
 export function getProfile(config: AppConfig, name?: string): Profile {
   const targetName = name || config.defaults.defaultProfile;
   if (!targetName) {
+    // Falling back to profiles[0] meant that with several hosts configured and
+    // no default chosen, a command with no profile argument ran against
+    // whichever host happened to be listed first — silently, and typically the
+    // one written down first, which tends to be production. One profile is
+    // unambiguous; more than one is a question the caller has to answer.
+    if (config.profiles.length > 1) {
+      const names = config.profiles.map((p) => p.name).join(', ');
+      throw new Error(
+        `No profile selected and no default configured, but ${config.profiles.length} profiles exist: ${names}. ` +
+        `Pass a "profile" argument, or set defaults.defaultProfile in the config.`,
+      );
+    }
     return config.profiles[0];
   }
   const profile = config.profiles.find((p) => p.name === targetName);

--- a/test/unit/config/loader.test.ts
+++ b/test/unit/config/loader.test.ts
@@ -203,6 +203,40 @@ user = "deploy"
   it('throws for unknown profile', () => {
     expect(() => getProfile(config, 'staging')).toThrow(/not found/);
   });
+
+  // Reported in #54: with several hosts configured and no default chosen, the
+  // old fallback ran the command against profiles[0] — no argument, no warning,
+  // and typically the first host written down, which tends to be production.
+  describe('ambiguous selection', () => {
+    async function configWithoutDefault(...names: string[]): Promise<AppConfig> {
+      const path = await writeConfig(
+        names.map((n) => `\n[[profiles]]\nname = "${n}"\nhost = "${n}.example.com"\nuser = "test"\n`).join(''),
+      );
+      return loadConfig(path);
+    }
+
+    it('refuses to guess between several profiles', async () => {
+      const c = await configWithoutDefault('prod', 'staging', 'dev');
+      expect(() => getProfile(c)).toThrow(/No profile selected/);
+    });
+
+    it('names the candidates and both ways out', async () => {
+      const c = await configWithoutDefault('prod', 'staging');
+      // An error that does not say what to do next just moves the guessing.
+      expect(() => getProfile(c)).toThrow(/prod, staging/);
+      expect(() => getProfile(c)).toThrow(/defaultProfile/);
+    });
+
+    it('still resolves when only one profile exists', async () => {
+      const c = await configWithoutDefault('only');
+      expect(getProfile(c).name).toBe('only');
+    });
+
+    it('still resolves when the caller names one', async () => {
+      const c = await configWithoutDefault('prod', 'staging');
+      expect(getProfile(c, 'staging').name).toBe('staging');
+    });
+  });
 });
 
 describe('checkPermissions', () => {


### PR DESCRIPTION
Closes #54. Also resolves #57, since `defaultProfile` is the opt-out it asked for.

`getProfile` fell back to `profiles[0]` when a tool call carried no `profile`
argument and no `defaults.defaultProfile` was set. With several hosts configured
that meant the command ran against whichever profile happened to be listed
first — no argument, no warning — and the first host written down tends to be
production:

```
profiles = [prod, staging, dev], no default, no argument  ->  prod
```

@Isla-Liu raised exactly this in #54, against v1. I had assumed v2's profile
model made it moot; it did not. The model changed, the ambiguity did not.

## After

```
No profile selected and no default configured, but 3 profiles exist:
prod, staging, dev. Pass a "profile" argument, or set
defaults.defaultProfile in the config.
```

The message names the candidates and both ways out — an error that says only
"ambiguous" moves the guessing to the reader.

A single configured profile is still unambiguous and resolves without a default.

## Compatibility

Anyone running several profiles with no `defaultProfile` gets an error where the
call previously succeeded. That is the point: it previously succeeded against a
host nobody chose. Released as a patch with the remedy in the changelog.

Suite: 338 passed, 6 skipped (344).

🤖 Generated with [Claude Code](https://claude.com/claude-code)