### PR TITLE
fix(policy): harden the read-only classification gate

### DIFF
--- a/.changeset/readonly-shell-metacharacters.md
+++ b/.changeset/readonly-shell-metacharacters.md
@@ -1,0 +1,26 @@
+---
+'ssh-mcp': patch
+---
+
+**Security.** Treat every shell metacharacter as disqualifying when deciding whether a command is read-only.
+
+The gate that decides whether an allowlisted binary counts as `read-only` tested
+only `>`, `;` and `|`. Command substitution — `$(...)` and backticks — was not in
+that set, so a command like `ls $(...)` was classified read-only, accepted by
+`read-command`, and expanded by the remote shell, which ran the inner command.
+The `read-command` tool is what the `viewer` role is restricted to, so its
+read-only guarantee could be escaped.
+
+The gate now rejects every character with syntactic meaning to a shell —
+`; & | < > \` $ ( ) { }` and newlines — rather than enumerating dangerous
+constructs, which is a list that is never finished.
+
+**Behaviour change:** commands using shell syntax are no longer classified
+read-only even when the binary is allowlisted. `echo $HOME` and `ls | grep x` now
+fall to the `safe` class, which `read-command` refuses and `run-command` accepts
+under the profile's approval policy. If you granted a client standing permission
+for `read-command`, that permission is now narrower — which is what it was
+supposed to be.
+
+Reported privately. Upgrading is recommended for anyone relying on the `viewer`
+role or on `read-command` as a security boundary.

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -1,5 +1,24 @@
 import type { CommandClass, ParsedCommand } from '../types.js';
 
+/**
+ * Anything through which the shell can start a second command.
+ *
+ * This gate decides whether an allowlisted binary counts as read-only, and the
+ * allowlist only vouches for the binary — never for what a shell might run
+ * beside it. It used to test /[>;|]/, which let `ls $(touch /tmp/x)` through as
+ * read-only: `ls` is allowlisted, no listed metacharacter appears, and the
+ * remote shell expands the substitution and runs the inner command anyway
+ * (GHSA-r8hm-vpm8-cfh6).
+ *
+ * Listing every dangerous construct is a losing game — `$()`, backticks,
+ * `<(...)`, `${x:=...}`, `&&`, a bare newline — so this refuses every character
+ * with syntactic meaning to the shell instead, and `$` wholesale rather than
+ * just `$(`. The cost is that `echo $HOME` is no longer classified read-only.
+ * That is the right trade for the tool whose entire promise is that it cannot
+ * write: run-command still accepts it under policy.
+ */
+const SHELL_CONTROL_CHARS = /[;&|<>`$(){}\n\r]/;
+
 const READ_ONLY_ALLOWLIST = new Set([
   'ls', 'cat', 'grep', 'find', 'stat', 'df', 'du', 'head', 'tail', 'wc',
   'ps', 'uname', 'uptime', 'hostname', 'id', 'who', 'whoami', 'date',
@@ -110,7 +129,7 @@ export function classifyCommand(command: string): ParsedCommand {
 
   const twoWordPrefix = fullCommand.split(/\s+/).slice(0, 2).join(' ');
   if (READ_ONLY_ALLOWLIST.has(binary) || READ_ONLY_ALLOWLIST.has(twoWordPrefix)) {
-    if (/[>;|]/.test(trimmed)) {
+    if (SHELL_CONTROL_CHARS.test(trimmed)) {
       return { binary, fullCommand, class: 'safe' as CommandClass };
     }
     return { binary, fullCommand, class: 'read-only' as CommandClass };

--- a/test/integration/readonly-substitution.test.ts
+++ b/test/integration/readonly-substitution.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SSHConnection } from '../../src/ssh/connection.js';
+import { resolveCredentials } from '../../src/config/credential-resolver.js';
+import { classifyCommand } from '../../src/policy/classifier.js';
+import { isSshServerUp, assertAvailable, SSH_HOST } from './helpers.js';
+import { PORTS, profiles } from './fixtures.js';
+
+/**
+ * Reported privately as GHSA-r8hm-vpm8-cfh6.
+ *
+ * `read-command` refuses anything the classifier does not call `read-only`, and
+ * the classifier rejected shell metacharacters with /[>;|]/ — a set that leaves
+ * out `$(...)` and backticks. So `ls $(touch /tmp/x)` classified as read-only
+ * while the remote shell still expanded and ran the inner command.
+ *
+ * Two halves have to hold for the report to be real, and both are asserted
+ * here: the classifier must refuse the payload, and the remote shell must
+ * actually execute a substitution when one reaches it.
+ */
+const up = await isSshServerUp(SSH_HOST, PORTS.viewer);
+assertAvailable(up, `viewer (${SSH_HOST}:${PORTS.viewer})`);
+
+describe('command substitution is not read-only', () => {
+  const payloads = [
+    'ls $(touch /tmp/proof)',
+    'ls `touch /tmp/proof`',
+    'cat /etc/hostname $(id)',
+    'ls ${IFS}$(whoami)',
+    'echo $(cat /etc/shadow)',
+  ];
+
+  it.each(payloads)('refuses %s', (command) => {
+    expect(classifyCommand(command).class).not.toBe('read-only');
+  });
+
+  // The allowlisted commands themselves must keep working, or the fix has just
+  // broken the tool it was protecting.
+  it.each([
+    'ls -la',
+    'cat /etc/hostname',
+    'df -h',
+    'grep error /var/log/syslog',
+    'systemctl status nginx',
+  ])('still allows %s', (command) => {
+    expect(classifyCommand(command).class).toBe('read-only');
+  });
+});
+
+describe.skipIf(!up)('the remote shell does expand substitutions', () => {
+  let conn: SSHConnection;
+  let saved: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    saved = { ...process.env };
+    process.env.SSH_MCP_VIEWER_PASSWORD = 'viewpass';
+    conn = new SSHConnection(profiles.viewer, await resolveCredentials(profiles.viewer), new Map(), 'insecure');
+    await conn.ensureConnected();
+  }, 30000);
+
+  afterAll(async () => {
+    await conn?.close();
+    if (saved) process.env = saved;
+  });
+
+  // Establishes the impact rather than assuming it: had such a command reached
+  // the channel, the inner half would have run. This is why classification has
+  // to stop it before execution — nothing downstream will.
+  it('runs the inner command when a substitution reaches the channel', async () => {
+    const marker = '/tmp/substitution-proof';
+    await conn.exec(`rm -f ${marker}`);
+
+    await conn.exec(`ls $(touch ${marker})`);
+
+    const check = await conn.exec(`test -f ${marker} && echo CREATED || echo ABSENT`);
+    expect(check.stdout.trim()).toBe('CREATED');
+
+    await conn.exec(`rm -f ${marker}`);
+  }, 30000);
+});


### PR DESCRIPTION
Tightens the check that decides whether an allowlisted binary counts as
`read-only`.

It tested `/[>;|]/` — three metacharacters. Shell syntax offers many more ways to
introduce a second command, and an allowlist vouches for the *binary*, never for
what a shell might run beside it. Enumerating the dangerous constructs is a list
that never finishes, so the gate now refuses every character with syntactic
meaning to a shell: `; & | < > \` $ ( ) { }` and newlines.

## Behaviour change

Commands using shell syntax are no longer classified read-only even when the
binary is allowlisted. `echo $HOME` and `ls | grep x` fall to `safe`, which
`read-command` refuses and `run-command` accepts under the profile's approval
policy.

That narrows `read-command` for anyone who granted a client standing permission
for it. Narrower is the point: it is the tool the `viewer` role is confined to,
and its only promise is that it cannot write.

## Tests

Both directions, because a gate that refuses everything is as broken as one that
refuses nothing:

- the substitution payloads are refused
- `ls -la`, `cat /etc/hostname`, `df -h`, `grep ...`, `systemctl status ...`
  still classify read-only
- a live-server check that a substitution reaching the channel really does
  execute the inner command — the impact is established, not assumed

Suite: 353 passed, 6 skipped (359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)