### PR TITLE
fix: patch the js-yaml ReDoS reachable from the release job

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -3440,9 +3440,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4493,9 +4493,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes the two Dependabot high alerts that appeared on `main` after the 2.2.0 release.

## The alerts

Both are the same advisory — [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) / CVE-2026-59870, CVSS 7.5: quadratic CPU consumption resolving `!!omap`.

Two entries because two js-yaml majors are in the tree:

```
@changesets/cli@2.31.1
├─ @changesets/read → @changesets/parse → js-yaml@4.3.0   (< 4.3.1)
└─ @manypkg/get-packages → read-yaml-file → js-yaml@3.15.0 (< 3.15.1)
```

`npm audit fix` resolved both **without `--force`** — patch bumps to 4.3.1 and 3.15.1. `package.json` is untouched; the diff is 8 lines of `package-lock.json`. `npm audit` now reports 0.

## Reach

Development scope. Nothing published is affected: `npm audit --omit=dev` was clean before this change, and `files` is `["build"]`.

The path that does exist is narrow but real, which is why this is worth doing rather than dismissing: `@changesets/parse` uses js-yaml to read the YAML frontmatter of changeset files. A crafted changeset could burn CPU in the release job. Low stakes, cheap fix.

## Verification

The risk with patching js-yaml is breaking the thing that depends on it, so I checked that specifically.

`changeset status` with no changeset files present only proves the config loads — it does not touch the frontmatter parser. So I dropped in a temporary changeset and ran it again:

```
🦋  info
🦋  - ssh-mcp
🦋  info NO packages to be bumped at minor
```

Frontmatter parsed, package picked up. Probe file removed.

Also: `npm run typecheck` clean, 257 unit and property tests pass.

No changeset — development dependency, lockfile only, nothing in the published tarball changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)