### PR TITLE
ci: pin the test-fixture images by digest, and let dependabot refresh them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,12 +57,27 @@ updates:
       prefix: fix
       prefix-development: chore
 
-  # Keeps the digest pins in docker-compose.yml and the test Dockerfiles from
-  # rotting. Pinning without an updater is how a test fixture quietly ends up
-  # years old — and these fixtures decide whether the SSH security tests are
-  # honest, so a stale sshd is not a cosmetic problem. Dependabot rewrites the
-  # digest and leaves the readable tag alongside it.
+  # Two entries, because Dependabot treats these as separate ecosystems: `docker`
+  # reads Dockerfiles, `docker-compose` reads compose files. Declaring only the
+  # first would leave the four sshd digests in docker-compose.yml — the pins that
+  # matter most, since those containers decide whether the SSH tests are honest —
+  # frozen with nothing to refresh them.
+  #
+  # Pinning without an updater is how a fixture quietly ends up years old. Both
+  # rewrite the digest and leave the readable tag beside it.
   - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      containers:
+        patterns: ['*']
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: docker-compose
     directory: /
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,3 +56,20 @@ updates:
     commit-message:
       prefix: fix
       prefix-development: chore
+
+  # Keeps the digest pins in docker-compose.yml and the test Dockerfiles from
+  # rotting. Pinning without an updater is how a test fixture quietly ends up
+  # years old — and these fixtures decide whether the SSH security tests are
+  # honest, so a stale sshd is not a cosmetic problem. Dependabot rewrites the
+  # digest and leaves the readable tag alongside it.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      containers:
+        patterns: ['*']
+    commit-message:
+      prefix: ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,17 @@
+# Test-fixture images are pinned by digest. These containers are the system
+# under test for an SSH security tool: a silently changed sshd could make
+# host-key verification, ProxyJump or an auth-failure test pass when it should
+# fail, and nothing would say so. The tag is kept alongside the digest so the
+# version stays readable; the digest is what resolves.
+#
+# The root Dockerfile's `node:22-slim` is deliberately NOT pinned. That image
+# builds the server rather than deciding whether a test is honest, so picking up
+# base-image security patches on rebuild is worth more there than reproducibility.
+
 services:
   # ─── Test SSH Servers (role-based, for integration tests) ──────────────────
   ssh-admin:
-    image: ghcr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest@sha256:96b9a4d3b5106746d08d43a6911650d4d21f7d5c7f2ac9660e792bdb5e63157c
     profiles: ["test"]
     environment:
       - USER_NAME=admin
@@ -14,7 +24,7 @@ services:
       - "2222:2222"
 
   ssh-viewer:
-    image: ghcr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest@sha256:96b9a4d3b5106746d08d43a6911650d4d21f7d5c7f2ac9660e792bdb5e63157c
     profiles: ["test"]
     environment:
       - USER_NAME=viewer
@@ -26,7 +36,7 @@ services:
       - "2223:2222"
 
   ssh-operator:
-    image: ghcr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest@sha256:96b9a4d3b5106746d08d43a6911650d4d21f7d5c7f2ac9660e792bdb5e63157c
     profiles: ["test"]
     environment:
       - USER_NAME=operator
@@ -42,7 +52,7 @@ services:
   # that an init hook enables AllowTcpForwarding, which the base image disables
   # — without it every direct-tcpip channel fails and the hop cannot be tested.
   ssh-bastion:
-    image: ghcr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:latest@sha256:96b9a4d3b5106746d08d43a6911650d4d21f7d5c7f2ac9660e792bdb5e63157c
     profiles: ["test"]
     environment:
       - USER_NAME=bastion

--- a/docker/alpine-sshd/Dockerfile
+++ b/docker/alpine-sshd/Dockerfile
@@ -5,7 +5,7 @@
 # survive: `bind` is a bash builtin that does not exist here, `set -o history`
 # is unsupported, and the default prompt differs. If the sentinel protocol or
 # the shell priming quietly depend on bash, this is where it shows.
-FROM alpine:3.20
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 RUN apk add --no-cache openssh-server && ssh-keygen -A
 

--- a/docker/dropbear-sshd/Dockerfile
+++ b/docker/dropbear-sshd/Dockerfile
@@ -8,7 +8,7 @@
 #
 # openssh-sftp-server is installed separately because dropbear ships no SFTP
 # subsystem of its own.
-FROM alpine:3.20
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 RUN apk add --no-cache dropbear openssh-sftp-server
 


### PR DESCRIPTION
Raised by the security review of #98 and deferred to its own change.

## Why these images specifically

The compose containers are the **system under test** for an SSH security tool.
A silently changed sshd can make host-key verification, ProxyJump, or an
auth-failure test pass when it should fail — and the run would go green having
verified something other than what it claims. `:latest` is the most mutable
reference there is to hang that on.

Pinned by digest:

| what | where |
|---|---|
| `ghcr.io/linuxserver/openssh-server` | 4 services in `docker-compose.yml` |
| `alpine:3.20` | the base under both sshd fixtures |

Tags stay next to the digests so the version is still readable; the digest is
what resolves. Both are **multi-arch manifest lists**, so amd64 CI and arm64
development resolve the same pin — a platform-specific digest would have broken
one of them.

## What is deliberately not pinned

The root `Dockerfile`'s `node:22-slim`. That image builds the server rather than
deciding whether a test is honest, so picking up base-image security patches on
rebuild is worth more there than reproducibility. The reasoning is written into
`docker-compose.yml` so the difference does not read as an oversight.

## The other half

Pinning without an updater is how a fixture quietly ends up years old — the same
loop the action SHAs needed closing in #98. `dependabot.yml` gains a `docker`
ecosystem: monthly, grouped, same seven-day cooldown, and it rewrites the digest
while leaving the readable tag.

## Verification

- Stack torn down and rebuilt from the pinned digests; containers report healthy
- Running containers confirmed to resolve
  `openssh-server:latest@sha256:96b9a4d3…`
- Full suite against them with `SSH_MCP_REQUIRE_SERVERS=1`: 384 passed, 6 skipped

## No release

`docker-compose.yml` and `docker/` are not in the published tarball (`files` is
`build` only — verified with `npm pack --dry-run`), and no workflow publishes an
image to any registry. Nothing a consumer installs changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)