### PR TITLE
fix(policy): add --group, and name what actually caused a refusal

### DIFF
--- a/.changeset/cli-group-flag.md
+++ b/.changeset/cli-group-flag.md
@@ -1,0 +1,36 @@
+---
+'ssh-mcp': minor
+---
+
+Add `--group`, and say which of role, group and class caused a policy refusal.
+
+A quick-start profile (`--host`/`--user`, no config file) carried no host group,
+so it fell to the strictest tier — where the `admin` role has no `privileged`.
+`sudo` could therefore never run for anyone who had not written a TOML config,
+and no flag existed to change it. Reported in #91.
+
+`--group` accepts `prod`, `staging` or `dev`. The default is still `prod`:
+treating an unknown host as production is the safe guess, and what was missing
+was a way to correct it. An unrecognised value is rejected rather than quietly
+falling back to the prod bindings.
+
+```bash
+npx ssh-mcp --host=10.0.0.5 --user=deploy --group=dev
+```
+
+The refusal itself was also misleading. It read:
+
+```
+Role "admin" cannot run "privileged" commands
+```
+
+naming the role and the class but not the host group, which is usually what
+decided. It now names all three, lists what the role *can* run, and — when the
+group was inferred rather than configured — says so and how to set one:
+
+```
+Role "admin" on host group "prod" cannot run "privileged" commands
+(allowed: read-only, safe, destructive). No group is set for profile "default",
+so it defaulted to the most restrictive tier. Set group = "dev" or "staging" on
+the profile, or pass --group, if this host is not production.
+```

--- a/README.md
+++ b/README.md
@@ -244,6 +244,25 @@ without it the tier is guessed from the profile name (`prod`/`staging`/`dev`,
 the strictest tier. A production host named `web-01` is therefore treated as
 production rather than silently getting dev permissions.
 
+Note what this means for `sudo`: **`admin` has no `privileged` on `prod`**, so
+`privileged-command` is refused there by design — including on a quick-start
+profile, which has no name to infer from and therefore lands on `prod`. If the
+host is not production, say so:
+
+```bash
+npx ssh-mcp --host=10.0.0.5 --user=deploy --group=dev
+```
+
+```toml
+[[profiles]]
+name = "build-box"
+group = "dev"
+```
+
+Leaving a real production host on `prod` and granting sudo there is a policy
+change, not a flag: add `privileged` to `admin.prod` in the config's
+`roleBindings`.
+
 ### Command Classification
 
 Every command is classified before execution:
@@ -439,6 +458,7 @@ Secrets are **never** passed as CLI arguments.
 | `--port` | 22 | Quick start: SSH port |
 | `--key` | — | Quick start: Path to private key |
 | `--workdir` | — | Quick start: Working directory for commands and sessions |
+| `--group` | prod | Quick start: Policy tier — `prod`, `staging` or `dev` |
 | `--timeout` | 60000 | Command timeout in ms |
 | `--maxChars` | 5000 | Max command length (`none` or `0` disables the limit) |
 | `--sessionMax` | 5 | Max concurrent sessions per connection |

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ function resolveHostKeyMode(argv: Record<string, string | null>): HostKeyMode {
  * The default stays `prod`. Guessing an unknown host is production is the safe
  * direction; what was missing was a way to correct the guess.
  */
-function resolveHostGroup(argv: Record<string, string | null>): string {
+export function resolveHostGroup(argv: Record<string, string | null>): string {
   const group = argv.group;
   if (group === null || group === undefined) return 'prod';
   if ((HOST_GROUPS as readonly string[]).includes(group)) return group;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadConfig } from './config/loader.js';
 import { ConnectionRegistry } from './ssh/connection-registry.js';
-import { PolicyEngine, DEFAULT_RULES } from './policy/engine.js';
+import { PolicyEngine, DEFAULT_RULES, HOST_GROUPS } from './policy/engine.js';
 import { AuditStore } from './audit/store.js';
 import { registerTools, registerResources, getToolHashes } from './tools/registry.js';
 import { initKeychain } from './config/credential-resolver.js';
@@ -74,6 +74,28 @@ function resolveHostKeyMode(argv: Record<string, string | null>): HostKeyMode {
   throw new Error(`Invalid --hostKeyMode=${mode}. Expected one of: tofu, strict, insecure.`);
 }
 
+/**
+ * Which policy tier a CLI-configured host belongs to.
+ *
+ * Without this there was no way to say it from the command line at all. The
+ * inline profile carries no group, so it fell to the strictest tier, where the
+ * `admin` role has no `privileged` — meaning `sudo` could never run for anyone
+ * who had not written a config file (#91).
+ *
+ * The default stays `prod`. Guessing an unknown host is production is the safe
+ * direction; what was missing was a way to correct the guess.
+ */
+function resolveHostGroup(argv: Record<string, string | null>): string {
+  const group = argv.group;
+  if (group === null || group === undefined) return 'prod';
+  if ((HOST_GROUPS as readonly string[]).includes(group)) return group;
+  // Falling through would silently apply the prod bindings to a typo, and the
+  // operator would read the refusal as policy rather than as their own slip.
+  throw new Error(
+    `Invalid --group=${group}. Expected one of: ${HOST_GROUPS.join(', ')}.`,
+  );
+}
+
 async function buildAppConfig(argv: Record<string, string | null>): Promise<AppConfig> {
   if (argv.config) {
     return loadConfig(argv.config);
@@ -119,6 +141,7 @@ async function buildAppConfig(argv: Record<string, string | null>): Promise<AppC
     maxChars: defaults.commandMaxChars,
     maxOutputBytes: defaults.commandMaxOutputBytes,
     role: 'admin',
+    group: resolveHostGroup(argv),
     readOnly: false,
     approvalPolicy: argv.disableApproval ? 'auto' : defaults.approvalMode,
     cert: false,

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -18,7 +18,7 @@ export interface PolicyRules {
 }
 
 /** Tiers, most restrictive first. Unknown/unset tiers resolve to the first. */
-const HOST_GROUPS = ['prod', 'staging', 'dev'] as const;
+export const HOST_GROUPS = ['prod', 'staging', 'dev'] as const;
 
 export const DEFAULT_RULES: PolicyRules = {
   roleBindings: {
@@ -97,7 +97,7 @@ export class PolicyEngine {
         commandClass: parsed.class,
         binary: parsed.binary,
         ruleId: 'role-binding',
-        reason: `Role "${profile.role}" cannot run "${parsed.class}" commands`,
+        reason: this.explainRoleDenial(profile, parsed.class),
       };
     }
 
@@ -197,6 +197,44 @@ export class PolicyEngine {
       `POLICY WARNING: OPA evaluation unavailable (${cause}). ` +
       'Falling back to local policy — commands OPA would deny may now be allowed.',
     );
+  }
+
+  /**
+   * Say which three things produced the refusal, not one of them.
+   *
+   * The message used to read `Role "admin" cannot run "privileged" commands`,
+   * which names the role and the class but not the host group — and the group
+   * is usually what decided, because `admin` has `privileged` on staging and
+   * dev but not on prod. A reader concludes their role is simply incapable of
+   * sudo and goes looking for a bigger role that does not exist (#91).
+   *
+   * The inferred case matters most: a profile with no group set lands on the
+   * strictest tier, so the reason is something the operator never wrote down
+   * anywhere and cannot see.
+   */
+  private explainRoleDenial(profile: Profile, commandClass: CommandClass): string {
+    if (profile.readOnly) {
+      return `Profile "${profile.name}" is read-only, so "${commandClass}" commands are refused. ` +
+        `Clear readOnly on the profile to allow them.`;
+    }
+
+    const group = this.resolveHostGroup(profile);
+    const inferred = !profile.group;
+    const allowed = this.getAllowedClasses(profile).join(', ');
+
+    let reason =
+      `Role "${profile.role}" on host group "${group}" cannot run "${commandClass}" commands ` +
+      `(allowed: ${allowed}).`;
+
+    if (inferred) {
+      reason +=
+        ` No group is set for profile "${profile.name}", so it defaulted to the most restrictive tier.` +
+        ` Set group = "dev" or "staging" on the profile, or pass --group, if this host is not production.`;
+    } else {
+      reason += ` Change the profile's group, or grant the class to this role in the policy's roleBindings.`;
+    }
+
+    return reason;
   }
 
   private getAllowedClasses(profile: Profile): CommandClass[] {

--- a/test/e2e/packaging.e2e.test.ts
+++ b/test/e2e/packaging.e2e.test.ts
@@ -50,6 +50,17 @@ describe.skipIf(!serverBuilt)('E2E — packaging', () => {
     ).rejects.toMatchObject({ stderr: expect.stringContaining('removed in v2') });
   }, 20000);
 
+  // #91: the CLI profile had no way to declare a host group, so it fell to the
+  // strictest tier and `sudo` could never run without writing a config file.
+  // A mistyped group must not quietly land back on those prod bindings — the
+  // operator would read the refusal as policy rather than as their own typo.
+  it('rejects an unknown --group instead of falling back to the strictest tier', async () => {
+    const { SSH_MCP_DISABLE_MAIN: _omit, ...env } = process.env;
+    await expect(
+      run('node', [SERVER_ENTRY, '--host=x', '--user=y', '--group=production'], { env: env as NodeJS.ProcessEnv }),
+    ).rejects.toMatchObject({ stderr: expect.stringContaining('Invalid --group=production') });
+  }, 20000);
+
   it('requires a bearer token for the HTTP transport', async () => {
     const { SSH_MCP_DISABLE_MAIN: _omit, ...env } = process.env;
     await expect(

--- a/test/unit/cli-group.test.ts
+++ b/test/unit/cli-group.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { resolveHostGroup } from '../../src/index.js';
+import { HOST_GROUPS } from '../../src/policy/engine.js';
+
+/**
+ * The flag added for #91, where a quick-start profile could never reach the
+ * `privileged` class because it had no way to declare a host group.
+ *
+ * The packaging e2e test drives this through a spawned binary, which proves the
+ * wiring but only covers the rejection path — and a spawned process is invisible
+ * to coverage. The branching belongs in a unit test: the default decides how
+ * safe an unconfigured host is, and the rejection decides whether a typo is
+ * caught or silently downgraded.
+ */
+describe('resolveHostGroup', () => {
+  it('defaults to the strictest tier when no group is given', () => {
+    // Assuming an unknown host is production is the safe direction; the flag
+    // exists to correct the guess, not to loosen the default.
+    expect(resolveHostGroup({})).toBe('prod');
+    expect(resolveHostGroup({ group: null })).toBe('prod');
+  });
+
+  it.each([...HOST_GROUPS])('accepts %s', (group) => {
+    expect(resolveHostGroup({ group })).toBe(group);
+  });
+
+  // Falling through to the default would apply the prod bindings to a typo, and
+  // the operator would read the resulting refusal as policy rather than as
+  // their own slip — which is the confusion #91 was made of.
+  it.each(['production', 'PROD', 'staging ', 'qa', ''])('rejects %o', (group) => {
+    expect(() => resolveHostGroup({ group })).toThrow(/Invalid --group/);
+  });
+
+  it('names the valid values in the error, so the fix needs no docs lookup', () => {
+    expect(() => resolveHostGroup({ group: 'production' }))
+      .toThrow(/Expected one of: prod, staging, dev/);
+  });
+});

--- a/test/unit/policy/engine.test.ts
+++ b/test/unit/policy/engine.test.ts
@@ -141,4 +141,49 @@ describe('PolicyEngine', () => {
     const tagged = makeProfile({ role: 'admin', name: 'web-01', group: 'dev' });
     expect(engine.evaluate('sudo whoami', tagged, 'privileged-command').decision).toBe('require-approval');
   });
+
+  /*
+   * Reported as #91: the refusal read `Role "admin" cannot run "privileged"
+   * commands`, so the reporter concluded the admin role simply cannot sudo and
+   * went looking for a larger role that does not exist. The host group is what
+   * actually decided — admin has `privileged` on staging and dev, not on prod —
+   * and the message never mentioned it.
+   */
+  describe('refusal explains which of the three things decided', () => {
+    function denial(overrides: Parameters<typeof makeProfile>[0]): string {
+      return engine.evaluate('sudo whoami', makeProfile(overrides), 'privileged-command').reason ?? '';
+    }
+
+    it('names the group, not just the role and class', () => {
+      const reason = denial({ role: 'admin', name: 'web-01', group: undefined });
+      expect(reason).toContain('admin');
+      expect(reason).toContain('privileged');
+      expect(reason).toContain('prod');
+    });
+
+    it('lists what the role can run, so the boundary is visible', () => {
+      expect(denial({ role: 'admin', name: 'web-01', group: 'prod' }))
+        .toMatch(/allowed: .*read-only.*safe.*destructive/);
+    });
+
+    // The inferred case is the one worth calling out: nobody wrote "prod"
+    // anywhere, so without saying so the operator cannot see why it applied.
+    it('says the group was inferred when none was set, and how to set one', () => {
+      const reason = denial({ role: 'admin', name: 'web-01', group: undefined });
+      expect(reason).toMatch(/No group is set/);
+      expect(reason).toMatch(/--group/);
+    });
+
+    it('points at the real levers when the group was explicit', () => {
+      const reason = denial({ role: 'admin', name: 'web-01', group: 'prod' });
+      expect(reason).not.toMatch(/No group is set/);
+      expect(reason).toMatch(/roleBindings/);
+    });
+
+    it('explains a read-only profile as read-only rather than as a role problem', () => {
+      const reason = denial({ role: 'admin', name: 'web-01', group: 'dev', readOnly: true });
+      expect(reason).toMatch(/read-only/);
+      expect(reason).toMatch(/readOnly/);
+    });
+  });
 });


### PR DESCRIPTION
Closes #91.

> Since V2 I get the error "POLICY_DENIED: Role "admin" cannot run "privileged"
> commands" for any sudo commands […] I cant find any flags that would elevate
> the connections role, except through a toml file.

Both halves of that are real, and reproduce from a plain CLI start:

```
sudo systemctl restart nginx  ->  privileged / deny
   | Role "admin" cannot run "privileged" commands
```

## Why it happened

The quick-start profile (`--host`/`--user`, no config file) is hardcoded to
`role: 'admin'` and carries **no group**. Without one the tier is inferred from
the profile name — which is the literal string `default`, matching nothing, so
it resolves to the strictest tier. And `admin` on `prod` is
`['read-only','safe','destructive']`: no `privileged`.

So `sudo` could never run for anyone who had not written a TOML config, and no
flag existed to say otherwise. That is a v1 → v2 regression for the simplest
deployment shape.

## What changed

**`--group`.** Takes `prod`, `staging` or `dev`. Still defaults to `prod` — an
unknown host *should* be assumed production; what was missing was a way to
correct the guess. An unrecognised value is rejected rather than quietly landing
back on the prod bindings, where the operator would read the refusal as policy
rather than as their own typo.

**The message.** Arguably the worse half. It named the role and the class but
not the host group, which is what decided — `admin` *does* have `privileged` on
staging and dev. The reporter concluded the admin role simply cannot sudo, went
looking for a bigger role that does not exist, and called it a dealbreaker.

```
Role "admin" on host group "prod" cannot run "privileged" commands
(allowed: read-only, safe, destructive). No group is set for profile "default",
so it defaulted to the most restrictive tier. Set group = "dev" or "staging" on
the profile, or pass --group, if this host is not production.
```

With an explicit group it drops the inference wording and points at
`roleBindings` instead. A read-only profile is explained as read-only rather
than as a role problem.

## Not changed

`admin` still has no `privileged` on `prod`. Granting sudo on a real production
host is a policy decision, made in `roleBindings` — not something a flag should
do quietly. The README now says this outright, next to the tier table.

## Tests

- The refusal names role, group and class; lists the allowed set; distinguishes
  inferred from explicit groups; explains read-only separately
- `--group=production` fails at startup with `Invalid --group=production`

Suite: 374 passed, 6 skipped (380).

🤖 Generated with [Claude Code](https://claude.com/claude-code)