### PR TITLE
chore(ci): analyse workflows with CodeQL's Actions queries

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -4,8 +4,12 @@ queries:
   - uses: security-and-quality
   - uses: security-extended
 
+# `src` for the JavaScript analysis, `.github/workflows` for the Actions one — a
+# single `paths` list applies to every language in this config, so both have to be
+# named or the Actions analysis has nothing in scope.
 paths:
   - src
+  - .github/workflows
 
 paths-ignore:
   - node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,13 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
-          languages: javascript
+          # `actions` as well as `javascript`. The workflows in this repository are
+          # worth analysing on their own terms: one of them publishes to npm over
+          # OIDC, and the reasoning about `permissions` blocks and `${{ }}`
+          # interpolation lives in comments rather than in anything enforced. The
+          # Actions queries check exactly that class — untrusted input reaching a
+          # `run:` block, over-broad tokens, unpinned actions.
+          languages: javascript,actions
           config-file: ./.github/codeql-config.yml
 
       - name: Autobuild


### PR DESCRIPTION
CodeQL 2.26.3 improved both the JavaScript modeling and the GitHub Actions queries. We were only getting half of that: `init` declared `languages: javascript`, so the workflows themselves were never analysed.

They are worth analysing on their own terms. `changesets.yml` publishes to npm over OIDC; `ci.yml` carries a `permissions` block whose reasoning is a comment rather than anything enforced, plus a `ci` gate that interpolates `${{ toJSON(needs) }}` into a `run:`. The Actions queries check that class directly — untrusted input reaching a shell, over-broad `GITHUB_TOKEN` scopes, unpinned actions.

One non-obvious part: `paths` in `codeql-config.yml` applies to **every** language in the file, and it was `src` only. Adding `actions` without widening `paths` would have produced an analysis with nothing in scope — green, and meaningless. `.github/workflows` is now listed alongside `src`.

The action version itself is left to Dependabot, which already covers the `github-actions` ecosystem monthly; this is about what we ask it to analyse, not which version does the analysing.

## Verification

Whether this actually produces Actions results is the thing to check on this PR, not something I can assert from a diff — the run's own output is the evidence, and I will post what it finds. If it surfaces something real in the release workflow, that is a separate fix rather than part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)