### PR TITLE
fix(ssh): re-establish inside the retry when opening a session or exec channel

### DIFF
--- a/.changeset/session-open-reconnect.md
+++ b/.changeset/session-open-reconnect.md
@@ -1,0 +1,17 @@
+---
+'ssh-mcp': patch
+---
+
+Re-establish the connection when opening a session or exec channel, instead of retrying a dead one.
+
+Channel opens run under `openWithRetry`, but the callbacks reached for the SSH
+client directly. `openSession` checks the link first, so an already-dead
+connection is rebuilt there — the gap is a link that dies *after* that check,
+while the channel is opening. Every retry then called `getClient()` on a null
+client and threw the same `SSH connection not established`, so the retry re-ran a
+dead connection three times and gave up.
+
+Dropbear drops the whole connection under channel churn rather than refusing the
+individual channel, so it hits this readily; any server that closes connections
+under load can. `SftpClient` already re-established inside its retry — the
+session and exec paths now do the same.

--- a/src/ssh/connection.ts
+++ b/src/ssh/connection.ts
@@ -39,18 +39,31 @@ export class SSHConnection {
     this.sessions = new SessionManager({
       // Live read: the profile object can be replaced after construction.
       profile: () => this.profile,
-      openShell: () => new Promise((resolve, reject) => {
-        this.getClient().shell(
-          { term: 'xterm-256color', cols: 200, rows: 50 },
-          (err, stream) => (err ? reject(err) : resolve(stream)),
-        );
-      }),
-      openExec: (command) => new Promise((resolve, reject) => {
-        this.getClient().exec(
-          this.applyWorkdir(command),
-          (err, stream) => (err ? reject(err) : resolve(stream)),
-        );
-      }),
+      // ensureConnected inside the callback, not just before the retry: these
+      // run under openWithRetry, and Dropbear drops the whole connection under
+      // channel churn rather than merely refusing the channel. openSession does
+      // check the link first, but the link can die between that check and the
+      // channel opening — and then every retry reached getClient() on a dead
+      // client and threw the same "SSH connection not established", so the retry
+      // re-ran a corpse three times. SftpClient already did it this way.
+      openShell: async () => {
+        await this.ensureConnected();
+        return new Promise<ClientChannel>((resolve, reject) => {
+          this.getClient().shell(
+            { term: 'xterm-256color', cols: 200, rows: 50 },
+            (err, stream) => (err ? reject(err) : resolve(stream)),
+          );
+        });
+      },
+      openExec: async (command) => {
+        await this.ensureConnected();
+        return new Promise<ClientChannel>((resolve, reject) => {
+          this.getClient().exec(
+            this.applyWorkdir(command),
+            (err, stream) => (err ? reject(err) : resolve(stream)),
+          );
+        });
+      },
       onChannelOpened: () => { this.activeChannels++; },
       onChannelClosed: () => { this.activeChannels--; },
     });

--- a/test/integration/session-reconnect.test.ts
+++ b/test/integration/session-reconnect.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SSHConnection } from '../../src/ssh/connection.js';
+import { resolveCredentials } from '../../src/config/credential-resolver.js';
+import { isSshServerUp, assertAvailable, SSH_HOST } from './helpers.js';
+import { PORTS, profiles } from './fixtures.js';
+import type { BackgroundSession } from '../../src/ssh/session.js';
+
+/**
+ * Opening a session has to survive the connection being gone underneath it.
+ *
+ * Channel opens are already wrapped in openWithRetry, but the callbacks reached
+ * for the client directly: with the link dropped, every attempt threw "SSH
+ * connection not established" for the same reason, so the retry re-ran a dead
+ * connection three times and gave up. SftpClient had already learned this and
+ * re-establishes inside its retry; the session paths had not.
+ *
+ * Dropbear drops the whole connection under channel churn, which is how CI kept
+ * seeing this as an intermittent failure on that target rather than as the bug
+ * it is. Closing the connection reproduces the same state deterministically.
+ */
+const up = await isSshServerUp(SSH_HOST, PORTS.admin);
+assertAvailable(up, `admin (${SSH_HOST}:${PORTS.admin})`);
+
+describe.skipIf(!up)('opening a session after the connection dropped', () => {
+  let conn: SSHConnection;
+  const saved = { ...process.env };
+
+  afterEach(async () => {
+    await conn?.close().catch(() => {});
+    process.env = { ...saved };
+  });
+
+  async function connect(): Promise<SSHConnection> {
+    process.env.SSH_MCP_ADMIN_PASSWORD = 'secret';
+    const c = new SSHConnection(profiles.admin, await resolveCredentials(profiles.admin), new Map(), 'insecure');
+    await c.ensureConnected();
+    return c;
+  }
+
+  it('re-establishes for an interactive session', async () => {
+    conn = await connect();
+    await conn.close();
+    expect(conn.isConnected()).toBe(false);
+
+    const session = await conn.openSession({ name: 'reconnect-interactive', type: 'interactive' });
+    expect(session).toBeTruthy();
+
+    const result = await (session as any).run('echo reconnected');
+    expect(result.stdout.trim()).toBe('reconnected');
+  }, 40000);
+
+  it('re-establishes for a background session', async () => {
+    conn = await connect();
+    await conn.close();
+
+    const session = await conn.openSession({
+      name: 'reconnect-background',
+      type: 'background',
+      command: "sh -c 'echo bg-alive; sleep 1'",
+    }) as BackgroundSession;
+
+    await new Promise((r) => setTimeout(r, 1200));
+    expect(session.readOutput(10)).toContain('bg-alive');
+  }, 40000);
+
+  // The real failure mode. openSession calls ensureConnected() first, so a link
+  // that is already gone gets rebuilt there — that is why closing the
+  // connection is not enough to reproduce it. What CI hit on Dropbear is the
+  // link dying *after* that check, while the channel is being opened. Reaching
+  // past openSession into the session manager puts us in exactly that state.
+  it('re-establishes when the link dies after the pre-check', async () => {
+    conn = await connect();
+    (conn as any).client = null;
+
+    const session = await (conn as any).sessions.open({
+      name: 'reconnect-midflight',
+      type: 'background',
+      command: "sh -c 'echo survived'",
+    });
+
+    await new Promise((r) => setTimeout(r, 800));
+    expect(session.readOutput(10)).toContain('survived');
+  }, 40000);
+
+  it('re-establishes for a one-shot command', async () => {
+    conn = await connect();
+    await conn.close();
+
+    const result = await conn.exec('id -un');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('admin');
+  }, 40000);
+});


### PR DESCRIPTION
The CI badge on main is red, and it is reporting a real bug rather than a flaky
container.

```
FAIL test/integration/shell-compat.test.ts > Host compatibility — dropbear
     > runs a background session and buffers its output
Error: Failed to open background session: SSH connection not established
```

## Cause

Channel opens already run under `openWithRetry`, but the callbacks reached for
the SSH client directly:

```ts
openShell: () => new Promise((resolve, reject) => {
  this.getClient().shell(...)   // throws if the link is gone
}),
```

`openSession` calls `ensureConnected()` first, so a connection that is *already*
dead gets rebuilt there — which is why simply closing the connection does not
reproduce this. The gap is a link that dies **after** that check, while the
channel is opening. From then on every retry called `getClient()` on a null
client and threw the identical error, so the retry re-ran a dead connection three
times and gave up.

Dropbear drops the whole connection under channel churn rather than refusing the
individual channel, which is why that target surfaced it — and why it read as
intermittent infrastructure noise. `SftpClient` had already run into this and
carries a comment explaining it; it re-establishes inside its retry. The session
and exec paths did not.

## Fix

`await this.ensureConnected()` inside the `openShell` and `openExec` callbacks,
matching `SftpClient`.

## Verification

The new test reproduces the state deterministically — clearing the client after
the pre-check — and on the previous code fails with the message CI produced:

```
× re-establishes when the link dies after the pre-check
  → Failed to open background session: SSH connection not established
```

Being straight about the other three cases in that file: they pass before and
after. They cover session-open after a clean close, which already worked; only
the mid-flight case is a regression guard.

- Full suite: 342 passed, 6 skipped (348)
- `shell-compat` (the file that was failing) run five times consecutively: 20/20 each

🤖 Generated with [Claude Code](https://claude.com/claude-code)