### PR TITLE
docs: explain why the release PR needs an admin merge

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -80,6 +80,32 @@ jobs:
       - name: Build
         run: npm run build
 
+      # The "Version Packages" pull request this opens will never show a green
+      # `test`, and that is expected rather than broken. This action pushes
+      # `changeset-release/main` using GITHUB_TOKEN, and GitHub does not start
+      # workflows for pushes made with that token — the loop-breaker that stops
+      # a workflow from triggering itself. So ci.yml never runs on that branch,
+      # the `test` context required by the "Main Branch Protection" ruleset
+      # never reports, and the PR sits at BLOCKED.
+      #
+      # Merging it therefore takes an admin bypass (`gh pr merge --admin`),
+      # which the ruleset already allows: its bypass_actors carries the Admin
+      # repository role at bypass_mode "always". Nothing needs adding, and
+      # nothing narrower is available — ruleset bypasses are granted to actors
+      # (roles, teams, apps, deploy keys), never to a branch, so "let only
+      # changeset-release/main through" is not expressible.
+      #
+      # What makes that acceptable is that the check would not tell us anything
+      # new. The ruleset sets strict_required_status_checks_policy, so the
+      # release branch must be up to date with main before it can merge, and
+      # ci.yml runs `test` on every push to main. The source being published has
+      # already passed there; the release PR adds a version number and a
+      # CHANGELOG entry on top of it.
+      #
+      # Before merging one, confirm exactly that: the PR touches only
+      # package.json's version, CHANGELOG.md and the consumed changeset files,
+      # and main is green at the commit it sits on. An admin merge of anything
+      # wider is skipping a real check.
       - name: Create Release Pull Request or Publish
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1 (branch, not a tag)
         with:


### PR DESCRIPTION
Reopens #118, which GitHub closed when I deleted its branch — I chained the cleanup on the merge command's sequence rather than on its success, and the merge had been blocked. Same commit, rebased onto `main`.

Closes the question raised while publishing 2.2.0. **Nothing is changed** — the ruleset is left exactly as it is, and this records why.

## What happened

The "Version Packages" PR (#113) sat at `BLOCKED` with no `test` check on it at all. Only Snyk had reported.

The cause is not visible from anything in the repo: the changesets action pushes `changeset-release/main` using `GITHUB_TOKEN`, and GitHub does not start workflows for pushes made with that token — the loop-breaker that stops a workflow triggering itself. So `ci.yml` never runs on that branch, the `test` context the ruleset requires never reports, and the PR can never go green. This will recur on **every** release.

## Both fixes I reached for first do not exist

I opened this expecting to add a narrow bypass. Reading the actual ruleset killed both ideas:

1. **There is no bypass to add.** `bypass_actors` already carries:
   ```json
   [{"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}]
   ```
   the Admin repository role, always. That is why `gh pr merge --admin` worked.

2. **A branch-scoped bypass is not expressible.** Ruleset bypasses are granted to *actors* — repository roles, teams, apps, deploy keys. Never to a branch. "Let only `changeset-release/main` through" cannot be written.

## And the check would add no signal

The ruleset sets `strict_required_status_checks_policy: true`, so the release branch has to be up to date with `main` before it can merge. `ci.yml` runs `test` on every push to `main` — verified on the last three (`863fbe5`, `eefa3d5`, `8bbc3e8`, all `push success`).

So the source being published has already passed `test` on main. The release PR adds a version number and a CHANGELOG entry on top of it. Re-running the suite against the same source plus a version bump tells us nothing we do not have.

## What the comment asks for instead

The operational half, which is the point:

> Before merging one, confirm exactly that: the PR touches only `package.json`'s version, `CHANGELOG.md` and the consumed changeset files, and main is green at the commit it sits on. An admin merge of anything wider is skipping a real check.

That is the habit that keeps `--admin` from becoming reflex. It is what I did for #113 before merging it — the diff was version + CHANGELOG + changeset removal, and main was green at `eefa3d5`.

## Considered and rejected

Giving the changesets action a PAT instead of `GITHUB_TOKEN` would make the push trigger CI normally. Rejected: that job holds `id-token: write` and mints the OIDC token that publishes the package. Adding a long-lived credential to it to gain a check that duplicates one we already have is a trade in the wrong direction.

Workflow-only change. No changeset — nothing published is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)