### PR TITLE
docs: correct three security claims that went stale after v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **SSH MCP Server** is a security-first Model Context Protocol server that gives LLM agents controlled SSH access to remote hosts — with command classification, policy-based authorization, human-in-the-loop approval, and full audit logging.
 
-> **WARNING — Lethal Trifecta Risk.** Giving an LLM SSH access creates a ["Lethal Trifecta"](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/) (private data + untrusted input + network egress). **Never run as root. Never enable `auto` approval on production.** See [SECURITY.md](./SECURITY.md) for the full threat model and mitigation checklist.
+> **The risk this server exists to manage.** Giving an LLM shell access on a remote host puts private data, untrusted input and network egress in one place — Simon Willison's ["lethal trifecta"](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/). Prompt injection has no general fix, so ssh-mcp assumes any command may be attacker-influenced: it classifies before executing, authorizes against a role × host-group matrix, gates destructive work behind approval, and records the decision either way. That narrows the blast radius; it does not remove the risk. Two things stay yours: **never point it at a root account**, and **never set `auto` approval on a production profile**. [SECURITY.md](./SECURITY.md) has the full threat model.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,7 @@ SSH MCP Server gives LLM agents the ability to execute shell commands on remote 
 | Command injection via metadata | Sanitizer strips CR/LF/NUL from all metadata; `description` feature removed |
 | MITM attacks | TOFU host key verification by default; strict mode available |
 | Weak SSH algorithms | Frozen algorithm allow-list per RFC 9142 (no SHA-1, no CBC, no ssh-rsa) |
-| PTY session leaks (MaxSessions) | `exec()`-only architecture; no persistent su shells |
+| PTY session leaks (MaxSessions) | Interactive sessions are bounded, not absent: `sessionMaxPerConnection` (default 5), `sessionIdleTimeoutMs` (10 min), `sessionBackgroundMaxMs` (1 h), and a reaper that sweeps expired sessions every 60s. One-shot commands use `exec()` and hold no channel. No persistent `su` shells |
 | Unbounded agent actions | Per-profile RBAC, rate limits, denylist, approval modes |
 
 ## Safe Deployment Guidelines
@@ -92,7 +92,7 @@ SSH MCP Server v2 implements controls that map to common security frameworks. Th
 |-----------------|-------------|-------------------|
 | A.8.2 | Privileged access rights | RBAC roles, policy engine, approval modes, denylist |
 | A.8.5 | Secure authentication | Credential cascade, no CLI-arg secrets, keychain + SSH agent + CA cert support |
-| A.8.23 | Web filtering | `--transport http` requires bearer auth, rate limiting (planned) |
+| A.8.23 | Web filtering | `--transport http` requires bearer auth, `--rateLimit` token bucket, `--allowedHosts` Host-header allow-list |
 | A.12.4 | Logging and monitoring | Audit log with ECS fields, hash-chain option, redaction |
 | A.13.1 | Network security controls | Host key verification, frozen algorithms, ProxyJump tunnel |
 | A.14.2 | Security in development | Property tests (fast-check), SAST (Semgrep), secret scanning (gitleaks), npm provenance |


### PR DESCRIPTION
Prompted by a question worth asking before a release: is the `WARNING — Lethal Trifecta Risk` line, which is the first thing on the npm package page, still true?

The answer was "true but written for v1", and checking its neighbours turned up two claims that are not true at all. Same class of problem as the research drafts removed in #116, except these are the documents people read.

## 1. `exec()`-only architecture — false since v2

SECURITY.md's mitigation table said:

> | PTY session leaks (MaxSessions) | `exec()`-only architecture; no persistent su shells |

v2 added `open-session` / `list-sessions`, which hold a real shell channel via `session-manager.ts:82`. **This one understates the attack surface**, which is the worse direction — someone doing a threat assessment against this table would skip a surface that exists.

Replaced with the mitigation actually in place, verified against `src/config/schema.ts:23-25` and `src/index.ts:227`:

- `sessionMaxPerConnection` (default 5)
- `sessionIdleTimeoutMs` (10 min)
- `sessionBackgroundMaxMs` (1 h)
- a reaper sweeping expired sessions every 60s

"No persistent `su` shells" was correct and stays.

## 2. Rate limiting "(planned)" — shipped

> | A.8.23 | Web filtering | `--transport http` requires bearer auth, rate limiting (planned) |

`--rateLimit` drives a token bucket enforced at `src/transport/http.ts:170`, and `--allowedHosts` gates the Host header (`http.ts:90`). Both named now.

## 3. The README warning — true, but speaking in v1's voice

Nothing in it is factually wrong. The problem is what it does on the npm page, where the sequence reads:

> line 10: security-first … classification, policy-based authorization, human-in-the-loop approval, full audit logging
> line 12: **WARNING — Lethal Trifecta Risk**

with nothing connecting them. It was written when the only mitigations were `--maxChars` and `--disableSudo`, so "this is dangerous, be careful" was the whole of the honest message. For v2 the risk is the reason the thing exists, and the warning should say so.

Rewritten to keep every honest part — the trifecta framing and Willison link, that prompt injection has no general fix, that policy narrows the blast radius **without removing the risk**, and both operator duties (not a root account, not `auto` on production) — while stating what the server does about it. Not softened into marketing: the "does not remove the risk" sentence is explicit.

`./SECURITY.md` was also checked as an npm concern: `package.json` sets `repository`, so npm resolves the relative link against the GitHub repo. Not broken.

## Verification

Every claim written into these files was checked against the source, not assumed: `allowedHosts` in `index.ts:210` and `http.ts:90`, the three session defaults in `schema.ts:23-25`, the 60s reaper in `index.ts:227`, and that no `su` shell exists anywhere in `src/`.

Docs-only. No changeset — nothing in the published tarball changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)