### PR TITLE
ci: take npm from Node 24 instead of installing it in the release job

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,33 +34,46 @@ jobs:
       # registry, so the .npmrc setup-node would write for it — carrying an
       # authToken line for a token we deliberately do not set — has nothing to
       # contribute.
+      # Node 24 (LTS) rather than 22, because it bundles npm 11.17.0 while every
+      # Node 22 release ships npm 10.9.x — and trusted publishing needs
+      # npm >= 11.5.1. Below that the CLI never detects the OIDC environment and
+      # silently falls back to token auth, which with no token configured means
+      # the publish fails at the last step of a release.
+      #
+      # This replaced a `npm install -g npm@11.19.0` step. That step existed to
+      # clear the 11.5.1 bar on Node 22, and was pinned to an exact 11.x rather
+      # than @latest because npm 12 changed the shape of `npm info <pkg> --json`
+      # from an object carrying a `versions` array to an array: @changesets/cli
+      # read `pkgInfo.versions`, got undefined, decided an already published
+      # version had never shipped, and tried to publish over it. Fixed upstream
+      # in @changesets/cli 2.31.1, which unwraps the array — so nothing is being
+      # dodged by moving Node here, and npm 11.17.0 predates the shape change
+      # anyway.
+      #
+      # The point of dropping the step is not the version. This job holds
+      # `id-token: write` — it mints the OIDC token that publishes ssh-mcp — and
+      # that install was the one thing it fetched from the registry outside the
+      # lockfile, before `npm ci` runs. Taking the npm that ships with a pinned
+      # Node removes a mutable reference from the publish path rather than
+      # bumping it.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22.x'
+          node-version: '24.x'
 
-      # Trusted publishing needs npm >= 11.5.1, and every Node 22 release ships
-      # npm 10.9.x. Without this the CLI never detects the OIDC environment and
-      # silently falls back to token auth — which, with no token configured,
-      # means the publish fails at the last step of a release.
-      #
-      # Pinned to 11.x rather than @latest. npm 12 changed the shape of
-      # `npm info <pkg> --json`: 11 returns an object carrying a `versions`
-      # array, 12 returns an array. @changesets/cli reads `pkgInfo.versions`,
-      # which is undefined on an array, so under npm 12 it decided an already
-      # published version had never shipped and tried to publish over it. Its
-      # own guard for that case did not catch it either, because npm 12 also
-      # dropped `code` from the error JSON the guard matches on. Publishing was
-      # never affected — 2.0.0 went out under npm 12 — only the read was.
-      #
-      # Pinned exactly, not to a range. This job holds `id-token: write` — it mints
-      # the OIDC token that publishes ssh-mcp — and this is the one thing it fetches
-      # from the registry outside the lockfile, before `npm ci` runs. A range would
-      # leave the publish path resolving a mutable reference at run time, which is
-      # the property the pinned action SHAs exist to remove. Bump deliberately.
-      - name: Install npm for trusted publishing
+      # The requirement above is real but invisible: too old an npm does not
+      # fail here, it fails four steps later as an authentication error that
+      # reads like a misconfigured trusted publisher. Assert it instead, so a
+      # Node image whose bundled npm regressed stops the release at the step
+      # that can explain why.
+      - name: Verify npm meets the trusted-publishing minimum
         run: |
-          npm install -g npm@11.19.0
-          npm -v
+          required=11.5.1
+          actual="$(npm -v)"
+          if [ "$(printf '%s\n%s\n' "$required" "$actual" | sort -V | head -n1)" != "$required" ]; then
+            echo "::error::npm $actual is older than $required. Trusted publishing would fall back to token auth, and no token is configured." >&2
+            exit 1
+          fi
+          echo "node $(node -v), npm $actual"
 
       - run: npm ci
 
@@ -89,8 +102,11 @@ jobs:
           # reached the registry that way — but the action saw no released
           # packages, so it silently skipped the git tag and the GitHub release
           # and still reported success. changeset publish decides what to ship
-          # by asking the registry first, which is why the .npmrc above matters:
-          # if that lookup cannot be trusted, neither can this step.
+          # by asking the registry first — `npm info` — which is why the npm
+          # version above matters: if that lookup cannot be trusted, neither can
+          # this step. (This sentence used to point at an .npmrc, from a wrong
+          # diagnosis of the republish loop; there is no .npmrc here, and
+          # removing `registry-url` was not what fixed it.)
           publish: npx changeset publish
           version: npm run version
           title: 'chore(release): version packages'


### PR DESCRIPTION
Closes the open question about the `npm@11.19.0` pin in `changesets.yml`.

## What the pin was doing

Two stacked reasons, and only one of them expired:

1. **Trusted publishing needs npm >= 11.5.1**, and every Node 22 release ships npm 10.9.x. Below the bar the CLI never detects the OIDC environment and silently falls back to token auth — with no token configured, the publish fails at the last step of a release. **This reason has not expired.** Deleting the step outright would have broken releases.
2. **Pinned to an exact 11.x rather than `@latest`**, because npm 12 changed `npm info <pkg> --json` from an object carrying a `versions` array to an array. `@changesets/cli` read `pkgInfo.versions`, got `undefined`, concluded an already-published version had never shipped, and tried to publish over it. **This one has expired.**

Verified (2) is genuinely fixed rather than assumed — `@changesets/cli` 2.31.1 landed on `main` in #110, and the installed copy contains:

```js
// npm 12 always wraps successful `npm info --json` output in an array.
// Unwrap it so downstream consumers keep seeing a single manifest.
function normalizeInfoJson(parsed) {
  return Array.isArray(parsed) ? parsed[0] : parsed;
}
```

## What this does instead of bumping the pin

Reason (1) is answered better by Node than by npm. From `nodejs.org/dist/index.json`:

| Node | bundled npm | LTS |
| --- | --- | --- |
| v24.19.0 | **11.17.0** | Krypton |
| v22.23.2 | 10.9.8 | Jod |

So `node-version: '24.x'` clears 11.5.1 with the npm that ships with it, and the global install goes away.

That removal is the point, not the version number. This job holds `id-token: write` — it mints the OIDC token that publishes the package — and that install was the one thing it fetched from the registry outside the lockfile, before `npm ci` runs. Taking npm from a pinned Node removes a mutable reference from the publish path; bumping the pin to npm 12 would only have moved it.

## New gate

The requirement is real but invisible, and the failure mode is bad: too old an npm does not fail where it is installed, it fails four steps later as an authentication error that reads like a misconfigured trusted publisher — which is exactly the misdiagnosis that cost us time on 2.0.0. So the step that was removed is replaced by one that asserts the minimum and says why:

```
required=11.5.1
actual="$(npm -v)"
if [ "$(printf '%s\n%s\n' "$required" "$actual" | sort -V | head -n1)" != "$required" ]; then
  echo "::error::npm $actual is older than $required. ..."
  exit 1
fi
```

Boundary-tested: 10.9.8 and 11.5.0 rejected, 11.5.1 / 11.17.0 / 12.0.2 accepted.

## Also

A comment on the publish step claimed `changeset publish`'s registry read "is why the .npmrc above matters". There is no `.npmrc` here — `registry-url` was deliberately removed, and removing it was not what fixed the republish loop. That sentence was a leftover from the wrong diagnosis; it now points at the npm version, which is what actually governs that read, and says so.

## Verification limits

Stated plainly: this workflow only runs on push to `main` and `workflow_dispatch`, so **this PR's CI does not exercise it**. What is verified here is the YAML parses with the steps in the intended order, the version comparison is correct at the boundary, the bundled-npm figures come from the Node release index, and the changesets fix is present in the installed package. The publish path itself is confirmed at the next release — and the new gate is what makes a regression there loud instead of silent.

No changeset: workflow-only change, nothing published is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)