### PR TITLE
fix(policy): recognise the elevation binaries 2.2.4 stopped catching

### DIFF
--- a/.changeset/rotten-pears-smash.md
+++ b/.changeset/rotten-pears-smash.md
@@ -1,0 +1,13 @@
+---
+"ssh-mcp": patch
+---
+
+Recognise the elevation binaries that 2.2.4 stopped catching, and two it never caught.
+
+The fix for [GHSA-6f54-mjqq-2jp8](https://github.com/tufantunc/ssh-mcp/security/advisories/GHSA-6f54-mjqq-2jp8) replaced four `^`-anchored regexes with exact membership in a set of four names. `/^\s*su\b/` had matched between `su` and a hyphen, so `su-exec` and `sudo-rs` were classified `privileged` — by accident of the regex rather than by intent, but the effect was protective. Exact matching dropped them, and on a `prod`-group profile that turned a `deny` into an `allow`. A security release narrowed a security control, which is not acceptable however narrow the shape.
+
+`gosu` and `run0` were caught by neither the old form nor the new one. `su-exec` and `gosu` are the standard elevation binaries of Alpine and Docker images; `sudo-rs` is the Rust implementation now shipping as the default sudo on some distributions; `run0` is systemd's replacement. A host using any of them had no elevation gate at all, before or after 2.2.4.
+
+`PRIVILEGE_PREFIXES` now lists `su-exec`, `gosu`, `sudo-rs`, `run0` and `pfexec` alongside `sudo`, `su`, `doas` and `pkexec`. It stays an explicit list rather than a pattern, because a pattern cannot tell `sudoedit` — which edits a file and is not elevation — from `sudo-rs`, which is sudo. That means it has to be maintained by hand as new implementations appear, and the cost of missing one is that its commands classify `safe`.
+
+Found by [@burtherman](https://github.com/burtherman)'s work on [#130](https://github.com/tufantunc/ssh-mcp/pull/130) — reviewing that branch is what surfaced the `\b` behaviour, and the same gap turned out to be in the advisory fix.

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -114,7 +114,27 @@ const FORBIDDEN_INVOCATIONS = new Set(['shutdown', 'reboot', 'halt', 'poweroff',
 /** Binaries that take the dangerous action as an argument: `systemctl reboot`. */
 const ACTION_MULTIPLEXERS = new Set(['systemctl', 'init', 'telinit']);
 
-const PRIVILEGE_PREFIXES = new Set(['sudo', 'su', 'doas', 'pkexec']);
+/**
+ * Binaries that run the rest of the command as another user.
+ *
+ * The list is explicit rather than a pattern, because a pattern cannot tell
+ * `sudoedit` — which edits a file and is not elevation — from `sudo-rs`, which
+ * is sudo. It has to be maintained by hand as new implementations appear; the
+ * cost of missing one is that its commands classify `safe`.
+ *
+ * The last five were added in 2.2.5 (#132). Until 2.2.4 the check was
+ * `/^\s*su\b/` and friends, and `\b` matched between `su` and the hyphen, so
+ * `su-exec` and `sudo-rs` were caught — by accident of the regex, not by
+ * intent. Moving to exact membership dropped them, which narrowed a security
+ * control inside a security release. `gosu` and `run0` were never caught by
+ * either form.
+ */
+const PRIVILEGE_PREFIXES = new Set([
+  'sudo', 'su', 'doas', 'pkexec',
+  // BusyBox/Alpine, Docker entrypoints, the Rust sudo now default on some
+  // distributions, systemd's replacement, and the Solaris/illumos spelling.
+  'su-exec', 'gosu', 'sudo-rs', 'run0', 'pfexec',
+]);
 
 /**
  * Binaries whose job is to run another command.

--- a/test/unit/policy/classifier.test.ts
+++ b/test/unit/policy/classifier.test.ts
@@ -142,6 +142,36 @@ describe('elevation and exec wrappers (GHSA-6f54-mjqq-2jp8)', () => {
     expect(classifyCommand('\\sudo id').class).toBe('privileged');
   });
 
+  /**
+   * A narrowing 2.2.4 introduced while fixing the advisory, and a gap that
+   * predates both.
+   *
+   * Until 2.2.4 the check was `/^\s*su\b/`, and `\b` matched between `su` and a
+   * hyphen — so `su-exec` and `sudo-rs` were classified privileged by accident
+   * of the regex. Exact `Set` membership dropped them, and on a prod profile
+   * that turned a `deny` into an `allow`. `gosu` was caught by neither form.
+   *
+   * These are the elevation binaries of container images and of distributions
+   * that have replaced sudo, so a host running one had no elevation gate at all.
+   */
+  it('recognises elevation binaries beyond the four classic names', () => {
+    expect(classifyCommand('su-exec deploy cat /etc/shadow').class).toBe('privileged');
+    expect(classifyCommand('gosu root id').class).toBe('privileged');
+    expect(classifyCommand('sudo-rs id').class).toBe('privileged');
+    expect(classifyCommand('run0 systemctl restart nginx').class).toBe('privileged');
+    expect(classifyCommand('pfexec id').class).toBe('privileged');
+    // And behind a wrapper or a separator, like the four already were.
+    expect(classifyCommand('env gosu root id').class).toBe('privileged');
+    expect(classifyCommand('echo hi; su-exec deploy id').class).toBe('privileged');
+  });
+
+  // The reason this is a list and not a pattern: `sudo*` would swallow both.
+  it('still does not treat sudoedit or an unrelated binary as elevation', () => {
+    expect(classifyCommand('sudoedit /etc/hosts').class).toBe('safe');
+    expect(classifyCommand('subl file.txt').class).toBe('safe');
+    expect(classifyCommand('sudoku').class).toBe('safe');
+  });
+
   it('treats find as writing when it carries an action flag', () => {
     expect(classifyCommand('find /var/www -delete').class).toBe('destructive');
     expect(classifyCommand('find / -name x -exec sudo id +').class).toBe('destructive');


### PR DESCRIPTION
A narrowing I introduced in the GHSA-6f54-mjqq-2jp8 fix, plus a gap that predates it.

## What broke

That fix replaced four `^`-anchored regexes with exact membership in a four-name set. `/^\s*su\b/` had matched between `su` and a hyphen, so `su-exec` and `sudo-rs` were classified `privileged` — by accident of the regex rather than by intent, but the effect was protective. Exact matching dropped them.

Measured on 2.2.4, `admin` on a `prod` profile:

| command | 2.2.3 | 2.2.4 |
| --- | --- | --- |
| `su-exec deploy cat /etc/shadow` | privileged → **deny** | safe → **allow** |
| `sudo-rs id` | privileged → **deny** | safe → **allow** |
| `gosu root id` | safe → allow | safe → allow |
| `sudo id` | privileged → deny | privileged → deny |

The first two are a regression: a security release narrowed a security control. `gosu` was caught by neither form, so it is a gap rather than a regression — and `run0`, systemd's sudo replacement, likewise.

These are not exotic. `su-exec` and `gosu` are the standard elevation binaries in Alpine and Docker images, and `sudo-rs` is the Rust implementation now shipping as the default sudo on some distributions. A host using any of them had no elevation gate at all.

## The fix

`PRIVILEGE_PREFIXES` gains `su-exec`, `gosu`, `sudo-rs`, `run0` and `pfexec`.

It stays an **explicit list rather than a pattern**, and that is the design decision worth stating: `sudo*` cannot tell `sudoedit` — which edits a file and is not elevation — from `sudo-rs`, which is sudo. So the list has to be maintained by hand as new implementations appear, and the cost of missing one is that its commands classify `safe`. That trade is now written down next to the list rather than left implicit.

## How this was missed

burtherman's [#130](https://github.com/tufantunc/ssh-mcp/pull/130) is what surfaced it. The correctness pass over that branch flagged that Set membership drops the `\b` matches — and I read that finding, wrote a fix using the same Set, reviewed my own fix, and shipped it with the identical gap. Recording it because the review said it plainly and it still got through.

## Verification

- `npm run typecheck`, `npm run build` — clean
- 320 unit and property tests (2 new cases)
- Integration suite against live containers: 122 passed, 6 skipped (`windows-compat`, needs `SSH_MCP_WIN_HOST`)
- Mutation-tested after committing: removing the five names fails exactly the new elevation case, nothing else

The `sudoedit` / `subl` guard is now asserted positively (`toBe('safe')` rather than `not.toBe('privileged')`), so a future widening of the list cannot quietly swallow them.

Changeset: `patch`. No advisory — `sudo` itself was never affected, and the exposure requires one of these alternative binaries to be installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)