### PR TITLE
ci: pull the sshd image from GHCR, authenticate to Docker Hub, retry pulls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Read here rather than in the step's `if:` so the condition can be
+      # evaluated at all — and so a pull request from a fork, which is never
+      # given secrets, resolves it to empty instead of failing.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -42,6 +47,39 @@ jobs:
       #
       # Keeping one definition also stops CI and docker-compose.yml drifting:
       # CI used to define three of the six servers and none of the sshd tuning.
+      # Anonymous pulls are rate limited per IP and Actions runners share IPs,
+      # so the quota goes to whoever else is on that address. Authenticating
+      # moves the limit onto this account, where a handful of images is nothing.
+      #
+      # This covers `alpine:3.20` and `node:22-slim`, which the build pulls from
+      # Docker Hub. It does *not* cover the sshd image — that comes from GHCR,
+      # and it was the one that actually failed on 2026-08-10. Both registries
+      # are behind the retry below.
+      - name: Log in to Docker Hub
+        # Skipped on pull requests from forks, which are never given secrets.
+        # Those keep pulling anonymously; the retry is what covers them.
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Pull separately from `up` so a throttled registry is retried rather than
+      # failing the job, and so the failure — if it survives three tries — names
+      # the registry instead of surfacing as an opaque compose error.
+      - name: Pull images
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose --profile test pull --quiet; then exit 0; fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 20))
+              echo "::warning::Image pull failed (attempt $attempt/3); retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          echo "::error::Could not pull the test images after 3 attempts — registry rate limit or outage"
+          exit 1
+
       - name: Start SSH test servers
         run: docker compose --profile test up -d --build --wait
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # ─── Test SSH Servers (role-based, for integration tests) ──────────────────
   ssh-admin:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest
     profiles: ["test"]
     environment:
       - USER_NAME=admin
@@ -14,7 +14,7 @@ services:
       - "2222:2222"
 
   ssh-viewer:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest
     profiles: ["test"]
     environment:
       - USER_NAME=viewer
@@ -26,7 +26,7 @@ services:
       - "2223:2222"
 
   ssh-operator:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest
     profiles: ["test"]
     environment:
       - USER_NAME=operator
@@ -42,7 +42,7 @@ services:
   # that an init hook enables AllowTcpForwarding, which the base image disables
   # — without it every direct-tcpip channel fails and the hop cannot be tested.
   ssh-bastion:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest
     profiles: ["test"]
     environment:
       - USER_NAME=bastion


### PR DESCRIPTION
A run on main failed on 2026-08-10 before a single test had started:

```
ssh-admin Error toomanyrequests: retry-after: 583.946µs, allowed: 44000/minute
```

Anonymous pulls are rate limited per IP, and Actions runners share IPs — the
quota goes to whoever else is on that address, not to this repository.

## Why three changes and not just the login

The obvious fix is a Docker Hub login. On its own it would not have prevented
this failure, because the images come from two registries:

| image | registry | used by |
|---|---|---|
| `openssh-server` | `lscr.io` | the four sshd services — **this is the one that failed** |
| `alpine:3.20`, `node:22-slim` | Docker Hub | the build step |

**`lscr.io` → `ghcr.io`.** `lscr.io` is linuxserver's redirector; GHCR is where
the image is actually served from, and it is on the same network as the runner.
The digests are identical, so this is not a different image:

```
lscr.io  sha256:96b9a4d3b5106746d08d43a6911650d4d21f7d5c7f2ac9660e792bdb5e63157c
ghcr.io  sha256:96b9a4d3b5106746d08d43a6911650d4d21f7d5c7f2ac9660e792bdb5e63157c
```

**Docker Hub login** for the base images the build pulls. Read-only token, and
the step is skipped when the secret is absent — pull requests from forks are
never given secrets, and failing their CI on a login step would be worse than
the problem being solved.

**A retry with backoff** around the pull. It is the only part that covers fork
pull requests, and it covers both registries. Pulling separately from `up` also
means a throttled registry gets named in the error rather than surfacing as an
opaque compose failure.

## Why bother

The badge went red twice in two days. One was a real defect that reached users —
the session reconnect bug fixed in 2.0.3 — and one was this. They look identical
from outside, and once infrastructure noise is common enough, the next real
failure gets waved through as "probably Docker again".

## Verification

- Digests compared directly: identical
- Stack brought up from GHCR locally; full suite passes: 368 passed, 6 skipped (374)
- `docker compose pull` skips the two build-only services cleanly rather than
  erroring, so the retry loop cannot fail on them

Nothing shipped changes — `files` is `build` only, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)