### PR TITLE
test: cover the OPA authorization path and audit chain continuity

### DIFF
--- a/test/unit/audit/chain-continuity.test.ts
+++ b/test/unit/audit/chain-continuity.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile, appendFile } from 'fs/promises';
+import { createHash } from 'crypto';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { AuditStore } from '../../../src/audit/store.js';
+
+/**
+ * The hash chain is what makes the audit log tamper-evident: each line commits
+ * to the one before it, so a deleted or edited entry stops verifying instead of
+ * simply disappearing.
+ *
+ * That only holds if the chain survives a restart. `loadLastHash()` reads the
+ * tail of an existing log to pick the chain back up, and it had no test — so a
+ * silent restart to `prevHash: ""` would look exactly like a normal log, and
+ * anything spanning a restart would be unverifiable without anyone noticing.
+ */
+const base = {
+  mcpRequestId: 1,
+  profile: 'dev',
+  user: 'test',
+  commandClass: 'read-only' as const,
+  binary: 'ls',
+  decision: 'allow' as const,
+  exitCode: 0,
+  durationMs: 1,
+};
+
+let dir: string;
+let logPath: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'ssh-mcp-chain-'));
+  logPath = join(dir, 'audit.log');
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function lines(): Promise<any[]> {
+  const raw = await readFile(logPath, 'utf8');
+  return raw.trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+}
+
+async function write(store: AuditStore, command: string): Promise<void> {
+  await store.record({ ...base, command });
+}
+
+describe('audit hash chain', () => {
+  it('links each entry to the one before it', async () => {
+    const store = new AuditStore(logPath, false, true);
+    await write(store, 'ls -la');
+    await write(store, 'df -h');
+    await write(store, 'whoami');
+    await store.close();
+
+    const [a, b, c] = await lines();
+    expect(a.prevHash).toBe('');
+    expect(b.prevHash).toBe(a.selfHash);
+    expect(c.prevHash).toBe(b.selfHash);
+    expect(new Set([a.selfHash, b.selfHash, c.selfHash]).size).toBe(3);
+  });
+
+  // The regression this file exists for.
+  it('picks the chain back up in a new process', async () => {
+    const first = new AuditStore(logPath, false, true);
+    await write(first, 'ls -la');
+    await write(first, 'df -h');
+    await first.close();
+
+    const before = await lines();
+
+    const second = new AuditStore(logPath, false, true);
+    await write(second, 'whoami');
+    await second.close();
+
+    const after = await lines();
+    expect(after).toHaveLength(3);
+    // Not a fresh chain: the entry written by the second instance commits to
+    // the last entry written by the first.
+    expect(after[2].prevHash).toBe(before[1].selfHash);
+    expect(after[2].prevHash).not.toBe('');
+  });
+
+  it('produces a chain that verifies end to end', async () => {
+    const first = new AuditStore(logPath, false, true);
+    await write(first, 'ls -la');
+    await first.close();
+    const second = new AuditStore(logPath, false, true);
+    await write(second, 'df -h');
+    await second.close();
+
+    // Recompute the way the writer does: the line without its hash fields,
+    // plus the previous hash.
+    let prev = '';
+    for (const entry of await lines()) {
+      const { prevHash, selfHash, ...body } = entry;
+      expect(prevHash).toBe(prev);
+      expect(createHash('sha256').update(JSON.stringify(body) + prevHash).digest('hex')).toBe(selfHash);
+      prev = selfHash;
+    }
+  });
+
+  it('detects an edited entry', async () => {
+    const store = new AuditStore(logPath, false, true);
+    await write(store, 'ls -la');
+    await write(store, 'rm -rf /tmp/evidence');
+    await store.close();
+
+    const all = await lines();
+    // Someone rewrites the second command to look harmless but leaves the
+    // hashes alone.
+    all[1].command = 'ls -la';
+    await writeFile(logPath, all.map((l) => JSON.stringify(l)).join('\n') + '\n');
+
+    const [, tampered] = await lines();
+    const { prevHash, selfHash, ...body } = tampered;
+    expect(createHash('sha256').update(JSON.stringify(body) + prevHash).digest('hex')).not.toBe(selfHash);
+  });
+
+  it('starts a fresh chain when there is no log yet', async () => {
+    const store = new AuditStore(logPath, false, true);
+    await write(store, 'ls -la');
+    await store.close();
+    expect((await lines())[0].prevHash).toBe('');
+  });
+
+  // An empty file is the state left by a crash between create and first write.
+  it('starts fresh on an empty file rather than failing to open', async () => {
+    await writeFile(logPath, '');
+    const store = new AuditStore(logPath, false, true);
+    await write(store, 'ls -la');
+    await store.close();
+
+    const all = await lines();
+    expect(all).toHaveLength(1);
+    expect(all[0].prevHash).toBe('');
+  });
+
+  // A half-written trailing line is what a kill -9 mid-append leaves behind.
+  // Logging must keep working; the broken line is the evidence of the crash.
+  it('keeps logging when the last line is truncated', async () => {
+    const first = new AuditStore(logPath, false, true);
+    await write(first, 'ls -la');
+    await first.close();
+    await appendFile(logPath, '{"command":"df -h","selfHa');
+
+    const second = new AuditStore(logPath, false, true);
+    await expect(write(second, 'whoami')).resolves.not.toThrow();
+    await second.close();
+
+    const raw = await readFile(logPath, 'utf8');
+    expect(raw).toContain('whoami');
+  });
+});

--- a/test/unit/policy/opa.test.ts
+++ b/test/unit/policy/opa.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createServer, type Server } from 'http';
+import { AddressInfo } from 'net';
+import { PolicyEngine, DEFAULT_RULES } from '../../../src/policy/engine.js';
+import type { Profile } from '../../../src/types.js';
+
+/**
+ * OPA is the second authorization layer, and none of it was covered.
+ *
+ * Two guarantees live here and neither is visible from the outside once it
+ * breaks. The deny branch is a gate some operators deploy as their real
+ * authorization boundary — if it stops denying, nothing says so. And the
+ * fallback is deliberately fail-open, which is only defensible because it is
+ * loud: an operator whose OPA is down keeps running commands OPA would have
+ * refused, and the warning is their only signal.
+ *
+ * A real HTTP server rather than a stubbed fetch, so the error paths — a 500, a
+ * refused connection — are the ones the code will actually meet.
+ */
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    name: 'dev', group: 'dev', host: 'localhost', port: 22, user: 'test',
+    auth: 'agent', tty: false, timeout: 60000, maxChars: 5000,
+    maxOutputBytes: 1048576, role: 'operator', readOnly: false,
+    approvalPolicy: 'ask-destructive', cert: false,
+    sessionMaxPerConnection: 5, sessionIdleTimeoutMs: 60000,
+    sessionBackgroundMaxMs: 3600000, commandQuotaPerDay: 0,
+    ...overrides,
+  };
+}
+
+describe('OPA evaluation', () => {
+  let server: Server | undefined;
+  let url: string;
+  let requests: any[] = [];
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  async function startOpa(handler: (req: any) => { status?: number; body?: unknown }) {
+    requests = [];
+    server = createServer((req, res) => {
+      let raw = '';
+      req.on('data', (c) => (raw += c));
+      req.on('end', () => {
+        const parsed = raw ? JSON.parse(raw) : {};
+        requests.push(parsed);
+        const { status = 200, body = {} } = handler(parsed);
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end(JSON.stringify(body));
+      });
+    });
+    await new Promise<void>((r) => server!.listen(0, '127.0.0.1', r));
+    url = `http://127.0.0.1:${(server!.address() as AddressInfo).port}`;
+  }
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (server) await new Promise<void>((r) => server!.close(() => r()));
+    server = undefined;
+  });
+
+  it('denies when OPA says no, even though the local policy allowed it', async () => {
+    await startOpa(() => ({ body: { result: false } }));
+    const engine = new PolicyEngine(DEFAULT_RULES);
+    engine.setOpaUrl(url);
+
+    const local = engine.evaluate('ls -la', makeProfile(), 'read-command');
+    expect(local.decision).not.toBe('deny');
+
+    const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+    expect(result.decision).toBe('deny');
+    expect(result.ruleId).toBe('opa');
+  });
+
+  it('keeps the local decision when OPA says yes', async () => {
+    await startOpa(() => ({ body: { result: true } }));
+    const engine = new PolicyEngine(DEFAULT_RULES);
+    engine.setOpaUrl(url);
+
+    const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+    expect(result.decision).not.toBe('deny');
+    expect(result.ruleId).not.toBe('opa');
+  });
+
+  // The request body is the whole basis on which an operator writes their rego.
+  // If a field is dropped or renamed, their policy silently stops matching and
+  // evaluates against undefined.
+  it('sends the subject, action, resource and context the policy is written against', async () => {
+    await startOpa(() => ({ body: { result: true } }));
+    const engine = new PolicyEngine(DEFAULT_RULES);
+    engine.setOpaUrl(url);
+
+    await engine.evaluateWithOpa('rm -rf /tmp/build', makeProfile({ role: 'admin', name: 'prod' }), 'run-command');
+
+    expect(requests).toHaveLength(1);
+    const { input } = requests[0];
+    expect(input.subject).toEqual({ role: 'admin', profile: 'prod' });
+    expect(input.action).toEqual({ tool: 'run-command', commandClass: 'destructive' });
+    expect(input.resource.binary).toBe('rm');
+    expect(input.resource.host).toBe('localhost');
+    expect(input.context).toEqual({ readOnly: false });
+  });
+
+  it('does not consult OPA when the local policy already denied', async () => {
+    await startOpa(() => ({ body: { result: true } }));
+    const engine = new PolicyEngine(DEFAULT_RULES);
+    engine.setOpaUrl(url);
+
+    // A forbidden command is denied locally; asking OPA could only overturn it.
+    const result = await engine.evaluateWithOpa('rm -rf /', makeProfile(), 'run-command');
+    expect(result.decision).toBe('deny');
+    expect(requests).toHaveLength(0);
+  });
+
+  describe('when OPA is unavailable', () => {
+    it('falls back to the local decision on an HTTP error, and says so', async () => {
+      await startOpa(() => ({ status: 500, body: { error: 'boom' } }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(url);
+
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).not.toBe('deny');
+
+      const warning = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(warning).toContain('POLICY WARNING');
+      // The consequence, not just the symptom: silence here is the whole risk.
+      expect(warning).toMatch(/may now be allowed/);
+    });
+
+    it('falls back when nothing is listening, and says so', async () => {
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl('http://127.0.0.1:1');
+
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).not.toBe('deny');
+      expect(errSpy.mock.calls.map((c) => String(c[0])).join('\n')).toContain('POLICY WARNING');
+    });
+
+    // Throttled so a dead OPA cannot bury the log — but a throttle that never
+    // reopens would silence the signal permanently, so both halves are checked.
+    it('warns once per minute rather than on every command', async () => {
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl('http://127.0.0.1:1');
+
+      await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(errSpy).toHaveBeenCalledTimes(1);
+
+      // shouldAdvanceTime keeps real timers running underneath, so the fetch to
+      // a dead port still rejects while Date.now() jumps past the window.
+      vi.useFakeTimers({ shouldAdvanceTime: true, now: Date.now() + 61_000 });
+      try {
+        await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+        expect(errSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it('skips OPA entirely when no URL is configured', async () => {
+    const engine = new PolicyEngine(DEFAULT_RULES);
+    const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+    expect(result.decision).not.toBe('deny');
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Not a coverage-percentage exercise. The bypass we shipped as 2.0.4 was in
`classifier.ts` — a file at **100% coverage**. The tests there asserted what the
code did, not what the tool promised, so the number never moved and the gap was
invisible. These two are chosen the other way round: guarantees the product
advertises, with nothing checking them.

## OPA authorization path — `engine.ts`, previously 0% of it exercised

Searching the suite for `opa` returned one hit: the word "opaque" in a comment.
The entire second authorization layer was untested — the deny branch, the request
body, and the fallback.

Two things fail silently here:

- Some operators deploy OPA as their real authorization gate. If the deny branch
  stops denying, nothing says so.
- The fallback is deliberately fail-open, which is only defensible because it is
  loud. An operator whose OPA is down keeps running commands OPA would have
  refused, and the warning is their only signal. A throttle that never reopened
  would silence it permanently — so both halves are asserted.

Tested against a real HTTP server rather than a stubbed `fetch`, so the 500 and
connection-refused paths are the ones the code actually meets. The request body
is asserted field by field, since that shape is what an operator writes their
rego against.

## Audit chain continuity — `store.ts`

The hash chain makes the log tamper-evident only if it survives a restart.
`loadLastHash()` reads the tail of an existing log to pick the chain back up, and
had no test. A silent restart to `prevHash: ""` looks exactly like a normal log
while anything spanning the restart quietly stops being verifiable.

It is also the function rewritten yesterday for the CodeQL TOCTOU finding — a
security-relevant function changed with no test under it.

Covered: linking within a run, continuity across instances, end-to-end
recomputation, detection of an edited entry, and the states a crash leaves
behind (absent file, empty file, truncated last line).

## Both verified against a broken implementation

| Sabotage | Result |
|---|---|
| Remove the warning throttle | throttle test fails |
| Short-circuit `loadLastHash` | two chain tests fail |

| | before | after |
|---|---|---|
| `engine.ts` | 75.7% (funcs 77.8%) | 97.7% (funcs 100%) |
| `store.ts` | 67.8% | 90.2% |
| overall | 78.5% | 80.9% |

Suite: 368 passed, 6 skipped (374). No production code changed, so no changeset.

## Left alone deliberately

`index.ts` (18%) is CLI wiring the e2e suite drives in a spawned process, where
in-process instrumentation cannot follow it. `tracer.ts` (12.5%) is OTEL setup.
The remaining gaps in `session.ts` and `http.ts` are network-failure branches
where the mock would cost more than it proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)