### PR TITLE
fix(approval): let Accept mean accept, and make three bare flags do something

### DIFF
--- a/.changeset/olive-donkeys-smile.md
+++ b/.changeset/olive-donkeys-smile.md
@@ -1,0 +1,13 @@
+---
+"ssh-mcp": patch
+---
+
+Fix the approval dialog turning Accept into a decline, and three boolean CLI flags that did nothing ([#91](https://github.com/tufantunc/ssh-mcp/issues/91)).
+
+**Approving a command now takes one keystroke, and works.** The elicitation request asked for a required `confirm` boolean on top of the protocol's own `accept`/`decline`, so clients rendered a checkbox beside the accept row. Choosing Accept without ticking it submitted a form missing a required field, the client answered `cancel`, and ssh-mcp reported `APPROVAL_DENIED: User did not approve this command` — to a user who had just pressed Approve. The decision now comes from `action` alone. An explicit `confirm: false` is still honoured for clients that send one.
+
+**Approval waits 10 minutes instead of 60 seconds.** The request inherited the SDK's `DEFAULT_REQUEST_TIMEOUT_MSEC`, setting a human's reading time from a default meant for machine round trips. An operator who stepped away, or who was working out an unfamiliar dialog, had it expire underneath them.
+
+**A timed-out approval says so.** `APPROVAL_UNAVAILABLE` led with "a client without elicitation support" for every error, including a timeout where support was fine — the same wrong-cause defect the message was split out to fix, one release later, inside its own fix. Timeouts now name the elapsed budget and say the prompt may still be open.
+
+**`--disableApproval`, `--auditEntropyScan` and `--auditTamperEvident` were no-ops.** `parseArgv` stores `null` for a flag written without `=`, which is how all three are documented, and each call site tested that for truthiness. They did nothing unless spelled `--flag=1`. The audit pair is the serious half: anyone who turned on hash-chained tamper-evident logging was running without it and had no signal. All flags now read presence through one helper, and `--flag=false` (or `0`, `no`, `off`) turns one back off.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,19 @@ distinguishable from a fresh human answer.
 **Off by default** (`0` = always prompt). Auto-approval weakens the gate that
 makes destructive commands safe, so turning it on should be a decision.
 
+#### Answering the prompt
+
+Approval goes through the MCP elicitation request, so what you see is your
+client's dialog. Accepting it approves the command — there is no second field to
+fill in.
+
+You have **10 minutes** to answer. Past that the request expires and the command
+is refused rather than left pending, and the refusal says so; the prompt may
+still be open in your client, in which case run the command again once you are
+ready. If your client does not support elicitation at all, every destructive and
+privileged command is refused with `APPROVAL_UNAVAILABLE` naming that cause —
+approval fails closed by design.
+
 ### Command Quota
 
 `commandQuotaPerDay` bounds how many commands a profile may run in a rolling

--- a/src/guard/elicitation.ts
+++ b/src/guard/elicitation.ts
@@ -1,3 +1,4 @@
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { PolicyEvaluation } from '../types.js';
 
@@ -14,6 +15,20 @@ export interface ApprovalResult {
 }
 
 /**
+ * How long a person has to read a destructive command and decide.
+ *
+ * Explicit because the SDK's DEFAULT_REQUEST_TIMEOUT_MSEC is 60 seconds, and
+ * inheriting it here set a human's reading time from a default chosen for
+ * machine round trips. An operator who stepped away, or who was working out an
+ * unfamiliar dialog, had the request expire underneath them and the command
+ * refused (#91).
+ *
+ * Ten minutes is long enough to be interrupted and come back, and still bounded
+ * so a client that never answers cannot pin a tool call open forever.
+ */
+export const APPROVAL_TIMEOUT_MS = 600_000;
+
+/**
  * Ask the MCP client to confirm a destructive or privileged command.
  *
  * Uses the SDK's typed `Server.elicitInput()` rather than a hand-built
@@ -21,8 +36,9 @@ export interface ApprovalResult {
  * of silently disabling the gate that guards every destructive command.
  *
  * Fails closed: any error (client without elicitation support, transport
- * failure, malformed reply) denies the command. The failure is logged, because
- * a gate that always denies for an unnoticed reason is its own kind of outage.
+ * failure, timeout, malformed reply) denies the command. The failure is logged,
+ * because a gate that always denies for an unnoticed reason is its own kind of
+ * outage.
  */
 export async function requestApproval(
   server: McpServer,
@@ -33,39 +49,64 @@ export async function requestApproval(
   const message = `Confirm ${evaluation.commandClass} command on "${profileName}":\n\n${command}`;
 
   try {
-    const result = await server.server.elicitInput({
-      message,
-      requestedSchema: {
-        type: 'object',
-        properties: {
-          confirm: {
-            type: 'boolean',
-            title: 'Approve this command?',
+    const result = await server.server.elicitInput(
+      {
+        message,
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            confirm: {
+              type: 'boolean',
+              title: 'Approve this command?',
+            },
           },
+          // `confirm` is deliberately not required. The protocol already carries
+          // the decision in `action`, where accept and decline are distinct
+          // results, so requiring a boolean on top asked the user to say the
+          // same thing twice — and clients render a required boolean as a
+          // checkbox beside the accept/decline row. Choosing Accept without
+          // ticking it submits a form missing a required field, so the client
+          // can produce no valid result and sends `cancel`, which arrived here
+          // as "User did not approve this command". The user picked Approve and
+          // was told they had declined (#91).
         },
-        required: ['confirm'],
       },
-    });
+      { timeout: APPROVAL_TIMEOUT_MS },
+    );
 
-    if (result.action === 'accept' && result.content?.confirm === true) {
+    // `action` decides. An explicit `confirm: false` from a client that still
+    // sends the field is honoured, because refusing to run on an explicit "no"
+    // costs nothing and reading it as approval would be indefensible.
+    if (result.action === 'accept' && result.content?.confirm !== false) {
       return { approved: true, approver: 'mcp-client' };
     }
     return { approved: false };
   } catch (err) {
+    const timedOut = err instanceof McpError && err.code === ErrorCode.RequestTimeout;
     const cause = err instanceof Error ? err.message : String(err);
+
     // stderr still gets it for the operator's logs, but it cannot be the only
     // copy: for a stdio MCP server that is a client log file nobody reads, so
     // the caller gets the diagnosis too and can put it in front of the user.
     console.error(
       `Approval request failed for ${evaluation.commandClass} command on "${profileName}" — denying. ` +
-      `Does this client support elicitation? Cause: ${cause}`,
+      `${timedOut ? `No answer within ${APPROVAL_TIMEOUT_MS / 1000}s.` : 'Does this client support elicitation?'} ` +
+      `Cause: ${cause}`,
     );
+
+    // Naming the cause rather than guessing at it. This message was introduced
+    // to stop APPROVAL_DENIED covering two different failures, and then led with
+    // "a client without elicitation support" for every error the catch saw,
+    // timeouts included — the same defect, inside its own fix.
     return {
       approved: false,
-      unavailable:
-        `this MCP client could not be asked to approve it. The likely cause is a client without ` +
-        `elicitation support; a transport failure or a malformed reply does the same. Approval fails ` +
-        `closed, so the command was refused rather than run. Underlying error: ${cause}`,
+      unavailable: timedOut
+        ? `no answer arrived within ${APPROVAL_TIMEOUT_MS / 1000}s, so it was refused rather than left ` +
+          `pending. The prompt may still be open in your client; approve the command again once you are ` +
+          `ready to answer it.`
+        : `this MCP client could not be asked to approve it. The likely cause is a client without ` +
+          `elicitation support; a transport failure or a malformed reply does the same. Approval fails ` +
+          `closed, so the command was refused rather than run. Underlying error: ${cause}`,
     };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,26 @@ function parseArgv(): Record<string, string | null> {
 }
 
 /**
+ * Whether a boolean flag was passed at all.
+ *
+ * `parseArgv` stores `null` for a flag written without `=`, which is how every
+ * documented boolean flag is written. Testing that value for truthiness makes
+ * the flag a no-op: `--disableApproval`, `--auditEntropyScan` and
+ * `--auditTamperEvident` all did nothing unless spelled `--flag=1`, which
+ * nothing documents (#91). The two call sites that got it right already used
+ * `!== undefined`; this gives the check a name so the next one cannot miss it.
+ *
+ * `--flag=false` and `--flag=0` turn it off, because a flag that cannot be
+ * turned off once written into a wrapper script is its own annoyance.
+ */
+function flagEnabled(argv: Record<string, string | null>, name: string): boolean {
+  if (!(name in argv)) return false;
+  const value = argv[name];
+  if (value === null || value === '') return true;
+  return !['false', '0', 'no', 'off'].includes(value.toLowerCase());
+}
+
+/**
  * v1 flags that v2 removed. Silently ignoring them means the user only finds
  * out at the first command, as an auth failure with no hint about the cause.
  */
@@ -67,7 +87,7 @@ function parseMaxChars(raw: string | null | undefined): number {
  * existed. `--insecureHostKey` is kept as an alias for the documented flag.
  */
 function resolveHostKeyMode(argv: Record<string, string | null>): HostKeyMode {
-  if (argv.insecureHostKey !== undefined) return 'insecure';
+  if (flagEnabled(argv, 'insecureHostKey')) return 'insecure';
   const mode = argv.hostKeyMode;
   if (mode === null || mode === undefined) return 'tofu';
   if (mode === 'tofu' || mode === 'strict' || mode === 'insecure') return mode;
@@ -143,7 +163,7 @@ async function buildAppConfig(argv: Record<string, string | null>): Promise<AppC
     role: 'admin',
     group: resolveHostGroup(argv),
     readOnly: false,
-    approvalPolicy: argv.disableApproval ? 'auto' : defaults.approvalMode,
+    approvalPolicy: flagEnabled(argv, 'disableApproval') ? 'auto' : defaults.approvalMode,
     cert: false,
     sessionMaxPerConnection: defaults.sessionMaxPerConnection,
     sessionIdleTimeoutMs: defaults.sessionIdleTimeoutMs,
@@ -165,8 +185,8 @@ async function main() {
 
   const config = await buildAppConfig(argv);
   const hostKeyMode = resolveHostKeyMode(argv);
-  const entropyScan = !!argv.auditEntropyScan;
-  const tamperEvident = !!argv.auditTamperEvident;
+  const entropyScan = flagEnabled(argv, 'auditEntropyScan');
+  const tamperEvident = flagEnabled(argv, 'auditTamperEvident');
 
   await initKeychain();
 
@@ -260,4 +280,4 @@ if (isCliEnabled || isTestMode) {
   });
 }
 
-export { parseArgv, buildAppConfig, checkRemovedFlags, parseMaxChars };
+export { parseArgv, buildAppConfig, checkRemovedFlags, parseMaxChars, flagEnabled, resolveHostKeyMode };

--- a/test/unit/cli-boolean-flags.test.ts
+++ b/test/unit/cli-boolean-flags.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { flagEnabled, resolveHostKeyMode } from '../../src/index.js';
+
+/**
+ * Every documented boolean flag is written bare — `--disableApproval`, not
+ * `--disableApproval=1`. `parseArgv` stores `null` for that form, and three
+ * call sites tested it for truthiness, so the flags did nothing at all (#91).
+ *
+ * The reporter's words were "--disableApproval doesnt work for me". It did not
+ * work for anyone. The two audit flags are the worse half: someone who turned
+ * on hash-chained tamper-evident logging ran without it and had no signal.
+ *
+ * These tests exist because the failure was silent in both directions — the
+ * flag produced no error and the feature produced no output.
+ */
+describe('flagEnabled', () => {
+  it('treats a bare flag as on, which is how they are documented', () => {
+    expect(flagEnabled({ disableApproval: null }, 'disableApproval')).toBe(true);
+    expect(flagEnabled({ auditTamperEvident: null }, 'auditTamperEvident')).toBe(true);
+  });
+
+  it('is off when absent', () => {
+    expect(flagEnabled({}, 'disableApproval')).toBe(false);
+    expect(flagEnabled({ other: null }, 'disableApproval')).toBe(false);
+  });
+
+  it.each(['1', 'true', 'yes', 'on', 'anything'])('accepts =%s as on', (value) => {
+    expect(flagEnabled({ f: value }, 'f')).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', '0', 'no', 'off'])('accepts =%s as off', (value) => {
+    // A flag baked into a wrapper script needs a way back off without editing
+    // the script.
+    expect(flagEnabled({ f: value }, 'f')).toBe(false);
+  });
+
+  it('treats an empty value as on', () => {
+    // `--flag=` is a slip, not an intent to disable; on matches the bare form.
+    expect(flagEnabled({ f: '' }, 'f')).toBe(true);
+  });
+});
+
+describe('boolean flags reach their call sites', () => {
+  /**
+   * The regression that matters: not that flagEnabled is correct in isolation,
+   * but that the flags are wired through it. A unit test of the helper alone
+   * would have passed against the broken code.
+   */
+  it('--insecureHostKey selects insecure mode when written bare', () => {
+    expect(resolveHostKeyMode({ insecureHostKey: null })).toBe('insecure');
+    expect(resolveHostKeyMode({})).toBe('tofu');
+    // And can be turned back off, unlike before.
+    expect(resolveHostKeyMode({ insecureHostKey: 'false' })).toBe('tofu');
+  });
+});

--- a/test/unit/guard/elicitation.test.ts
+++ b/test/unit/guard/elicitation.test.ts
@@ -152,6 +152,31 @@ describe('requestApproval', () => {
       expect(result.unavailable).toMatch(/elicitation support/);
       expect(result.unavailable).not.toMatch(/no answer arrived/);
     });
+
+    it('reads a non-timeout McpError as missing support, which is what it is', async () => {
+      // The real shape of "this client does not support elicitation": the SDK
+      // raises MethodNotFound, an McpError like the timeout but not one. The
+      // check has to discriminate on the code, not on the error type.
+      const server = {
+        server: {
+          elicitInput: vi.fn().mockRejectedValue(
+            new McpError(ErrorCode.MethodNotFound, 'Method not found: elicitation/create'),
+          ),
+        },
+      } as any;
+      const result = await requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+      expect(result.unavailable).toMatch(/elicitation support/);
+      expect(result.unavailable).toContain('Method not found');
+    });
+
+    it('survives a rejection that is not an Error at all', async () => {
+      // A client or transport that rejects with a string would otherwise reach
+      // `err.message` on a string and report `undefined` as the cause.
+      const server = { server: { elicitInput: vi.fn().mockRejectedValue('socket closed') } } as any;
+      const result = await requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+      expect(result.approved).toBe(false);
+      expect(result.unavailable).toContain('socket closed');
+    });
   });
 
   it('does not approve when the client accepts but confirm is false', async () => {

--- a/test/unit/guard/elicitation.test.ts
+++ b/test/unit/guard/elicitation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { requestApproval } from '../../../src/guard/elicitation.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { requestApproval, APPROVAL_TIMEOUT_MS } from '../../../src/guard/elicitation.js';
 import type { PolicyEvaluation } from '../../../src/types.js';
 
 const mockEvaluation: PolicyEvaluation = {
@@ -86,6 +87,73 @@ describe('requestApproval', () => {
     expect(result.unavailable).toBeUndefined();
   });
 
+  /**
+   * Requiring a `confirm` boolean on top of `action` made clients render a
+   * checkbox beside the accept/decline row. Choosing Accept without ticking it
+   * submits a form missing a required field, so the client sends `cancel` — and
+   * the user who picked Approve was told they had declined (#91).
+   */
+  describe('the decision comes from action, not a second checkbox', () => {
+    it('does not mark confirm as required', () => {
+      const server = makeMockServer('accept');
+      requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+      const params = server.server.elicitInput.mock.calls[0][0];
+      expect(params.requestedSchema.required ?? []).not.toContain('confirm');
+    });
+
+    it('approves a bare accept that carries no content at all', async () => {
+      const server = { server: { elicitInput: vi.fn().mockResolvedValue({ action: 'accept' }) } } as any;
+      const result = await requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+      expect(result.approved).toBe(true);
+    });
+
+    it('still honours an explicit confirm: false', async () => {
+      // Reading an explicit "no" as approval would be indefensible, whatever
+      // `action` says.
+      const server = {
+        server: { elicitInput: vi.fn().mockResolvedValue({ action: 'accept', content: { confirm: false } }) },
+      } as any;
+      expect((await requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation)).approved).toBe(false);
+    });
+  });
+
+  /**
+   * The elicitation request inherited the SDK's DEFAULT_REQUEST_TIMEOUT_MSEC of
+   * 60s, setting a human's reading time from a default meant for machine round
+   * trips. Worse, the expiry then reported "a client without elicitation
+   * support" — the wrong cause, in the very message added to stop reporting the
+   * wrong cause.
+   */
+  describe('timeout', () => {
+    it('asks for a human-scale budget rather than inheriting the SDK default', () => {
+      const server = makeMockServer('accept');
+      requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+      const options = server.server.elicitInput.mock.calls[0][1];
+      expect(options?.timeout).toBe(APPROVAL_TIMEOUT_MS);
+      expect(APPROVAL_TIMEOUT_MS).toBeGreaterThan(60_000);
+    });
+
+    it('names the timeout instead of guessing at missing elicitation support', async () => {
+      const server = {
+        server: {
+          elicitInput: vi.fn().mockRejectedValue(
+            new McpError(ErrorCode.RequestTimeout, 'Request timed out'),
+          ),
+        },
+      } as any;
+      const result = await requestApproval(server, 'rm /tmp/x', 'dev', mockEvaluation);
+      expect(result.approved).toBe(false);
+      expect(result.unavailable).toMatch(/no answer arrived within/);
+      expect(result.unavailable).not.toMatch(/elicitation support/);
+    });
+
+    it('keeps the missing-support wording for errors that are not timeouts', async () => {
+      const result = await requestApproval(makeMockServer('error'), 'rm /tmp/x', 'dev', mockEvaluation);
+      expect(result.unavailable).toMatch(/elicitation support/);
+      expect(result.unavailable).not.toMatch(/no answer arrived/);
+    });
+  });
+
   it('does not approve when the client accepts but confirm is false', async () => {
     const server = {
       server: { elicitInput: vi.fn().mockResolvedValue({ action: 'accept', content: { confirm: false } }) },
@@ -101,6 +169,8 @@ describe('requestApproval', () => {
     expect(params.message).toContain('destructive');
     expect(params.message).toContain('prod-web-1');
     expect(params.message).toContain('rm -rf /tmp/x');
-    expect(params.requestedSchema.required).toContain('confirm');
+    // `confirm` is still offered so a client that wants a field has one; it is
+    // no longer required, which is what turned Accept into a decline (#91).
+    expect(params.requestedSchema.properties.confirm).toBeDefined();
   });
 });


### PR DESCRIPTION
Four defects reported on #91 by @nordscope-fi and @Blackspell01, who had already worked around the previous round. The client-log excerpts in [that thread](https://github.com/tufantunc/ssh-mcp/issues/91#issuecomment-5266147201) did most of the diagnosis.

## 1. Accept meant decline

`requestedSchema` asked for a **required** `confirm` boolean on top of the protocol's own `accept`/`decline`, so clients render a checkbox beside the accept row:

```
> * Approve this command?: []
    Accept    Decline
```

Choosing Accept without ticking `[]` submits a form missing a required field. The client cannot produce a valid result, sends `cancel`, and we reported:

```
APPROVAL_DENIED: User did not approve this command
```

to someone who had just pressed Approve. From the outside it is indistinguishable from a decline — the operator's description was *"I select Approve and hit Enter, and then it just jumps back"*.

`action` decides now. `confirm` stays as an optional field, and an explicit `confirm: false` is still honoured — reading an explicit no as approval would be indefensible.

The safety direction is fine and probably improves. The friction was not buying anything; it was pushing people to `--disableApproval`, which drops the gate on every destructive and privileged command. @nordscope-fi spent twenty minutes there on the strength of a wrong diagnosis.

## 2. A human had 60 seconds

The request inherited the SDK default:

```js
// @modelcontextprotocol/sdk/dist/esm/shared/protocol.js:8
export const DEFAULT_REQUEST_TIMEOUT_MSEC = 60000;
```

That is a budget for a machine round trip, not for a person reading a destructive command. Now an explicit **10 minutes** — long enough to be interrupted and come back, still bounded so a client that never answers cannot pin a tool call open.

One correction to the report, because it changes the fix: this was attributed to `commandTimeoutMs`. That only wraps exec, at `connection.ts:212`. Both defaulting to 60000 makes the reading natural, but raising `commandTimeoutMs` would have changed nothing.

## 3. `APPROVAL_UNAVAILABLE` named the wrong cause

It led with *"a client without elicitation support"* for every error the catch saw, timeouts included. That message shipped **one release ago**, in #121, specifically to stop a failure from naming the wrong cause — and then did it itself. Timeouts now say so and mention the prompt may still be open.

## 4. `--disableApproval` did nothing — and neither did the audit flags

@Blackspell01 reported it does not work. It did not work for anyone:

```ts
if (eq === -1) { config[arg.slice(2)] = null; }          // parseArgv
approvalPolicy: argv.disableApproval ? 'auto' : ...      // null is falsy
```

Every boolean flag is documented bare, so all three of these were no-ops unless spelled `--flag=1`:

| flag | before | now |
| --- | --- | --- |
| `--disableApproval` | no-op | works |
| `--auditEntropyScan` | no-op | works |
| `--auditTamperEvident` | no-op | works |
| `--insecureHostKey` | worked (`!== undefined`) | works |
| `--dumpToolHashes` | worked (`!== undefined`) | works |

**The audit pair is the serious half.** Anyone who turned on hash-chained tamper-evident logging has been running without it, with no signal — a security feature silently off is worse than one that fails loudly.

Two call sites already used the right pattern, so the codebase knew; `flagEnabled()` gives it a name so the next one cannot miss it, and `--flag=false` (or `0`, `no`, `off`) now turns one back off.

## Verification

Each fix mutation-tested **after** committing, so the revert could not take the fix with it:

| mutation | fails |
| --- | --- |
| restore `required: ['confirm']` + `=== true` | the bare-accept case |
| drop the `timeout` option | the human-scale-budget case |
| flatten the timeout branch | the timeout-wording case |
| `flagEnabled` → `!!argv[name]` | six flag cases |

Nothing else moves in any of them.

- `npm run typecheck`, `npm run build` — clean
- 287 unit and property tests (20 new)
- `SSH_MCP_REQUIRE_SERVERS=1 npm run test:integration` — 122 passed, 6 skipped against live containers; the skips are `windows-compat.test.ts`, which needs `SSH_MCP_WIN_HOST`

README gains an "Answering the prompt" subsection: one keystroke, the 10-minute budget, and what happens on a client without elicitation.

Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)