### PR TITLE
ci: do not let dependabot pick the Node major for the server image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,14 @@ updates:
     groups:
       containers:
         patterns: ['*']
+    # Node majors are a human decision, not a batch one. Dependabot proposed
+    # 22-slim -> 25-slim, and odd-numbered Node releases are Current rather than
+    # LTS: roughly six months of support instead of three years. Choosing the
+    # runtime an SSH access server runs on is not something to accept from a
+    # grouped bump — minors and patches still flow.
+    ignore:
+      - dependency-name: node
+        update-types: [version-update:semver-major]
     commit-message:
       prefix: ci
 


### PR DESCRIPTION
Closes #104 rather than merging it.

Dependabot proposed `node:22-slim` → `25-slim` in the root Dockerfile. It passes
CI, and it needs no release — the image is not published anywhere and the file is
not in the npm tarball. But odd-numbered Node releases are **Current, not LTS**:
roughly six months of support against three years, with no security backports
after that window.

For an SSH access server, the runtime's support lifetime is not a detail to
accept from a grouped bump because the number went up.

`ignore` on `node` majors only. Minors and patches keep flowing, so base-image
security fixes still arrive — which is the same reasoning behind leaving the root
Dockerfile unpinned while the test fixtures are pinned by digest: that image
should pick up patches, it just should not change major runtime on its own.

Moving to `24-slim` (current Active LTS) is worth doing, deliberately, as its own
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)