### PR TITLE
fix(policy): detect elevation by segment, not by a leading anchor

### DIFF
--- a/.changeset/olive-falcons-listen.md
+++ b/.changeset/olive-falcons-listen.md
@@ -1,0 +1,19 @@
+---
+"ssh-mcp": patch
+---
+
+Detect elevation anywhere a shell would act on it, not just at the start of the command.
+
+`classifyCommand` decided the `privileged` class with four regexes anchored at `^`: `/^\s*sudo\b/` and the same for `su`, `doas` and `pkexec`. Only a *leading* prefix counted. `sudo id` classified as `privileged` and went to the approval gate; `echo hi; sudo id` classified as **`safe`** and ran with no approval at all.
+
+Any harmless first segment was enough — `true &&`, `cd /tmp;`, a newline, a pipe. The elevation itself was never inspected, so under the default `approvalMode = "ask-destructive"` the prompt a `privileged` command is supposed to raise simply never appeared. `roleBindings` had the same blind spot from the other side: `admin` on `prod` is granted `read-only, safe, destructive` and *not* `privileged`, so a compound command classified `safe` was permitted outright on a tier whose whole point is that it cannot elevate.
+
+The fix reuses the tokenizer that already exists in this file. `parseSegments` walks privilege prefixes to find each segment's head binary, so it always knew which segments were elevated — it just discarded that fact. It now records it as `Segment.privileged`, and `isPrivileged()` is true when any segment carries it.
+
+Scanning the raw string for `\bsudo\b` would have been the smaller diff and the wrong one: it re-breaks for `sudo` exactly what #91 fixed for `reboot`. `grep sudo /var/log/auth.log`, `cat /etc/sudoers`, `ls -la /usr/bin/sudo` and `journalctl -u sudo` mention elevation without invoking it, and all four stay `read-only` here. `classifier.ts` had already written down the rule this follows: *"Matching an invocation rather than a mention needs to know where a command word can start, and that is a tokenizer's job, not a regex's."* That reasoning was applied to power-state commands and not to privilege prefixes.
+
+Unchanged: a bare `sudo`, or `sudo -u root` with no command, still classifies `privileged` — the anchored regex counted it, and a head-less segment now carries the flag so it still does. `sudoedit` and `subl` are not prefixes and are not elevation. Path-qualified spellings (`/usr/bin/sudo`) were already handled by `stripPath` and now benefit in every segment rather than only the first. The prefix list keeps its second, narrower use in `extractBinary`, where anchoring is correct — that names `sudo systemctl status` after `systemctl` — and it is renamed `LEADING_PRIVILEGE_PREFIXES` so the two questions stop sharing one constant.
+
+No regex was added, and nothing here backtracks, so the linear-classification property from the previous release holds. Measured on the shapes that release targeted, at 1 MB: the repeated `dd`/`curl`/`chown` literal case goes 84 ms → 103 ms and a 150k-segment command 240 ms → 311 ms, the cost of one more linear pass over the same tokens. A command that *does* elevate gets faster — 243 ms → 65 ms — because `isPrivileged` now returns before the destructive rules run. Both directions stay linear; the 65 s quadratic case from #128 does not reappear.
+
+One deliberate behaviour change beyond the classification itself: under the default bindings, `admin` on `prod` is not granted `privileged`, so a compound command that previously ran as `safe` — `cd /srv && sudo systemctl restart app` — is now refused rather than prompted. That is the point of the fix, but it will surface as newly-failing commands for anyone whose CLI-configured host took the default `prod` group. `--group=staging`/`dev`, or a `roleBindings` override granting `admin.prod` the `privileged` class, restores it deliberately.

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -137,6 +137,8 @@ interface Segment {
   head: string;
   /** Everything after it, verbatim — `of=/dev/sda` must not be path-stripped. */
   args: string[];
+  /** Whether a privilege prefix (sudo, su, doas, pkexec) introduced this segment. */
+  privileged: boolean;
 }
 
 function parseSegments(command: string): Segment[] {
@@ -146,7 +148,9 @@ function parseSegments(command: string): Segment[] {
     const words = raw.trim().split(/\s+/).filter(Boolean);
 
     let i = 0;
+    let privileged = false;
     while (i < words.length && PRIVILEGE_PREFIXES.has(stripPath(words[i]))) {
+      privileged = true;
       i++;
       while (i < words.length && words[i].startsWith('-')) {
         const consumesValue = PREFIX_VALUE_FLAGS.has(words[i]);
@@ -156,11 +160,35 @@ function parseSegments(command: string): Segment[] {
     }
 
     if (i < words.length) {
-      segments.push({ head: stripPath(words[i]), args: words.slice(i + 1) });
+      segments.push({ head: stripPath(words[i]), args: words.slice(i + 1), privileged });
+    } else if (privileged) {
+      // `sudo`, or `sudo -u root`, with nothing after it. No binary runs, but
+      // privilege was still requested, and the old anchored regex classified it
+      // as privileged. Keep that: a head-less segment is inert for every other
+      // consumer here (none of them match an empty head).
+      segments.push({ head: '', args: [], privileged });
     }
   }
 
   return segments;
+}
+
+/**
+ * Whether the command asks for elevation *anywhere a shell would act on it*.
+ *
+ * This used to be `PRIVILEGED_INDICATORS.some((re) => re.test(command))` with
+ * every pattern anchored at `^`, so only a leading prefix counted. `sudo id`
+ * was privileged; `echo hi; sudo id` was `safe` and ran with no approval at
+ * all. Any harmless first segment — `true &&`, `cd /tmp;`, a `|` — was enough
+ * to drop elevation past the gate.
+ *
+ * Scanning the raw string for `\bsudo\b` instead would re-break what #91 fixed
+ * for `reboot`: `grep sudo /var/log/auth.log` and `cat /etc/sudoers` mention
+ * the word without invoking it. Segment heads are already the distinction
+ * between an invocation and a mention, so this reuses them.
+ */
+function isPrivileged(command: string): boolean {
+  return parseSegments(command).some((segment) => segment.privileged);
 }
 
 function invokedWords(command: string): string[] {
@@ -277,7 +305,16 @@ function isDestructive(command: string): boolean {
   return isForbidden(command) || DESTRUCTIVE_PATTERNS.some((re) => re.test(command));
 }
 
-const PRIVILEGED_INDICATORS = [
+/**
+ * Leading privilege prefixes, stripped so `sudo systemctl status` is *named*
+ * after `systemctl`.
+ *
+ * Naming only. The privilege *decision* is isPrivileged(), which walks every
+ * segment — these are anchored at `^` and answer a different question: "what
+ * should this command be called?", not "does it elevate?". Conflating the two
+ * is what let `echo hi; sudo id` through.
+ */
+const LEADING_PRIVILEGE_PREFIXES = [
   /^\s*sudo\b/,
   /^\s*su\b/,
   /^\s*doas\b/,
@@ -286,7 +323,7 @@ const PRIVILEGED_INDICATORS = [
 
 export function extractBinary(command: string): string {
   let cmd = command.trim();
-  for (const prefix of PRIVILEGED_INDICATORS) {
+  for (const prefix of LEADING_PRIVILEGE_PREFIXES) {
     cmd = cmd.replace(prefix, '').trim();
   }
   if (cmd.startsWith('-c ')) {
@@ -301,9 +338,7 @@ export function classifyCommand(command: string): ParsedCommand {
   const binary = extractBinary(trimmed);
   const fullCommand = trimmed;
 
-  const isPrivileged = PRIVILEGED_INDICATORS.some((re) => re.test(trimmed));
-
-  if (isPrivileged) {
+  if (isPrivileged(trimmed)) {
     return { binary, fullCommand, class: 'privileged' as CommandClass };
   }
 

--- a/test/unit/policy/classifier.test.ts
+++ b/test/unit/policy/classifier.test.ts
@@ -17,6 +17,52 @@ describe('classifyCommand', () => {
     expect(classifyCommand('doas whoami').class).toBe('privileged');
   });
 
+  // A privilege prefix only counted at the very start of the string, so any
+  // harmless leading segment carried sudo past the approval gate as `safe`.
+  it('classifies elevation as privileged after every shell separator', () => {
+    expect(classifyCommand('echo hi; sudo id').class).toBe('privileged');
+    expect(classifyCommand('true && sudo id').class).toBe('privileged');
+    expect(classifyCommand('false || sudo id').class).toBe('privileged');
+    expect(classifyCommand('cat /etc/hosts | sudo tee /etc/hosts.bak').class).toBe('privileged');
+    expect(classifyCommand('cd /tmp\nsudo id').class).toBe('privileged');
+    expect(classifyCommand('ls / ; sudo systemctl restart nginx').class).toBe('privileged');
+  });
+
+  it('classifies elevation as privileged regardless of which prefix or path', () => {
+    expect(classifyCommand('echo hi; /usr/bin/sudo id').class).toBe('privileged');
+    expect(classifyCommand('echo hi; doas id').class).toBe('privileged');
+    expect(classifyCommand('echo hi; pkexec id').class).toBe('privileged');
+    expect(classifyCommand('echo hi; sudo -u root id').class).toBe('privileged');
+  });
+
+  // The mirror of #91: matching the word anywhere would refuse commands that
+  // only read about sudo. These invoke nothing, so they must stay unprivileged.
+  it('does not treat a mention of sudo as an invocation', () => {
+    expect(classifyCommand('grep sudo /var/log/auth.log').class).toBe('read-only');
+    expect(classifyCommand('cat /etc/sudoers').class).toBe('read-only');
+    expect(classifyCommand('ls -la /usr/bin/sudo').class).toBe('read-only');
+    expect(classifyCommand('echo sudo').class).toBe('read-only');
+    expect(classifyCommand('journalctl -u sudo').class).toBe('read-only');
+  });
+
+  it('does not treat a binary that merely starts with a prefix name as elevation', () => {
+    expect(classifyCommand('sudoedit /etc/hosts').class).not.toBe('privileged');
+    expect(classifyCommand('subl file.txt').class).not.toBe('privileged');
+  });
+
+  it('treats a bare privilege prefix with no command as privileged', () => {
+    expect(classifyCommand('sudo').class).toBe('privileged');
+    expect(classifyCommand('sudo -u root').class).toBe('privileged');
+    expect(classifyCommand('echo hi; sudo').class).toBe('privileged');
+  });
+
+  // privileged is checked before destructive, and both must still win over the
+  // read-only allowlist that the leading segment would otherwise earn.
+  it('ranks elevation above the leading segment classification', () => {
+    expect(classifyCommand('ls -la; sudo id').class).toBe('privileged');
+    expect(classifyCommand('df -h && sudo reboot').class).toBe('privileged');
+  });
+
   it('classifies destructive patterns', () => {
     expect(classifyCommand('rm -rf /').class).toBe('destructive');
     expect(classifyCommand('mkfs.ext4 /dev/sda').class).toBe('destructive');


### PR DESCRIPTION
## The gap

`classifyCommand` decided the `privileged` class with four regexes anchored at `^`:

```ts
const PRIVILEGED_INDICATORS = [/^\s*sudo\b/, /^\s*su\b/, /^\s*doas\b/, /^\s*pkexec\b/];
const isPrivileged = PRIVILEGED_INDICATORS.some((re) => re.test(trimmed));
```

Only a *leading* prefix counted:

```
sudo id                                  -> privileged   (approval gate)
echo hi; sudo id                         -> safe         (no approval, runs)
true && sudo id                          -> safe
ls / ; sudo systemctl restart nginx      -> safe
cat /etc/hosts | sudo tee /etc/hosts.bak -> safe
```

Any harmless first segment carries elevation past the gate. Under the default `approvalMode = "ask-destructive"`, the prompt a `privileged` command should raise never appears.

`roleBindings` has the same blind spot from the other side: `admin` on `prod` is granted `read-only, safe, destructive` and deliberately *not* `privileged` — so a compound command classified `safe` is permitted outright on the one tier whose point is that it cannot elevate.

I hit this by accident, not by looking for it: a discovery command of mine ran `sudo ls /etc/cron.d/` on a production host through `run-command` and no approval prompt appeared.

## The fix

`parseSegments` already walks privilege prefixes to find each segment's head binary — it knew which segments were elevated and discarded that fact. It now records it as `Segment.privileged`, and `isPrivileged()` is true when any segment carries it.

Scanning the raw string for `\bsudo\b` would have been the smaller diff and the wrong one — it re-breaks for `sudo` exactly what #91 fixed for `reboot`. These all stay `read-only`:

```
grep sudo /var/log/auth.log
cat /etc/sudoers
ls -la /usr/bin/sudo
journalctl -u sudo
```

`classifier.ts` had already written down the rule this follows:

> *"Matching an invocation rather than a mention needs to know where a command word can start, and that is a tokenizer's job, not a regex's."*

That reasoning was applied to power-state commands and not to privilege prefixes.

The prefix list keeps its second, narrower use in `extractBinary`, where anchoring **is** correct — it names `sudo systemctl status` after `systemctl`. It is renamed `LEADING_PRIVILEGE_PREFIXES` so the two questions stop sharing one constant.

## Preserved

- A bare `sudo`, or `sudo -u root` with no command, still classifies `privileged` — a head-less segment carries the flag.
- `sudoedit`, `subl` are not prefixes and are not elevation.
- Path-qualified spellings (`/usr/bin/sudo`) were already handled by `stripPath`, and now benefit in every segment rather than only the first.

## Performance

No regex added and nothing backtracks, so the linear property from #128 holds. Measured on the shapes that PR targeted, at 1 MB:

| case | before | after |
|---|---|---|
| repeated `dd`/`curl`/`chown` literals | 84 ms | 103 ms |
| ~150k segments | 240 ms | 311 ms |
| ~150k segments ending in `sudo id` | 243 ms | **65 ms** |

One more linear pass over the same tokens for non-elevated commands; elevated ones get faster, because `isPrivileged` now returns before the destructive rules run. The 65 s quadratic case from #128 does not reappear.

## Behaviour change worth calling out in release notes

Under the default bindings, `cd /srv && sudo systemctl restart app` on a `prod`-group profile is now **refused** rather than silently run. That is the point of the fix, but it will surface as newly-failing commands for anyone whose CLI-configured host took the default `prod` group. `--group=staging`/`dev`, or a `roleBindings` override granting `admin.prod` the `privileged` class, restores it deliberately.

## Tests

Six new cases in `test/unit/policy/classifier.test.ts` covering elevation after each separator, prefix/path variants, the mention-vs-invocation guard, bare prefixes, and precedence over the leading segment's own class. `npx vitest run` — 322 passed, 140 skipped (integration, no live SSH server). Changeset included.