### PR TITLE
chore: release the policy config work as 2.2.0 rather than 3.0.0

### DIFF
--- a/.changeset/soft-poems-shave.md
+++ b/.changeset/soft-poems-shave.md
@@ -1,5 +1,5 @@
 ---
-"ssh-mcp": major
+"ssh-mcp": minor
 ---
 
 Read policy overrides from the config file, and refuse to start when the policy does not mean what it says.
@@ -22,7 +22,7 @@ All problems are reported at once rather than one per restart.
 
 An unresolved tier no longer falls back to the role's `prod` cell. While the matrix was compiled in, that fallback meant falling back to the strictest cell for that role; once `[policy]` can write `prod`, the same hop hands an unresolved tier whatever production was granted. A partial custom role plus profiles that set no `group` was enough to reach it with no typo involved.
 
-**Upgrade notes.** Two kinds of config that started under 2.x now fail at load. Both failures name the offending line, and both are the point of the release rather than side effects:
+**Upgrade notes — read these before upgrading, even though this is a minor release.** Two kinds of config that started under 2.1.0 now fail at load. That is normally a major, and shipping it as a minor is a deliberate call rather than an oversight: the reach of both is narrow, and neither failure is silent — each names the offending line and tells you what to write instead. But it does mean a `^2.1.0` range will pick this up automatically, so nothing warns you by version number alone. Both failures are the point of the release rather than side effects:
 
 1. **An unrecognised top-level section.** Previously parsed cleanly and was dropped, so an upgrade can surface a typo that has been inert for some time — including a `[policy]` block written against the old README, which said such a block was accepted and ignored. Read any pre-existing `[policy]` section before upgrading: it is live now, and the usual content of one is a grant.
 2. **A custom `role` on a profile.** `role` is a free string that only ever matched `viewer`, `operator` or `admin`; anything else was silently demoted to read-only. That now stops startup, and it is the one new failure that can fire on a config carrying no `[policy]` section at all. Either correct the role, or give it bindings with `[policy.roleBindings.<role>]`.


### PR DESCRIPTION
Reverses the `major` bump in 18d853f. Maintainer's call.

## What is not changing

Both startup failures that 18d853f documented stay exactly as they are:

1. **An unrecognised top-level section** — the root `.strict()`.
2. **A custom `role` with no bindings** — the one that can fire on a config carrying no `[policy]` section at all.

Neither is softened, and neither is being reclassified as harmless. This changes the version number, not the behaviour.

## What decided it

Reach. `role` has only ever been documented as `viewer | operator | admin` — in 2.1.0's README as much as today's. A config in category 2 is therefore one that ignored the documented enum, and its reward for doing so on 2.1.0 was a silent demotion to read-only. Category 1 is a typo, or a `[policy]` block written against the old README, and for that second group erroring is the protective outcome: the alternative is the block going live as a grant.

Neither failure is silent. Both name the offending line and tell you what to write instead, and all problems are reported in one pass.

## What the note now says

The upgrade section leads with the trade rather than burying it:

> **Upgrade notes — read these before upgrading, even though this is a minor release.** Two kinds of config that started under 2.1.0 now fail at load. That is normally a major, and shipping it as a minor is a deliberate call rather than an oversight: the reach of both is narrow, and neither failure is silent — each names the offending line and tells you what to write instead. But it does mean a `^2.1.0` range will pick this up automatically, so nothing warns you by version number alone.

Recording the counter-argument, since it is the honest half: a `^2.1.0` range auto-upgrades, so users get no signal from the version. That is the cost of this decision, and the note is where it gets disclosed.

## Verification

- `npm run typecheck` — clean
- 257 unit and property tests pass
- `npm run coverage` — Lines 77.33%, matching the pre-existing figure. (I had flagged a possible ~9-point drop from the vitest 4 upgrade based on Codecov's PR baseline; the actual measurement shows no regression.)

Changeset-only change. Merging this makes the next Version Packages PR produce **2.2.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)