### PR TITLE
docs: stop documenting roleBindings as configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,17 @@ name = "build-box"
 group = "dev"
 ```
 
-Leaving a real production host on `prod` and granting sudo there is a policy
-change, not a flag: add `privileged` to `admin.prod` in the config's
-`roleBindings`.
+**The matrix above is not configurable yet.** `PolicyEngine` is always built
+from the compiled-in defaults, and a `roleBindings` table in the config file is
+accepted by the parser and then silently ignored
+([#95](https://github.com/tufantunc/ssh-mcp/issues/95)).
+
+So on a host labelled `group = "prod"` there is currently no way to allow
+`privileged-command`. An OPA sidecar does not help: OPA is consulted only for
+commands the built-in policy already allows, so it can refuse more but never
+grant. The only thing that works today is labelling the host `staging` or
+`dev` — which is a lie the rest of the policy then acts on, so treat it as a
+stopgap and not a configuration.
 
 ### Command Classification
 


### PR DESCRIPTION
Removes an instruction that cannot be followed, reported in #95.

The Roles section said:

> Leaving a real production host on `prod` and granting sudo there is a policy
> change, not a flag: add `privileged` to `admin.prod` in the config's
> `roleBindings`.

Nothing reads `roleBindings` from config. `AppConfig` is `{ defaults, profiles }`,
`PolicyEngine` is always built from the compiled-in `DEFAULT_RULES`, and the root
config schema is not `.strict()` — so the table parses, is dropped, and the
operator gets a clean startup with no effect and nothing to explain it.

I wrote that sentence a day ago while fixing #91, having read that
`PolicyEngine`'s constructor accepts rules and assumed something fed it from
configuration. The reporter migrated from 1.5.0 on the strength of it.

## The OPA claim, corrected

My first attempt at this text offered an OPA sidecar as the workaround. That is
also wrong, and I only caught it by testing. `evaluateWithOpa` short-circuits
before calling out:

```ts
const local = this.evaluate(command, profile, toolName);
if (local.decision === 'deny') return local;   // OPA never consulted
```

Against a stub OPA answering `{"result": true}` for a `privileged` command on an
`admin`/`prod` profile, the result is still `deny`. OPA is a deny-only layer —
correct design, but not an override.

So the honest statement is stronger than the issue's: on a host labelled `prod`
there is **no** way to reach `privileged-command` in 2.1.0. Not config, not OPA.
The README now says that, and names relabelling as the stopgap it is.

Docs only — the capability itself is #95, which the reporter has offered to
implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)