### PR TITLE
fix(config): let a config file say "no command-length limit"

### DIFF
--- a/.changeset/lucky-hounds-smile.md
+++ b/.changeset/lucky-hounds-smile.md
@@ -1,0 +1,13 @@
+---
+"ssh-mcp": patch
+---
+
+Let a config file say "no command-length limit", the way the CLI flag already can ([#123](https://github.com/tufantunc/ssh-mcp/issues/123)).
+
+`--maxChars=none` disables the cap and the README documents `none` or `0` as doing so. The TOML schema was `positive()`, so `commandMaxChars = 0` was a startup error and the config file had no spelling for it. Moving a flags-based invocation into a config file therefore tightened the limit back to the 5000 default, and the only way to express uncapped was to write `9007199254740991` out in full.
+
+`commandMaxChars` and the per-profile `maxChars` are now `nonnegative()`, with `0` meaning unlimited. That is the convention this config file already uses for `commandQuotaPerDay` and `approvalGrantTtlMs`, so `commandMaxChars` was the odd one out rather than the key needing a new spelling invented for it.
+
+**`0` is mapped rather than merely permitted.** `sanitizeCommand` tests `cleaned.length > maxChars`, so a literal `0` arriving there would reject every non-empty command with `Command is too long (max 0 characters)` — a worse failure than the one being fixed. `normalizeConfig` maps it to `Number.MAX_SAFE_INTEGER`, the same value `parseMaxChars` produces for the flag, so the two surfaces hand the rest of the code an identical `Profile` rather than two spellings of uncapped.
+
+Negatives stay rejected. `--maxChars=-1` means unlimited only as a wart of `parseInt` handling, it is undocumented, and it is likelier to be a typo than an intent; parity is worth having between the documented behaviours, not between the accidents.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ sessionMaxPerConnection = 5
 sessionIdleTimeoutMs = 600000       # 10min
 sessionBackgroundMaxMs = 3600000    # 1hr
 commandTimeoutMs = 60000
-commandMaxChars = 5000
+commandMaxChars = 5000              # 0 = unlimited, the config spelling of --maxChars=none
 commandMaxOutputBytes = 1048576     # 1MB
 connectionIdleReapMs = 900000       # 15min
 commandQuotaPerDay = 0              # 0 = unlimited; circuit breaker for runaway agents
@@ -177,6 +177,7 @@ cert = false                        # SSH CA cert auth — auto-detects keyRef-c
 sessionMaxPerConnection = 3         # per-profile override
 sessionIdleTimeoutMs = 300000       # stricter for prod
 commandQuotaPerDay = 200            # per-profile override
+maxChars = 0                        # per-profile override; 0 = unlimited
 
 # Optional. Merged over the built-in role matrix; see "Policy Engine" below.
 # roleBindings is keyed by role and then by tier, so the block below changes
@@ -554,7 +555,7 @@ Secrets are **never** passed as CLI arguments.
 | `--workdir` | — | Quick start: Working directory for commands and sessions |
 | `--group` | prod | Quick start: Policy tier — `prod`, `staging` or `dev` |
 | `--timeout` | 60000 | Command timeout in ms |
-| `--maxChars` | 5000 | Max command length (`none` or `0` disables the limit) |
+| `--maxChars` | 5000 | Max command length (`none` or `0` disables the limit; in a config file the same setting is `commandMaxChars = 0`) |
 | `--sessionMax` | 5 | Max concurrent sessions per connection |
 | `--sessionTtl` | 600000 | Session idle timeout in ms |
 | `--transport` | stdio | `stdio` or `http` |

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -81,6 +81,23 @@ export async function loadConfig(customPath?: string): Promise<AppConfig> {
 }
 
 /**
+ * `0` means unlimited, the convention `commandQuotaPerDay` and
+ * `approvalGrantTtlMs` already use in this config file.
+ *
+ * It has to be *mapped* rather than merely permitted. `sanitizeCommand` tests
+ * `cleaned.length > maxChars`, so a literal `0` arriving there rejects every
+ * non-empty command with "Command is too long (max 0 characters)" — a worse
+ * failure than the one this spelling exists to fix.
+ *
+ * MAX_SAFE_INTEGER is the value `parseMaxChars` produces for `--maxChars=none`,
+ * so the flag and the config file hand the rest of the code an identical
+ * Profile rather than two spellings of uncapped (#123).
+ */
+function uncapZero(maxChars: number): number {
+  return maxChars === 0 ? Number.MAX_SAFE_INTEGER : maxChars;
+}
+
+/**
  * Resolve every profile against [defaults]. Each of these keys is documented as
  * a default that profiles inherit, so all of them must cascade — a key that is
  * accepted by the schema but never applied silently ignores the operator's
@@ -95,7 +112,7 @@ function normalizeConfig(raw: RawConfig): AppConfig {
   const profiles: Profile[] = raw.profiles.map((p) => ({
     ...p,
     timeout: p.timeout ?? defaults.commandTimeoutMs,
-    maxChars: p.maxChars ?? defaults.commandMaxChars,
+    maxChars: uncapZero(p.maxChars ?? defaults.commandMaxChars),
     maxOutputBytes: p.maxOutputBytes ?? defaults.commandMaxOutputBytes,
     approvalPolicy: p.approvalPolicy ?? defaults.approvalMode,
     sessionMaxPerConnection: p.sessionMaxPerConnection ?? defaults.sessionMaxPerConnection,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -24,7 +24,10 @@ export const defaultsSchema = z.object({
   sessionIdleTimeoutMs: z.number().int().positive().default(600_000),
   sessionBackgroundMaxMs: z.number().int().positive().default(3_600_000),
   commandTimeoutMs: z.number().int().positive().default(60_000),
-  commandMaxChars: z.number().int().positive().default(5000),
+  // 0 = unlimited, matching `--maxChars=none` on the CLI. normalizeConfig()
+  // maps it to Number.MAX_SAFE_INTEGER so both surfaces hand the rest of the
+  // code an identical Profile.
+  commandMaxChars: z.number().int().nonnegative().default(5000),
   commandMaxOutputBytes: z.number().int().positive().default(1_048_576),
   connectionIdleReapMs: z.number().int().positive().default(900_000),
   // 0 = unlimited. A circuit breaker for runaway agents, not a rate limit.
@@ -57,7 +60,8 @@ export const profileSchema = z.object({
   // a schema-level .default() would make "user omitted it" indistinguishable
   // from "user set the default value", silently shadowing [defaults].
   timeout: z.number().int().positive().optional(),
-  maxChars: z.number().int().positive().optional(),
+  // 0 = unlimited, as in [defaults].commandMaxChars above.
+  maxChars: z.number().int().nonnegative().optional(),
   maxOutputBytes: z.number().int().positive().optional(),
   approvalPolicy: approvalModeSchema.optional(),
   sessionMaxPerConnection: z.number().int().positive().optional(),

--- a/test/unit/config/max-chars.test.ts
+++ b/test/unit/config/max-chars.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, chmod, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadConfig, getProfile } from '../../../src/config/loader.js';
+import { sanitizeCommand } from '../../../src/guard/sanitizer.js';
+
+/**
+ * These go config file → loadConfig → sanitizeCommand, because the bug in the
+ * middle of #123 is invisible one step earlier.
+ *
+ * `--maxChars=none` disabled the cap; the TOML schema was `positive()`, so the
+ * config file could not say the same thing. Widening it to `nonnegative()` is
+ * only half a fix: `sanitizeCommand` tests `cleaned.length > maxChars`, so a
+ * literal `0` reaching it rejects every non-empty command with "Command is too
+ * long (max 0 characters)". A schema-level assertion that `0` parses would pass
+ * against exactly that.
+ */
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'ssh-mcp-maxchars-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+async function writeConfig(content: string): Promise<string> {
+  const path = join(tempDir, 'config.toml');
+  await writeFile(path, content, 'utf8');
+  await chmod(path, 0o600);
+  return path;
+}
+
+const PROFILE = `
+[[profiles]]
+name = "web"
+host = "10.0.0.5"
+user = "deploy"
+role = "admin"
+group = "dev"
+`;
+
+/** Longer than the 5000-char default, so the default would reject it. */
+const LONG_COMMAND = `echo ${'x'.repeat(6000)}`;
+
+async function maxCharsFor(toml: string): Promise<number> {
+  const config = await loadConfig(await writeConfig(toml));
+  return getProfile(config, 'web').maxChars;
+}
+
+describe('commandMaxChars = 0 means unlimited', () => {
+  it('accepts a command longer than the default cap', async () => {
+    const maxChars = await maxCharsFor(`
+[defaults]
+commandMaxChars = 0
+${PROFILE}`);
+
+    expect(sanitizeCommand(LONG_COMMAND, maxChars)).toBe(LONG_COMMAND);
+  });
+
+  it('resolves to the same value --maxChars=none produces', async () => {
+    const maxChars = await maxCharsFor(`
+[defaults]
+commandMaxChars = 0
+${PROFILE}`);
+
+    // parseMaxChars() maps `none`, `0` and negatives to this. The two surfaces
+    // are one setting, so they must produce one Profile.
+    expect(maxChars).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it('works as a per-profile override too', async () => {
+    const maxChars = await maxCharsFor(`
+[defaults]
+commandMaxChars = 100
+${PROFILE}
+maxChars = 0
+`);
+
+    expect(maxChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(sanitizeCommand(LONG_COMMAND, maxChars)).toBe(LONG_COMMAND);
+  });
+
+  it('a profile inherits an unlimited default', async () => {
+    const maxChars = await maxCharsFor(`
+[defaults]
+commandMaxChars = 0
+${PROFILE}`);
+
+    expect(sanitizeCommand('uptime', maxChars)).toBe('uptime');
+  });
+});
+
+describe('a real cap still caps', () => {
+  it('rejects a command over an explicit limit', async () => {
+    const maxChars = await maxCharsFor(`
+[defaults]
+commandMaxChars = 10
+${PROFILE}`);
+
+    expect(maxChars).toBe(10);
+    expect(() => sanitizeCommand(LONG_COMMAND, maxChars)).toThrow(/too long \(max 10 characters\)/);
+  });
+
+  it('a per-profile cap overrides an unlimited default', async () => {
+    const maxChars = await maxCharsFor(`
+[defaults]
+commandMaxChars = 0
+${PROFILE}
+maxChars = 10
+`);
+
+    expect(maxChars).toBe(10);
+    expect(() => sanitizeCommand(LONG_COMMAND, maxChars)).toThrow(/too long/);
+  });
+
+  it('the default cap is unchanged when nothing is set', async () => {
+    const maxChars = await maxCharsFor(PROFILE);
+
+    expect(maxChars).toBe(5000);
+    expect(() => sanitizeCommand(LONG_COMMAND, maxChars)).toThrow(/too long \(max 5000 characters\)/);
+  });
+});
+
+describe('negatives are still rejected', () => {
+  /**
+   * `--maxChars=-1` means unlimited only as a wart of parseInt handling, and is
+   * far likelier to be a typo than an intent. Parity is worth having between
+   * the documented behaviours, not between the accidents.
+   */
+  it('fails at load rather than parsing into a grant of nothing', async () => {
+    await expect(maxCharsFor(`
+[defaults]
+commandMaxChars = -1
+${PROFILE}`)).rejects.toThrow(/commandMaxChars/);
+  });
+
+  it('rejects a negative per-profile override', async () => {
+    await expect(maxCharsFor(`
+[defaults]
+commandMaxChars = 100
+${PROFILE}
+maxChars = -1
+`)).rejects.toThrow(/maxChars/);
+  });
+});


### PR DESCRIPTION
Closes #123. Built to the shape you specified there rather than either option I offered, including the `0 = no limit` convention argument, which is the right one: `commandMaxChars` was the odd key out, not the one needing a new spelling invented for it.

## What changed

**Schema.** `commandMaxChars` and the per-profile `maxChars` go from `positive()` to `nonnegative()`, each with a comment naming the convention the way `commandQuotaPerDay` and `approvalGrantTtlMs` do.

**The mapping, which is the part that matters.** `normalizeConfig` maps `0` to `Number.MAX_SAFE_INTEGER` right where it resolves `p.maxChars ?? defaults.commandMaxChars`, since `??` keeps a `0` rather than swallowing it:

```ts
maxChars: uncapZero(p.maxChars ?? defaults.commandMaxChars),
```

`MAX_SAFE_INTEGER` because that is what `parseMaxChars` produces, so the flag and the config file hand the rest of the code an identical `Profile` rather than two spellings of uncapped.

**README.** The config spelling sits next to the flag row, and both `[defaults]` and the per-profile block carry it inline, so the parity is documented rather than only implemented.

## The test goes all the way to a decision

`test/unit/config/max-chars.test.ts`, driven the way `policy-config.test.ts` drives its cases: config file → `loadConfig` → `sanitizeCommand`, with a 6000-character command so the 5000 default would reject it.

Nine cases across four groups: `0` uncaps (defaults, per-profile override, inheritance), a real cap still caps (explicit limit, per-profile cap over an unlimited default, the untouched 5000 default), and negatives still fail at load on both keys.

**Verified it catches the half-fix**, which is the failure mode you named. Removing the mapping while leaving the schema widened:

```
× accepts a command longer than the default cap
× resolves to the same value --maxChars=none produces
× works as a per-profile override too
× a profile inherits an unlimited default

McpError: MCP error -32602: Command is too long (max 0 characters)
```

Four fail, with exactly the error you predicted. A schema-level assertion that `0` parses passes against that state.

## Verification

- `npm run typecheck`, `npm run build`: clean
- `npx vitest run`: 312 passed, 141 skipped

One pre-existing failure, unrelated and not from this branch: `packaging.e2e.test.ts > rejects an unknown --group instead of falling back to the strictest tier` times out at 20s. It does the same on a clean `main` here, so it is this machine or a flake rather than the change; flagging it rather than touching it.

## Two things I left alone

**`defaults.commandMaxChars` keeps the operator's literal `0`** in the returned `AppConfig`. Every consumer reads `profile.maxChars` (`pipeline.ts:244` into `sanitizeCommand`, `resources.ts:69`), and `index.ts:161` builds its quick-start profile from its own CLI-derived defaults, so the profile-level map covers all of them. Mapping `defaults` too would also work; it seemed better for the parsed config to keep saying what the file said. Happy to change it if you would rather there were no unmapped `0` anywhere.

**`sanitizeCommand`'s `Number.isFinite(maxChars)` guard**, which you noted is a branch nothing produces. Still true after this, since both routes yield `MAX_SAFE_INTEGER`. Left as you said.
