### PR TITLE
fix: report the Windows config ACL instead of refusing to start on it

### DIFF
--- a/.changeset/windows-acl-advisory.md
+++ b/.changeset/windows-acl-advisory.md
@@ -1,0 +1,13 @@
+---
+"ssh-mcp": patch
+---
+
+Report the Windows config ACL instead of refusing to start on it.
+
+2.3.0 added an ACL check for the Windows config file and made it refuse. On the first day it blocked a reporter's config at the documented `%APPDATA%` location ([#138](https://github.com/tufantunc/ssh-mcp/issues/138)): their ACL carried a principal the allowlist did not know about, because that allowlist was measured on one machine and generalised. `--allowUncheckedConfigAcl` deliberately did not cover a known-bad verdict, so there was no way past it at all — not a flag, not a config change they could discover from the message.
+
+A security check whose worst outcome is stranding an operator in their own config is not a good trade, and the guarantee it enforces is one Windows states far less clearly than POSIX does. So the check still runs and still says exactly what it found — including the two `icacls` commands, because a config under `C:\` really does grant `BUILTIN\Users` read and `Authenticated Users` modify — but it loads the config afterwards.
+
+`--strictConfigAcl` restores refusing, for anyone who wants it enforced. Under that flag `--allowUncheckedConfigAcl` keeps its old meaning: load anyway when the ACL could not be determined.
+
+The POSIX mode check is unchanged and still refuses. There "only the owner" is unambiguous, `chmod` is a one-line fix, and the check has been in place since 2.0.0 without this problem.

--- a/README.md
+++ b/README.md
@@ -51,24 +51,27 @@ approvalPolicy = "auto"    # dev is permissive
 chmod 700 ~/.config/ssh-mcp && chmod 600 ~/.config/ssh-mcp/config.toml
 ```
 
-The server refuses to start if anyone but you can read the config, since it
-decides which hosts, roles and policy rules this server honours.
+The config decides which hosts, roles and policy rules this server honours, so it checks
+that nobody but you can read it — and treats the two platforms differently, because the
+question has a much clearer answer on one of them.
 
-On Linux and macOS that is the mode check above — the directory too, which is why
-`chmod 700` is in that command: `mkdir -p` under the default umask leaves it 0755. On Windows there are no mode
-bits, so it reads the ACL instead and requires that only your account, `SYSTEM`
-and `Administrators` hold access. A config under `%APPDATA%` inherits exactly
-that and needs nothing done to it. One created elsewhere does not — a file under
-`C:\` inherits read access for every local account and modify for every
-authenticated one — and the refusal names the two `icacls` commands that fix it,
-or, when the directory is a filesystem root or sits outside your user profile, leads with
-moving the config instead — it still prints the commands, but removing entries from a
-directory other accounts share is a judgement only you can make.
+**Linux and macOS: enforced.** The mode check above, on the file *and* the directory —
+which is why `chmod 700` is in that command, since `mkdir -p` under the default umask
+leaves the directory 0755. The server refuses to start otherwise. "Only the owner" is
+unambiguous here and `chmod` is a one-line fix.
 
-If the ACL cannot be read at all, the server refuses rather than assuming the file is
-private, and `--allowUncheckedConfigAcl` loads it unverified. Two cases do not need the
-flag — `icacls` being absent from the machine, and the check running out of time — because
-both are statements about the machine rather than about the file. Each warns and loads.
+**Windows: reported.** There are no mode bits, so it reads the ACL and tells you what it
+grants — a config under `%APPDATA%` inherits access for you, `SYSTEM` and `Administrators`
+and needs nothing done to it, while one created elsewhere does not: a file under `C:\`
+inherits read for every local account and modify for every authenticated one. The message
+names the two `icacls` commands that fix it, and then the config loads anyway.
+
+Advisory rather than enforced because enforced was tried first: 2.3.0 refused, and it
+blocked a config at the documented `%APPDATA%` location whose ACL carried a principal the
+allowlist had never seen ([#138](https://github.com/tufantunc/ssh-mcp/issues/138)). A check
+whose worst outcome is locking you out of your own config is not worth that. Pass
+`--strictConfigAcl` to refuse instead; under it, `--allowUncheckedConfigAcl` still loads a
+config whose ACL could not be determined at all.
 
 ### Exit statuses
 
@@ -602,6 +605,7 @@ Secrets are **never** passed as CLI arguments.
 | `--allowedHosts` | bind address + localhost | Comma-separated Host headers accepted by the DNS-rebinding guard |
 | `--insecureHostKey` | false | Disable host key verification (test only!) |
 | `--allowUncheckedConfigAcl` | false | Windows: load the config even if its ACL could not be read |
+| `--strictConfigAcl` | Windows: refuse to start on a broad or unreadable config ACL instead of reporting it |
 | `--disableApproval` | false | Skip the approval gate (quick start profile only) |
 | `--opaUrl` | — | OPA sidecar URL for external policy |
 | `--commandQuota` | 0 (off) | Max commands per rolling 24h per profile |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,10 +43,12 @@ SSH MCP Server gives LLM agents the ability to execute shell commands on remote 
 4. **Restrict network egress** on the target host (iptables/Cilium) to prevent data exfiltration.
 5. **Use read-only profiles** (`readOnly = true`) for monitoring/observer access.
 6. **Review audit logs** regularly — all commands are logged with redaction.
-7. **Restrict your config file** — `chmod 700` the directory and `chmod 600` the file; the
-   server refuses to start otherwise, and `chmod 600` alone does not satisfy the directory
-   check. On Windows there are no mode bits: the ACL must grant only your account, `SYSTEM`
-   and `Administrators`, which a config under `%APPDATA%` inherits automatically.
+7. **Restrict your config file** — `chmod 700` the directory and `chmod 600` the file; on
+   Linux and macOS the server refuses to start otherwise, and `chmod 600` alone does not
+   satisfy the directory check. On Windows there are no mode bits: the ACL should grant only
+   your account, `SYSTEM` and `Administrators`, which a config under `%APPDATA%` inherits
+   automatically. There the finding is reported rather than enforced — `--strictConfigAcl`
+   enforces it if you want that.
 
 ## Supported Versions
 

--- a/src/config/windows-acl.ts
+++ b/src/config/windows-acl.ts
@@ -274,6 +274,24 @@ export interface UnverifiedAcl {
 
 export interface AclOptions {
   /**
+   * Refuse rather than warn when the ACL is readable beyond its owner.
+   * `--strictConfigAcl`. Off by default, and that default is the point.
+   *
+   * Refusing was the default in 2.3.0, and it blocked a reporter's config at the
+   * documented `%APPDATA%` location on the first day — their ACL carried a fourth
+   * principal, which the allowlist was built without knowing about because it was
+   * measured on one machine. `--allowUncheckedConfigAcl` deliberately did not cover a
+   * known-bad verdict, so there was no way past it at all: a security check whose worst
+   * outcome is locking an operator out of their own config, over a guarantee Windows
+   * states less clearly than POSIX does.
+   *
+   * So the finding is reported and the config loads. What the check knows is still worth
+   * saying — a config under `C:\` really does grant `BUILTIN\Users` read and
+   * `Authenticated Users` modify — but saying it and refusing are different things, and
+   * only one of them can strand somebody.
+   */
+  strict?: boolean;
+  /**
    * Load the config even when the ACL could not be determined.
    * `--allowUncheckedConfigAcl`.
    */
@@ -870,25 +888,26 @@ export async function assertPrivateOnWindows(
 
     if (verdict.status === 'restricted') continue;
 
-    if (verdict.status === 'broad') {
-      const named = verdict.grants.map((g) => g.name).join(', ');
-      throw new OperatorError(
-        `Config ${kind} ${path} is readable beyond its owner: access is granted to ${named}. ` +
-        'Required: this account, SYSTEM and Administrators only.\n' +
-        (isTightenable(path, kind) ? remediation(path, kind, verdict.grants) : relocation(path, kind, verdict.grants)),
-      );
-    }
+    if (verdict.status === 'broad' || verdict.status === 'no-dacl') {
+      const grants = verdict.status === 'broad' ? verdict.grants : [];
+      const what = verdict.status === 'broad'
+        ? `is readable beyond its owner: access is granted to ${grants.map((g) => g.name).join(', ')}. ` +
+          'Required: this account, SYSTEM and Administrators only.'
+        : 'has no access control list at all, which on Windows means full control for ' +
+          'every account on the machine.';
+      const message =
+        `Config ${kind} ${path} ${what}\n` +
+        (isTightenable(path, kind) ? remediation(path, kind, grants) : relocation(path, kind, grants));
 
-    if (verdict.status === 'no-dacl') {
-      throw new OperatorError(
-        `Config ${kind} ${path} has no access control list at all, which on Windows means ` +
-        'full control for every account on the machine.\n' +
-        (isTightenable(path, kind) ? remediation(path, kind) : relocation(path, kind, [])),
-      );
+      if (opts.strict) throw new OperatorError(message);
+      // Advisory by default; see AclOptions.strict for why.
+      console.error(`Warning: ${message}`);
+      continue;
     }
 
     // status === 'unknown'
-    if (verdict.reason === 'tool-missing' || verdict.reason === 'timed-out' || opts.allowUnchecked) {
+    if (!opts.strict || verdict.reason === 'tool-missing' || verdict.reason === 'timed-out'
+      || opts.allowUnchecked) {
       report({ path, reason: verdict.reason, detail: verdict.detail });
       continue;
     }
@@ -896,7 +915,7 @@ export async function assertPrivateOnWindows(
     throw new OperatorError(
       `Config ${kind} ${path} could not be checked for access by other accounts ` +
       `(${verdict.reason}: ${verdict.detail}).\n` +
-      'This is refused rather than assumed safe, because the config decides which hosts, ' +
+      'Refused because --strictConfigAcl was given, and the config decides which hosts, ' +
       'roles and policy rules this server honours.\n' +
       'Either fix the cause, move the config under %APPDATA%\\ssh-mcp, or pass ' +
       '--allowUncheckedConfigAcl to load it unverified.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ async function buildAppConfig(argv: Record<string, string | null>): Promise<AppC
   // the audit store as well needs an AuditRecord variant for a startup event — that type
   // is hash-chained and tamper-evident, so it is its own change, and it is queued.
   const aclOpts = {
+    strict: flagEnabled(argv, 'strictConfigAcl'),
     allowUnchecked: flagEnabled(argv, 'allowUncheckedConfigAcl'),
     onUnverified: (e: UnverifiedAcl) => {
       unverified.push(e);

--- a/test/unit/config/windows-acl-decisions.test.ts
+++ b/test/unit/config/windows-acl-decisions.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join, parse } from 'path';
 import {
   inspectAcl,
+  type AclOptions,
+  type UnverifiedAcl,
   assertPrivateOnWindows,
   type AclVerdict,
   type Grant,
@@ -46,6 +48,17 @@ const unknown = (reason: UnknownReason, detail = 'x'): AclVerdict =>
 const broad = (...grants: Grant[]): AclVerdict => ({ status: 'broad', grants });
 
 /** Awaits the refusal and names the behaviour if there isn't one. */
+/** The default posture: report, do not refuse. */
+function warned(): { events: UnverifiedAcl[]; warnings: string[]; opts: AclOptions } {
+  const events: UnverifiedAcl[] = [];
+  const warnings: string[] = [];
+  vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => { warnings.push(String(a[0])); });
+  return { events, warnings, opts: { onUnverified: (e) => events.push(e) } };
+}
+
+/** Refusal is opt-in now, so every refusal test says so. */
+const strict = (extra: AclOptions = {}): AclOptions => ({ ...extra, strict: true });
+
 async function refusal(p: Promise<void>): Promise<Error> {
   const err = await p.then(() => null, (e: Error) => e);
   expect(err, 'expected a refusal, but the check accepted the path').toBeInstanceOf(OperatorError);
@@ -94,7 +107,7 @@ describe('assertPrivateOnWindows — a clean ACL', () => {
 describe('assertPrivateOnWindows — a broad ACL', () => {
   it('refuses and names the principals', async () => {
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(FILE, broad(
+      assertPrivateOnWindows(FILE, strict(), only(FILE, broad(
         grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545'),
         grant('Authenticated Users', 'AU', 'S-1-5-11'),
       ))),
@@ -108,14 +121,14 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // 1337 having done nothing — and DU is what a descriptor on a domain-joined
     // host, the case this check exists for, actually spells. So the fixture uses
     // the realistic alias trustee and the assertion demands a SID in the command.
-    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, broad(EVERYONE))));
+    const err = await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, broad(EVERYONE))));
     expect(err.message).toMatch(/\/remove:g \*S-1-[0-9-]+\b/);
     expect(err.message).not.toMatch(/\/remove:g \*[A-Z]{2,3}\b/);
   });
 
   it('removes exactly the trustees it found, for a mix of spellings', async () => {
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(FILE, broad(
+      assertPrivateOnWindows(FILE, strict(), only(FILE, broad(
         EVERYONE,
         grant('S-1-5-21-1-2-3-513', 'S-1-5-21-1-2-3-513', 'S-1-5-21-1-2-3-513'),
       ))),
@@ -134,7 +147,7 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // OW on redirected profiles) and every domain-relative one on a host with no account
     // domain land here.
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(FILE, broad(grant('OW', 'OW', null)))),
+      assertPrivateOnWindows(FILE, strict(), only(FILE, broad(grant('OW', 'OW', null)))),
     );
     expect(err.message).not.toMatch(/\/remove:g \*[A-Z]{2,3}\b/);
     expect(err.message).toMatch(/cannot be named as a SID/);
@@ -143,7 +156,7 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
 
   it('still removes the entries it can name when only one is unresolvable', async () => {
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(FILE, broad(EVERYONE, grant('OW', 'OW', null)))),
+      assertPrivateOnWindows(FILE, strict(), only(FILE, broad(EVERYONE, grant('OW', 'OW', null)))),
     );
     expect(err.message).toContain('/remove:g *S-1-1-0');
     expect(err.message).toMatch(/cannot be named as a SID/);
@@ -153,14 +166,14 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // %USERNAME% is cmd.exe syntax. Pasted into PowerShell — the default shell on
     // Windows 11 — icacls receives it literally, reports "Failed processing 1
     // files", and changes nothing. Measured. That is `chmod 600` one shell over.
-    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, broad(EVERYONE))));
+    const err = await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, broad(EVERYONE))));
     expect(err.message).not.toContain('%USERNAME%');
     expect(err.message).toMatch(/\/grant:r "[^"%]+:/);
   });
 
   it('uses inheritable rights for a directory and plain rights for a file', async () => {
-    const onFile = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, broad(EVERYONE))));
-    const onDir = await refusal(assertPrivateOnWindows(FILE, {}, only(DIR, broad(EVERYONE))));
+    const onFile = await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, broad(EVERYONE))));
+    const onDir = await refusal(assertPrivateOnWindows(FILE, strict(), only(DIR, broad(EVERYONE))));
     expect(onFile.message).toContain(':F"');
     expect(onFile.message).not.toContain('(OI)(CI)');
     expect(onDir.message).toContain('(OI)(CI)F');
@@ -172,7 +185,7 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // BUILTIN\Users — which, run as printed, takes the volume away from every
     // non-administrator account.
     const err = await refusal(
-      assertPrivateOnWindows(join(ROOT, 'config.toml'), {}, only(ROOT, broad(
+      assertPrivateOnWindows(join(ROOT, 'config.toml'), strict(), only(ROOT, broad(
         grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545'),
       ))),
     );
@@ -189,7 +202,7 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // subject `.` — the working directory, which belongs to whichever MCP client
     // spawned us, not to the operator. Same destructive shape as the root case.
     const err = await refusal(
-      assertPrivateOnWindows('config.toml', {}, only('.', broad(EVERYONE))),
+      assertPrivateOnWindows('config.toml', strict(), only('.', broad(EVERYONE))),
     );
     expect(err.message.indexOf('Move the config')).toBeLessThan(err.message.indexOf('icacls'));
     expect(err.message).toMatch(/only you can judge/);
@@ -202,7 +215,7 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // what it replaced.
     const outsideFile = join(ROOT, 'sshcfg', 'config.toml');
     const err = await refusal(
-      assertPrivateOnWindows(outsideFile, {}, only(outsideFile, broad(EVERYONE))),
+      assertPrivateOnWindows(outsideFile, strict(), only(outsideFile, broad(EVERYONE))),
     );
     expect(err.message).toContain('/inheritance:d');
     expect(err.message).toContain('/remove:g *S-1-1-0');
@@ -215,7 +228,7 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // account's traverse to its own profile.
     const outside = join(ROOT, 'Users', 'config.toml');
     const err = await refusal(
-      assertPrivateOnWindows(outside, {}, only(join(ROOT, 'Users'), broad(
+      assertPrivateOnWindows(outside, strict(), only(join(ROOT, 'Users'), broad(
         grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545'),
       ))),
     );
@@ -233,14 +246,14 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
     // guard exists to prevent: strip BUILTIN\Users from a shared directory.
     vi.stubEnv('USERPROFILE', '');
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(DIR, broad(grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545')))),
+      assertPrivateOnWindows(FILE, strict(), only(DIR, broad(grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545')))),
     );
     expect(err.message).toMatch(/Move the config/);
   });
 
   it('refuses to prescribe ACL surgery on the parent directory', async () => {
     const err = await refusal(
-      assertPrivateOnWindows(join('..', 'config.toml'), {}, only('..', broad(EVERYONE))),
+      assertPrivateOnWindows(join('..', 'config.toml'), strict(), only('..', broad(EVERYONE))),
     );
     expect(err.message).toMatch(/Move the config/);
   });
@@ -248,13 +261,13 @@ describe('assertPrivateOnWindows — a broad ACL', () => {
 
 describe('assertPrivateOnWindows — a NULL DACL', () => {
   it('refuses, because no ACL means full control for everyone', async () => {
-    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, { status: 'no-dacl' })));
+    const err = await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, { status: 'no-dacl' })));
     expect(err.message).toContain('no access control list');
   });
 
   it('prescribes granting a DACL rather than removing entries', async () => {
     // There is nothing to /remove:g — the fix is to give the file an ACL at all.
-    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, { status: 'no-dacl' })));
+    const err = await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, { status: 'no-dacl' })));
     expect(err.message).toContain('/grant:r');
     expect(err.message).not.toContain('/remove:g');
   });
@@ -268,7 +281,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
     await expect(
       assertPrivateOnWindows(
         FILE,
-        { onUnverified: (e) => reported.push(e) },
+        strict({ onUnverified: (e) => reported.push(e) }),
         only(FILE, unknown('tool-missing', 'no icacls.exe')),
       ),
     ).resolves.toBeUndefined();
@@ -282,7 +295,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
     await expect(
       assertPrivateOnWindows(
         FILE,
-        { onUnverified: (e) => reported.push(e) },
+        strict({ onUnverified: (e) => reported.push(e) }),
         only(FILE, unknown('timed-out', 'exceeded 5000ms')),
       ),
     ).resolves.toBeUndefined();
@@ -292,7 +305,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
   it('falls back to stderr when the caller supplies no sink', async () => {
     const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
     await expect(
-      assertPrivateOnWindows(FILE, {}, only(FILE, unknown('tool-missing'))),
+      assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('tool-missing'))),
     ).resolves.toBeUndefined();
     expect(String(warn.mock.calls[0][0])).toMatch(/was not checked/);
   });
@@ -302,7 +315,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
     // collapsed every failure to "unchecked, load anyway", so breaking icacls was
     // enough to disable the check.
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(FILE, unknown('read-refused', 'Access is denied'))),
+      assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('read-refused', 'Access is denied'))),
     );
     expect(err.message).toContain('read-refused');
     expect(err.message).toContain('--allowUncheckedConfigAcl');
@@ -310,7 +323,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
 
   it('refuses a descriptor it cannot parse', async () => {
     const err = await refusal(
-      assertPrivateOnWindows(FILE, {}, only(FILE, unknown('unparsable', 'no DACL component'))),
+      assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('unparsable', 'no DACL component'))),
     );
     expect(err.message).toContain('unparsable');
   });
@@ -318,7 +331,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
   it("refuses when this account's own SID could not be read", async () => {
     // Without an identity there is no allowlist to compare against, so a verdict
     // would be meaningless rather than merely uncertain.
-    await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, unknown('identity-unknown'))));
+    await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('identity-unknown'))));
   });
 
   it('honours --allowUncheckedConfigAcl for the refusing reasons', async () => {
@@ -326,7 +339,7 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
     await expect(
       assertPrivateOnWindows(
         FILE,
-        { allowUnchecked: true, onUnverified: (e) => reported.push(e) },
+        strict({ allowUnchecked: true, onUnverified: (e) => reported.push(e) }),
         only(FILE, unknown('read-refused', 'Access is denied')),
       ),
     ).resolves.toBeUndefined();
@@ -336,7 +349,62 @@ describe('assertPrivateOnWindows — an unknown ACL', () => {
   it('does not let the escape hatch turn a broad ACL into a warning', async () => {
     // The flag is about an unanswered question, not about a known-bad answer.
     await expect(
-      assertPrivateOnWindows(FILE, { allowUnchecked: true }, only(FILE, broad(EVERYONE))),
+      assertPrivateOnWindows(FILE, strict({ allowUnchecked: true }), only(FILE, broad(EVERYONE))),
     ).rejects.toThrow(/Everyone/);
+  });
+});
+
+describe('assertPrivateOnWindows — advisory by default', () => {
+  /**
+   * The posture this settled on, and why.
+   *
+   * 2.3.0 refused a broad ACL, and on the first day it blocked a reporter's config at the
+   * documented `%APPDATA%` location: their ACL carried a principal the allowlist did not
+   * know about, because the allowlist was measured on one machine. `--allowUncheckedConfigAcl`
+   * deliberately did not cover a known-bad verdict, so there was no way past it — a check
+   * whose worst outcome is stranding an operator in their own config.
+   */
+  it('reports a broad ACL and loads the config', async () => {
+    const { warnings } = warned();
+    await expect(
+      assertPrivateOnWindows(FILE, {}, only(FILE, broad(EVERYONE))),
+    ).resolves.toBeUndefined();
+    expect(warnings.join('\n')).toMatch(/readable beyond its owner/);
+    // The commands are still printed: the finding is worth stating, and stating it is not
+    // the same act as refusing.
+    expect(warnings.join('\n')).toContain('/remove:g *S-1-1-0');
+  });
+
+  it('reports a NULL DACL and loads the config', async () => {
+    const { warnings } = warned();
+    await expect(
+      assertPrivateOnWindows(FILE, {}, only(FILE, { status: 'no-dacl' })),
+    ).resolves.toBeUndefined();
+    expect(warnings.join('\n')).toMatch(/no access control list/);
+  });
+
+  it('reports an undeterminable ACL and loads the config', async () => {
+    const { warnings } = warned();
+    await expect(
+      assertPrivateOnWindows(FILE, {}, only(FILE, unknown('read-refused', 'Access is denied'))),
+    ).resolves.toBeUndefined();
+    expect(warnings.join('\n')).toMatch(/was not checked/);
+  });
+
+  it('still examines the directory after warning about the file', async () => {
+    // Warning must not short-circuit what refusing used to.
+    const seen: string[] = [];
+    warned();
+    await assertPrivateOnWindows(FILE, {}, async (p) => {
+      seen.push(p);
+      return broad(EVERYONE);
+    });
+    expect(seen).toEqual([FILE, DIR]);
+  });
+
+  it('refuses only when --strictConfigAcl asks it to', async () => {
+    await expect(
+      refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, broad(EVERYONE)))),
+    ).resolves.toBeInstanceOf(OperatorError);
   });
 });

--- a/test/unit/config/windows-acl.live.test.ts
+++ b/test/unit/config/windows-acl.live.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFile, exec } from 'child_process';
 import { promisify } from 'util';
 import { mkdtemp, writeFile, rm } from 'fs/promises';
@@ -10,6 +10,13 @@ import { MINIMAL_CONFIG } from './helpers.js';
 
 const run = promisify(execFile);
 const shell = promisify(exec);
+
+/**
+ * Refusal is opt-in since the reporter of #138 was blocked by the default.
+ * These cases are about what the check *finds*, so they ask it to enforce; the
+ * default posture gets its own case at the end.
+ */
+const STRICT = { strict: true } as const;
 const onWindows = platform() === 'win32';
 
 /**
@@ -59,34 +66,34 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
   }
 
   it('accepts a file that only its owner can reach', async () => {
-    await expect(checkPermissions(file)).resolves.toBeUndefined();
+    await expect(checkPermissions(file, STRICT)).resolves.toBeUndefined();
   });
 
   it('refuses a file granted to Everyone', async () => {
     await run('icacls', [file, '/grant', '*S-1-1-0:(R)']);
-    await expect(checkPermissions(file)).rejects.toThrow(/Everyone/);
+    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/Everyone/);
   });
 
   it('refuses a file granted to BUILTIN\\Users', async () => {
     await run('icacls', [file, '/grant', '*S-1-5-32-545:(R)']);
-    await expect(checkPermissions(file)).rejects.toThrow(/Users/);
+    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/Users/);
   });
 
   it('refuses a file granted to a group no denylist would have named', async () => {
     // Power Users is the point of the allowlist rewrite: it is neither Everyone
     // nor Users, and the first version passed it as owner-only.
     await run('icacls', [file, '/grant', '*S-1-5-32-547:(R)']);
-    await expect(checkPermissions(file)).rejects.toThrow(/Power Users/);
+    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/Power Users/);
   });
 
   it('refuses when the directory is open even though the file is not', async () => {
     await run('icacls', [dir, '/grant', '*S-1-1-0:(R)']);
-    await expect(checkPermissions(file)).rejects.toThrow(/directory/);
+    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/directory/);
   });
 
   it('names the principal and the path, not just the fact of a refusal', async () => {
     await run('icacls', [file, '/grant', '*S-1-1-0:(R)']);
-    const err = await refusal(checkPermissions(file));
+    const err = await refusal(checkPermissions(file, STRICT));
     expect(err.message).toContain('Everyone');
     expect(err.message).toContain(file);
     expect(err.message).toContain('icacls');
@@ -119,19 +126,19 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
   async function fixUntilClean(path: string): Promise<void> {
     const subjects: string[] = [];
     for (let round = 0; round < 3; round++) {
-      const err = await checkPermissions(path).then(() => null, (e: Error) => e);
+      const err = await checkPermissions(path, STRICT).then(() => null, (e: Error) => e);
       if (err === null) break;
       subjects.push(err.message.match(/^Config (?:file|directory) (\S+)/)?.[1] ?? '?');
       await runPrescription(err.message);
     }
-    await expect(checkPermissions(path)).resolves.toBeUndefined();
+    await expect(checkPermissions(path, STRICT)).resolves.toBeUndefined();
     expect(new Set(subjects).size, `a subject needed fixing twice: ${subjects.join(', ')}`)
       .toBe(subjects.length);
   }
 
   it('prescribes commands that actually fix an explicit grant', async () => {
     await run('icacls', [file, '/grant', '*S-1-1-0:(R)']);
-    await expect(checkPermissions(file)).rejects.toThrow();
+    await expect(checkPermissions(file, STRICT)).rejects.toThrow();
 
     await fixUntilClean(file);
     expect((await inspectAcl(file)).status).toBe('restricted');
@@ -159,7 +166,7 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
     // too, and the file is examined first, so the message would be about the
     // file and this test would silently exercise the arm it already covers.
     await run('icacls', [dir, '/grant', '*S-1-1-0:(R)']);
-    const err = await refusal(checkPermissions(file));
+    const err = await refusal(checkPermissions(file, STRICT));
     expect(err.message).toContain('directory');
     expect(err.message).toContain('(OI)(CI)F');
 
@@ -191,14 +198,48 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
   it('refuses rather than loading when the ACL cannot be read', async () => {
     // The fail-closed direction, end to end: a path whose ACL icacls will not
     // report must not become "unchecked, loaded anyway".
-    await expect(checkPermissions(join(dir, 'no-such-dir', 'config.toml'))).rejects.toThrow(
-      /could not be checked/,
-    );
+    await expect(
+      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), STRICT),
+    ).rejects.toThrow(/could not be checked/);
   });
 
   it('loads unverified when the operator asks for it', async () => {
     await expect(
-      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), { allowUnchecked: true }),
+      // Both flags: without `strict` the load happens anyway, so the assertion would
+      // pass whether or not allowUnchecked did anything.
+      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), { ...STRICT, allowUnchecked: true }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe.runIf(onWindows)('the default posture, against a real ACL', () => {
+  /**
+   * The reporter's shape, on a real filesystem: a config the check objects to, at a path
+   * the operator did not choose wrongly. 2.3.0 refused this and left them no way past it.
+   */
+  it('reports a broad ACL and loads the config anyway', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ssh-mcp-adv-'));
+    const file = join(dir, 'config.toml');
+    try {
+      await writeFile(file, '[[profiles]]\nname = "t"\nhost = "h"\nuser = "u"\n');
+      await run('icacls', [file, '/grant', '*S-1-5-32-545:(R)']);
+
+      const warnings: string[] = [];
+      const spy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => {
+        warnings.push(String(a[0]));
+      });
+      try {
+        await expect(checkPermissions(file)).resolves.toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+      expect(warnings.join('\n')).toMatch(/readable beyond its owner/);
+      expect(warnings.join('\n')).toContain('/remove:g *S-1-5-32-545');
+
+      // And the same ACL still refuses when asked to enforce.
+      await expect(checkPermissions(file, STRICT)).rejects.toThrow(/readable beyond its owner/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Reopens and addresses [#138](https://github.com/tufantunc/ssh-mcp/issues/138), which came back within a day of 2.3.0.

## What happened

2.3.0's ACL check refused a config whose ACL grants anyone beyond the owner, SYSTEM and Administrators. The reporter's config — at `%APPDATA%\ssh-mcp\config.toml`, the documented location — carries a fourth principal, so it was refused. And `--allowUncheckedConfigAcl` covers only an *undeterminable* ACL, never a known-bad one, which was a deliberate decision on my part. So there was no way past it: no flag, nothing discoverable from the message, and downgrading only returns them to the original #138 defect.

Two things were wrong with the design, not the implementation:

- **The allowlist was measured on one machine.** `{SYSTEM, Administrators, owner}` is what `%APPDATA%` inherits on my Windows 11 VM. Real machines carry more — package SIDs, logon SIDs, domain groups, whatever an MDM applies — and I generalised from a sample of one.
- **The escape hatch excluded the case most likely to be wrong.** A false positive on a known-bad verdict is exactly the outcome that needs an escape, and it is the one I closed.

The reporter also argues Windows should leave this to the operator. Their premise is not quite right — Win32-OpenSSH does check ACLs on private keys, which is why `OpenSSHUtils` ships `Repair-*Permission` cmdlets — but the conclusion holds: that check is disliked for precisely the reason they hit here.

## The change

`broad` and `no-dacl` now report and load. The message is unchanged, including the two `icacls` commands — a config under `C:\` really does grant `BUILTIN\Users` read and `Authenticated Users` modify, and that is worth saying. Saying it and refusing are different acts, and only one can strand somebody.

`--strictConfigAcl` restores the 2.3.0 behaviour for anyone who wants it enforced. Under that flag, `--allowUncheckedConfigAcl` keeps its meaning.

**The POSIX branch is untouched and still refuses.** That asymmetry is the point: "only the owner" is unambiguous under POSIX, `chmod` fixes it in one line, and the check has been there since 2.0.0 without producing this. Windows offers neither of those properties.

## Verification

On Windows 11 ARM64, reproducing the reporter's shape — a `%APPDATA%` config granted to `BUILTIN\Users`:

| | result |
| --- | --- |
| published 2.3.0 | refuses, exit 2 |
| this branch | warns, `SSH MCP Server v2 running on stdio` |
| this branch + `--strictConfigAcl` | refuses |

- 443 unit and property, 29 e2e, full suite green against the live containers.
- The decisions suite now states the default: four cases assert that a broad ACL, a NULL DACL and an undeterminable one all report-and-load, that the directory is still examined after the file is warned about, and that refusal happens only under `--strictConfigAcl`. Every pre-existing refusal test now opts in explicitly, which is how the default reads in the tests too.
- Their second report — that the prescribed commands had no effect — does **not** reproduce on my host: `/inheritance:d` then `/grant:r … /remove:g *SID` clears the check. So that has another cause, and I have asked for the ACL and `whoami /user` rather than guessing at it. It is not a blocker for this change, since nobody is refused by default any more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)