### PR TITLE
ci: declare least privilege, pin every action to a commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+
+# Grouped and monthly on purpose. The objection to enabling this was a stream of
+# individual pull requests, each needing its own triage — so everything below
+# collapses into at most three PRs a month, and the split between them is the one
+# that decides how much care each needs.
+updates:
+  # The counterpart to pinning every action to a commit SHA. Pinned refs do not
+  # move on their own, and codeql-action is the sharpest case: GitHub ages out old
+  # CodeQL bundles, so a stale pin first warns and then degrades. Dependabot
+  # understands the `@<sha> # <tag>` convention and rewrites both parts.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ['*']
+    commit-message:
+      prefix: ci
+
+  # Production dependencies ship to users: a bump here changes what `npm i
+  # ssh-mcp` resolves, so it needs a changeset and a release. Kept separate from
+  # dev precisely so that decision is never made by accident in a batch.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    allow:
+      - dependency-type: production
+    groups:
+      production:
+        patterns: ['*']
+        update-types: [minor, patch]
+    # Majors on the SSH and MCP libraries are not batch work — ssh2 and the SDK
+    # are where a silent behaviour change would surface as a security regression
+    # rather than a failing test.
+    ignore:
+      - dependency-name: ssh2
+        update-types: [version-update:semver-major]
+      - dependency-name: '@modelcontextprotocol/sdk'
+        update-types: [version-update:semver-major]
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+
+  # Dev dependencies never reach the published tarball — `files` is `build` only —
+  # so these need no changeset and no release. The full suite runs against real
+  # SSH servers on every PR, which is what actually decides whether a bump is safe.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: development
+    groups:
+      development:
+        patterns: ['*']
+    commit-message:
+      prefix: chore

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,8 @@ version: 2
 
 # Grouped and monthly on purpose. The objection to enabling this was a stream of
 # individual pull requests, each needing its own triage — so everything below
-# collapses into at most three PRs a month, and the split between them is the one
-# that decides how much care each needs.
+# collapses into at most three PRs a month, split along the line that decides how
+# much care each one needs.
 updates:
   # The counterpart to pinning every action to a commit SHA. Pinned refs do not
   # move on their own, and codeql-action is the sharpest case: GitHub ages out old
@@ -13,30 +13,41 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # Do not propose a version until it has been public for a week. Malicious
+    # releases are typically caught and yanked within days, and nothing here is
+    # urgent enough to want the first hour of a new tag. Security advisories
+    # bypass this — Dependabot security updates are a separate feed.
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ['*']
     commit-message:
       prefix: ci
 
-  # Production dependencies ship to users: a bump here changes what `npm i
-  # ssh-mcp` resolves, so it needs a changeset and a release. Kept separate from
-  # dev precisely so that decision is never made by accident in a batch.
+  # One entry, because Dependabot requires a unique ecosystem+directory pair —
+  # but two groups, so production and development arrive as separate pull
+  # requests. That split is the point: a production bump changes what
+  # `npm i ssh-mcp` resolves and needs a changeset and a release, while a dev bump
+  # reaches nothing published (`files` is `build` only) and needs neither.
+  # Batching them together would mean making that call by accident.
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
     versioning-strategy: increase-if-necessary
-    allow:
-      - dependency-type: production
+    cooldown:
+      default-days: 7
     groups:
       production:
-        patterns: ['*']
+        dependency-type: production
         update-types: [minor, patch]
-    # Majors on the SSH and MCP libraries are not batch work — ssh2 and the SDK
-    # are where a silent behaviour change would surface as a security regression
-    # rather than a failing test.
+      development:
+        dependency-type: development
+    # Majors on the SSH and MCP libraries are not batch work: these are where a
+    # silent behaviour change surfaces as a security regression rather than as a
+    # failing test, so they want a human opening the diff.
     ignore:
       - dependency-name: ssh2
         update-types: [version-update:semver-major]
@@ -45,19 +56,3 @@ updates:
     commit-message:
       prefix: fix
       prefix-development: chore
-
-  # Dev dependencies never reach the published tarball — `files` is `build` only —
-  # so these need no changeset and no release. The full suite runs against real
-  # SSH servers on every PR, which is what actually decides whether a bump is safe.
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 5
-    allow:
-      - dependency-type: development
-    groups:
-      development:
-        patterns: ['*']
-    commit-message:
-      prefix: chore

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -10,6 +10,14 @@ on:
   # an empty commit to main. Neither belongs in a release path.
   workflow_dispatch:
 
+# Least privilege by default: every job starts read-only and elevates only what
+# it needs, below. Without a top-level block a job that declares nothing — the
+# `test` job did — inherits the repository's default, which is a setting outside
+# this file and can be widened without touching it. That job sees the Docker Hub
+# and Codecov tokens, so what it is allowed to do should be stated here.
+permissions:
+  contents: read
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -20,13 +28,13 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # No registry-url: publishing goes through OIDC against the default
       # registry, so the .npmrc setup-node would write for it — carrying an
       # authToken line for a token we deliberately do not set — has nothing to
       # contribute.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22.x'
 
@@ -54,7 +62,7 @@ jobs:
         run: npm run build
 
       - name: Create Release Pull Request or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           # No --provenance: trusted publishing generates provenance
           # attestations automatically for a public package from a public repo.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -51,9 +51,15 @@ jobs:
       # own guard for that case did not catch it either, because npm 12 also
       # dropped `code` from the error JSON the guard matches on. Publishing was
       # never affected — 2.0.0 went out under npm 12 — only the read was.
+      #
+      # Pinned exactly, not to a range. This job holds `id-token: write` — it mints
+      # the OIDC token that publishes ssh-mcp — and this is the one thing it fetches
+      # from the registry outside the lockfile, before `npm ci` runs. A range would
+      # leave the publish path resolving a mutable reference at run time, which is
+      # the property the pinned action SHAs exist to remove. Bump deliberately.
       - name: Install npm for trusted publishing
         run: |
-          npm install -g npm@11
+          npm install -g npm@11.19.0
           npm -v
 
       - run: npm ci
@@ -62,7 +68,7 @@ jobs:
         run: npm run build
 
       - name: Create Release Pull Request or Publish
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1 (branch, not a tag)
         with:
           # No --provenance: trusted publishing generates provenance
           # attestations automatically for a public package from a public repo.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -10,11 +10,11 @@ on:
   # an empty commit to main. Neither belongs in a release path.
   workflow_dispatch:
 
-# Least privilege by default: every job starts read-only and elevates only what
-# it needs, below. Without a top-level block a job that declares nothing — the
-# `test` job did — inherits the repository's default, which is a setting outside
-# this file and can be widened without touching it. That job sees the Docker Hub
-# and Codecov tokens, so what it is allowed to do should be stated here.
+# Read-only default, so a job added here later starts with no write access until
+# it asks. `release` below is the one job in this file and it opts up explicitly
+# — this block does not scope it. Without a default, a future job that declares
+# nothing would inherit the repository setting instead, which lives outside this
+# file and can be widened without anyone editing it.
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main, v2]
 
+# Least privilege by default: every job starts read-only and elevates only what
+# it needs, below. Without a top-level block a job that declares nothing — the
+# `test` job did — inherits the repository's default, which is a setting outside
+# this file and can be widened without touching it. That job sees the Docker Hub
+# and Codecov tokens, so what it is allowed to do should be stated here.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,9 +23,9 @@ jobs:
       # given secrets, resolves it to empty instead of failing.
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -59,7 +67,7 @@ jobs:
         # Skipped on pull requests from forks, which are never given secrets.
         # Those keep pulling anonymously; the retry is what covers them.
         if: env.DOCKERHUB_USERNAME != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -120,7 +128,7 @@ jobs:
           echo "lcov records: $(grep -c '^SF:' coverage/lcov.info)"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -137,7 +145,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # gitleaks scans a commit range, which the default shallow clone
           # (depth 1) cannot resolve: it fails with "unknown revision" and exits
@@ -146,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Semgrep Scan
-        uses: returntocorp/semgrep-action@v1
+        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
         with:
           config: >-
             p/javascript
@@ -156,7 +164,7 @@ jobs:
             p/command-injection
 
       - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -164,7 +172,7 @@ jobs:
         run: npm audit --audit-level=high || true
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         if: github.event_name == 'pull_request'
         with:
           fail-on-severity: high
@@ -176,16 +184,16 @@ jobs:
       security-events: write
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           languages: javascript
           config-file: ./.github/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,15 @@ jobs:
       #
       # exited 0, and the step reported success. This gate had been scanning
       # nothing while reporting green — which is the failure mode the rest of this
-      # workflow exists to prevent. `--error` is what makes findings fail the job.
+      # workflow exists to prevent. `--error` is what makes findings fail the job,
+      # and the summary is left on deliberately: it ends with a line like
+      # "Ran 112 rules on 90 files: 0 findings", so a clean run leaves evidence it
+      # scanned rather than only the absence of complaint.
       - name: Semgrep Scan
         run: |
           docker run --rm -v "$PWD:/src" -w /src \
             semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8 \
-            semgrep scan --error --quiet \
+            semgrep scan --error --metrics=off \
               --config=p/javascript \
               --config=p/nodejs \
               --config=p/typescript \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,15 @@ on:
   pull_request:
     branches: [main, v2]
 
-# Least privilege by default: every job starts read-only and elevates only what
-# it needs, below. Without a top-level block a job that declares nothing — the
-# `test` job did — inherits the repository's default, which is a setting outside
-# this file and can be widened without touching it. That job sees the Docker Hub
-# and Codecov tokens, so what it is allowed to do should be stated here.
+# Read-only default for GITHUB_TOKEN. A job that declares nothing — the `test`
+# job does not — would otherwise inherit the repository setting, which lives
+# outside this file and can be widened without anyone editing it.
+#
+# Two things this does NOT do, since the wording invites both mistakes:
+# `permissions` gates GITHUB_TOKEN only and has no effect on `secrets.*`, so the
+# test job still receives the Docker Hub and Codecov tokens. And a job-level
+# block replaces this one rather than extending it — adding a scope here does
+# not reach any job that declares its own.
 permissions:
   contents: read
 
@@ -153,15 +157,35 @@ jobs:
           # found in partial scan". Full history is what makes the scan real.
           fetch-depth: 0
 
+      # Run the image directly instead of returntocorp/semgrep-action. That action
+      # is a Docker action whose action.yml is fifteen lines pointing at
+      # `docker://returntocorp/semgrep-agent:v1`, so pinning its commit freezes the
+      # YAML and none of the code that executes. The project is marked deprecated
+      # and was last pushed in January 2024, and that image can no longer parse the
+      # current rule packs: it died with
+      #
+      #   ValueError: invalid rule severity value: MEDIUM
+      #
+      # exited 0, and the step reported success. This gate had been scanning
+      # nothing while reporting green — which is the failure mode the rest of this
+      # workflow exists to prevent. `--error` is what makes findings fail the job.
       - name: Semgrep Scan
-        uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
-        with:
-          config: >-
-            p/javascript
-            p/nodejs
-            p/typescript
-            p/owasp-top-ten
-            p/command-injection
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src \
+            semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8 \
+            semgrep scan --error --quiet \
+              --config=p/javascript \
+              --config=p/nodejs \
+              --config=p/typescript \
+              --config=p/owasp-top-ten \
+              --config=p/command-injection \
+              --exclude=docker/alpine-sshd/Dockerfile \
+              --exclude=docker/dropbear-sshd/Dockerfile
+
+      # Excluded above rather than suppressed globally: both are throwaway test
+      # fixtures running sshd, which has to be root to authenticate users and open
+      # shells as them, so `missing-user` is wrong for these two files and right
+      # everywhere else.
 
       - name: gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
@@ -172,7 +196,7 @@ jobs:
         run: npm audit --audit-level=high || true
 
       - name: Dependency review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4 (branch, not a tag)
         if: github.event_name == 'pull_request'
         with:
           fail-on-severity: high


### PR DESCRIPTION
Two findings from actually running OpenSSF Scorecard against the repo rather
than guessing what it would say. Overall 6.5/10; these are the two low scores
worth acting on.

## `Token-Permissions` 0/10 — no top-level `permissions`

The repository default is currently `read`, so nothing is over-privileged today.
The problem is that the `test` job declared nothing at all, which made its
permissions a property of a repository setting rather than of this file — and
that setting can be widened without anyone touching the workflow. That job holds
`DOCKERHUB_TOKEN` and `CODECOV_TOKEN`.

Both workflows now start at `contents: read`, with each job elevating only what
it needs (`security-events: write` for the scanners, `contents`/`id-token`/
`pull-requests: write` for the release).

## `Pinned-Dependencies` 2/10 — actions referenced by tag

`actions/checkout@v4` is a mutable ref. Worse, `changesets/action@v1` and
`actions/dependency-review-action@v4` are not tags at all — they resolve to
**branches**, so they move by design.

This CI sees `DOCKERHUB_TOKEN`, `CODECOV_TOKEN`, and the OIDC identity that
publishes to npm. A repointed ref runs different code with all of that in reach.
All 15 uses are pinned to a commit, with the version in a trailing comment so
the intent stays readable.

Cross-check: the resolved SHA for `codecov-action@v5`
(`0fb7174895f61a3b6b78fc075e0cd60383518dac`) matches what a previous CI run
logged when it downloaded the action.

## Not addressed, on purpose

- **Code-Review 0/10, Contributors 0/10** — one maintainer merging their own PRs.
  Not fixable without a second reviewer, and not a defect.
- **Branch-Protection 4/10** — wants required approvers, CODEOWNERS review, and
  "apply to administrators". Required approvers would make merging impossible
  here; admin enforcement would close the bypass the release bot relies on.
- **CII-Best-Practices 0/10** — a separate self-assessment badge, not filled in.

No badge is being added. A 6.5 that is mostly structural would read as sloppier
than the project is; the value was in the two findings above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)