### PR TITLE
fix: refuse a Windows config another account can change, report one it can only read

### DIFF
--- a/.changeset/windows-acl-write-split.md
+++ b/.changeset/windows-acl-write-split.md
@@ -1,0 +1,28 @@
+---
+"ssh-mcp": patch
+---
+
+Refuse a Windows config another account can *change*, and report one it can only read.
+
+2.3.1 made the whole ACL check advisory, because 2.3.0 refused a config at the documented `%APPDATA%` location and left its owner no way past ([#138](https://github.com/tufantunc/ssh-mcp/issues/138)). That was too broad a retreat: the check never looked at the rights an ACE granted, so `Authenticated Users:(M)` — another account being able to rewrite the file — was reported in the same words, and with the same shrug, as `BUILTIN\Users:(RX)`.
+
+Those are not the same finding. The config decides which hosts, which roles, which approval policy and which command classes this server honours, so another account being able to rewrite it is an authorization bypass rather than a disclosure. And Windows is not ambiguous about it: "an ACE grants a non-owner FILE_WRITE_DATA or WRITE_DAC" is exactly as clear as `0o022`. The ambiguity that justified retreating is specific to *read* access on a shared volume.
+
+So the rights mask is now read, and the posture follows it:
+
+| The ACL lets another account… | Default |
+|---|---|
+| only read the config | reported; the server starts |
+| change the config | refused |
+| nothing at all (a NULL DACL) | refused — that is full control for everyone |
+| an ACL that could not be read | refused, unless `icacls` is absent or the check timed out |
+
+The message says which it found — "can be modified by accounts other than its owner" rather than "is readable beyond its owner" — because calling a modify grant readable understated it.
+
+`--strictConfigAcl` refuses everything the check objects to, read-only grants included. `--allowUncheckedConfigAcl` now reports everything and refuses nothing, so it is the single exit from any of this; in 2.3.1 it covered only an undeterminable ACL, which is how #138's reporter ended up with no exit at all.
+
+Also in this release: every ACL finding now reaches the caller's `onFinding` sink rather than the strongest one going straight to stderr; `userInfo()` throwing (a Windows service under a virtual account) no longer turns a report into a crash; and the `ci` gate's `toJSON(needs)` moved out of the command line into an env var.
+
+## Behaviour changes
+
+- **On Windows, a config another account can modify refuses to start again.** If you are relying on 2.3.1's blanket advisory posture, `--allowUncheckedConfigAcl` restores it. A read-only over-grant is unaffected — it still reports and starts.

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -4,12 +4,21 @@ queries:
   - uses: security-and-quality
   - uses: security-extended
 
-# `src` for the JavaScript analysis, `.github/workflows` for the Actions one — a
-# single `paths` list applies to every language in this config, so both have to be
-# named or the Actions analysis has nothing in scope.
+# `src` for the JavaScript analysis, `.github` for the Actions one.
+#
+# A single `paths` list applies to every language in this config — GitHub documents it as
+# config-wide, and codeql-action's own repository works around that by splitting configs
+# per language — so both have to be named here. Whether the `actions` extractor honours
+# path filters at all is undocumented (the docs enumerate only interpreted languages and
+# build-less compiled ones), so this is the safe direction rather than a known
+# requirement; the run's per-database file counts are what confirm it.
+#
+# `.github` rather than `.github/workflows`: the Actions extractor also covers composite
+# actions, and an `action.yml` added under `.github/actions/` later would otherwise be
+# silently out of scope while the list still matched something.
 paths:
   - src
-  - .github/workflows
+  - .github
 
 paths-ignore:
   - node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,15 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - name: Report the job results
-        run: echo '${{ toJSON(needs) }}'
+        # Through env rather than interpolated into the command. Safe today only because
+        # no job in this file declares `outputs:`, so the JSON can only hold result enums —
+        # and `toJSON` escapes double quotes but not single ones, so the first job output
+        # carrying an apostrophe would break the command, and the first one derived from
+        # `github.event` would make it an injection. That is correctness resting on a
+        # property of the rest of the file, which is what this gate exists to stop.
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: echo "$NEEDS"
       # One expression over `needs.*`, so adding a job to `needs` above covers it
       # by construction. Three explicit comparisons was the first shape, and it
       # made the gate's correctness depend on three lists staying in step — the
@@ -302,6 +310,13 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
+          # Note what is *not* pinned here. The action ref fixes its default bundle —
+          # v4.37.6's defaults.json says CLI 2.26.2 — but the action prefers a newer CLI
+          # already in the runner's toolcache, and the run for this commit reported
+          # "Found CodeQL tools version 2.26.3 in the toolcache. Using CodeQL CLI version
+          # 2.26.3". So the analysing version floats with the runner image, not with our
+          # SHA pin. Pass `tools:` if that ever needs to be reproducible.
+          #
           # `actions` as well as `javascript`. The workflows in this repository are
           # worth analysing on their own terms: one of them publishes to npm over
           # OIDC, and the reasoning about `permissions` blocks and `${{ }}`

--- a/README.md
+++ b/README.md
@@ -60,18 +60,32 @@ which is why `chmod 700` is in that command, since `mkdir -p` under the default 
 leaves the directory 0755. The server refuses to start otherwise. "Only the owner" is
 unambiguous here and `chmod` is a one-line fix.
 
-**Windows: reported.** There are no mode bits, so it reads the ACL and tells you what it
-grants — a config under `%APPDATA%` inherits access for you, `SYSTEM` and `Administrators`
-and needs nothing done to it, while one created elsewhere does not: a file under `C:\`
-inherits read for every local account and modify for every authenticated one. The message
-names the two `icacls` commands that fix it, and then the config loads anyway.
+**Windows: split by what the ACL actually allows.** There are no mode bits, so the ACL is
+read instead — and read exposure and write exposure are not treated alike, because Windows
+is much clearer about one of them than the other.
 
-Advisory rather than enforced because enforced was tried first: 2.3.0 refused, and it
-blocked a config at the documented `%APPDATA%` location whose ACL carried a principal the
-allowlist had never seen ([#138](https://github.com/tufantunc/ssh-mcp/issues/138)). A check
-whose worst outcome is locking you out of your own config is not worth that. Pass
-`--strictConfigAcl` to refuse instead; under it, `--allowUncheckedConfigAcl` still loads a
-config whose ACL could not be determined at all.
+| The ACL lets another account… | Default |
+|---|---|
+| only **read** the config | reported, and the server starts |
+| **change** the config | refused |
+| nothing (no ACL at all) | refused — that is full control for everyone |
+| …and if the ACL could not be read | refused, except when `icacls` is absent or the check timed out |
+
+A config under `%APPDATA%` inherits access for you, `SYSTEM` and `Administrators` and needs
+nothing done to it. One created elsewhere does not: a file under `C:\` inherits *read* for
+every local account and *modify* for every authenticated one. The message names the two
+`icacls` commands that fix it either way.
+
+Read exposure is reported rather than refused because that is where Windows is genuinely
+muddier than POSIX, and refusing over it blocked a config at the documented location
+([#138](https://github.com/tufantunc/ssh-mcp/issues/138)). Write exposure is refused
+because it is not muddy at all: another account being able to rewrite the file that decides
+which hosts, roles and approval policy this server honours is an authorization bypass, not
+a disclosure.
+
+Two flags move the whole thing: `--strictConfigAcl` refuses everything the check objects
+to, read-only grants included; `--allowUncheckedConfigAcl` reports everything and refuses
+nothing. Neither combination leaves you without an exit, which is the lesson of #138.
 
 ### Exit statuses
 
@@ -604,8 +618,8 @@ Secrets are **never** passed as CLI arguments.
 | `--rateLimit` | 0 | HTTP requests per minute on the MCP route (0 = unlimited) |
 | `--allowedHosts` | bind address + localhost | Comma-separated Host headers accepted by the DNS-rebinding guard |
 | `--insecureHostKey` | false | Disable host key verification (test only!) |
-| `--allowUncheckedConfigAcl` | false | Windows: load the config even if its ACL could not be read |
-| `--strictConfigAcl` | Windows: refuse to start on a broad or unreadable config ACL instead of reporting it |
+| `--allowUncheckedConfigAcl` | false | Windows: report every ACL finding and refuse none |
+| `--strictConfigAcl` | false | Windows: refuse on every ACL finding, including a read-only over-grant |
 | `--disableApproval` | false | Skip the approval gate (quick start profile only) |
 | `--opaUrl` | — | OPA sidecar URL for external policy |
 | `--commandQuota` | 0 (off) | Max commands per rolling 24h per profile |

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -24,19 +24,21 @@ export function getConfigPath(customPath?: string): string {
 }
 
 /**
- * Refuse a config file that anyone but its owner can read, because it holds the
- * hosts, roles and policy rules that decide what this server will run.
+ * Check that nobody but the owner can reach a config file, because it holds the hosts,
+ * roles and policy rules that decide what this server will run.
  *
- * One question, asked of two different access-control systems. Mode bits are
- * POSIX's answer and are meaningless on Windows, which is the whole of #138:
- * Node synthesises `0o666` for every readable file there, so `& 0o077` was
- * non-zero unconditionally and every Windows config that has ever existed was
- * rejected. The `chmod 600` it prescribed could not lift that rejection —
- * measured on Windows 11, `chmod(path, 0o600)` leaves the mode at `0o666`,
- * because `fs.chmod` there only toggles the read-only bit. Following the
- * instruction exactly returned the operator to where they started.
+ * The two platforms answer differently on purpose. POSIX refuses: "only the owner" is
+ * unambiguous there and `chmod` is a one-line fix. Windows refuses a config another
+ * account can *change* and reports one it can only *read*, because read exposure is where
+ * the platform is genuinely muddier — see `waived` in windows-acl.ts.
  *
- * Windows reads the ACL instead; see assertPrivateOnWindows.
+ * Mode bits are POSIX's answer and are meaningless on Windows, which is the whole of #138:
+ * Node synthesises `0o666` for every readable file there, so `& 0o077` was non-zero
+ * unconditionally and every Windows config that has ever existed was rejected. The
+ * `chmod 600` it prescribed could not lift that rejection — measured on Windows 11,
+ * `chmod(path, 0o600)` leaves the mode at `0o666`, because `fs.chmod` there only toggles
+ * the read-only bit. Following the instruction exactly returned the operator to where
+ * they started.
  */
 export async function checkPermissions(filePath: string, opts: AclOptions = {}): Promise<void> {
   return platform() === 'win32'

--- a/src/config/windows-acl.ts
+++ b/src/config/windows-acl.ts
@@ -73,7 +73,7 @@ const CHILD_ENV: NodeJS.ProcessEnv = { SystemRoot: join(SYSTEM32, '..'), Path: S
  *
  * Generous, because running out is not evidence about the file: five seconds across
  * three process creations plus two temp-directory round trips, so that on-access
- * virus scanning or a loaded host does not turn a private config into a refusal.
+ * virus scanning or a loaded host does not turn a private config into a finding.
  * Expiry gets its own verdict for the same reason — see `timed-out`.
  */
 const ACL_TIMEOUT_MS = 5_000;
@@ -215,6 +215,54 @@ const ACE_FLAG_CODES: ReadonlySet<string> = new Set([
   'CI', 'OI', 'IO', 'NP', 'ID', 'SA', 'FA', 'TP', 'CR',
 ]);
 
+/**
+ * Rights that let a trustee change the object, as SDDL letter codes. `WD` here is
+ * WRITE_DAC, not Everyone — the rights field and the trustee field have separate
+ * vocabularies that happen to share spellings.
+ */
+const WRITE_RIGHT_CODES: ReadonlySet<string> = new Set([
+  'FA', 'FW', 'KA', 'KW', 'GA', 'GW', 'SD', 'WD', 'WO', 'CC', 'DC', 'SW', 'WP', 'DT',
+]);
+
+/** Rights that only let a trustee look. Anything unrecognised counts as write. */
+const READ_RIGHT_CODES: ReadonlySet<string> = new Set([
+  'FR', 'FX', 'GR', 'GX', 'KR', 'RC', 'RP', 'LC', 'LO',
+]);
+
+/**
+ * FILE_WRITE_DATA, FILE_APPEND_DATA, FILE_WRITE_EA, FILE_WRITE_ATTRIBUTES, DELETE,
+ * WRITE_DAC, WRITE_OWNER, GENERIC_WRITE, GENERIC_ALL.
+ */
+const WRITE_MASK = 0x2 | 0x4 | 0x10 | 0x100 | 0x10000 | 0x40000 | 0x80000 | 0x40000000 | 0x10000000;
+
+/**
+ * Whether a rights field lets its trustee *change* the object rather than only read it.
+ *
+ * This distinction is the basis of the default posture, and the field used to be parsed
+ * and discarded. Read exposure on Windows is genuinely muddier than under POSIX — a
+ * shared volume grants `BUILTIN\Users` read, and refusing over that stranded the reporter
+ * of #138 — but write exposure is not muddy at all: "an ACE grants a non-owner
+ * FILE_WRITE_DATA or WRITE_DAC" is exactly as unambiguous as `0o022`, and a config another
+ * account can rewrite decides which hosts, roles and approval policy this server honours.
+ * That is an authorization bypass, not a disclosure, and it was being reported as one.
+ *
+ * Measured from real inheritance: `0x1200a9` is read-and-execute, `0x1301bf` is modify.
+ * Anything this cannot classify counts as write, because refusing is the safe direction.
+ */
+function grantsWrite(rights: string): boolean {
+  const field = rights.trim().toUpperCase();
+  if (field === '') return true;
+  if (/^0X[0-9A-F]+$/.test(field)) return (Number.parseInt(field.slice(2), 16) & WRITE_MASK) !== 0;
+  if (/^[0-9]+$/.test(field)) return (Number.parseInt(field, 10) & WRITE_MASK) !== 0;
+  if (field.length % 2 !== 0) return true;
+  for (let i = 0; i < field.length; i += 2) {
+    const code = field.slice(i, i + 2);
+    if (WRITE_RIGHT_CODES.has(code)) return true;
+    if (!READ_RIGHT_CODES.has(code)) return true;
+  }
+  return false;
+}
+
 export interface Grant {
   /** How the operator will see it in `icacls` output; falls back to the trustee. */
   name: string;
@@ -236,6 +284,8 @@ export interface Grant {
    * the verdict cannot disagree, on any host.
    */
   sid: string | null;
+  /** Whether this grant lets the trustee change the file, not merely read it. */
+  writes: boolean;
 }
 
 /** Why the ACL could not be determined. Decides whether we refuse or continue. */
@@ -265,12 +315,25 @@ export type AclVerdict =
   /** No answer. The caller decides what an absent answer means. */
   | { status: 'unknown'; reason: UnknownReason; detail: string };
 
-/** Reported when a check could not be performed and the config was loaded anyway. */
-export interface UnverifiedAcl {
-  path: string;
-  reason: UnknownReason;
-  detail: string;
-}
+/**
+ * A finding the caller is told about, whether or not it also refuses.
+ *
+ * Discriminated because the two kinds are not the same statement and a reader of a log has
+ * to tell them apart: "this ACL lets Authenticated Users modify your config" and "I could
+ * not read this ACL" are different facts, and the first is the more actionable. The earlier
+ * shape could only express the second, so the stronger finding went straight to
+ * `console.error` and no caller could reach it — which is what `onFinding`'s own doc says
+ * must not happen.
+ */
+export type AclFinding =
+  | {
+      path: string; kind: 'file' | 'directory';
+      status: 'unchecked'; reason: UnknownReason; detail: string; message: string;
+    }
+  | {
+      path: string; kind: 'file' | 'directory';
+      status: 'broad' | 'no-dacl'; grants: Grant[]; message: string;
+    };
 
 export interface AclOptions {
   /**
@@ -290,7 +353,7 @@ export interface AclOptions {
    * `Authenticated Users` modify — but saying it and refusing are different things, and
    * only one of them can strand somebody.
    */
-  strict?: boolean;
+  enforce?: boolean;
   /**
    * Load the config even when the ACL could not be determined.
    * `--allowUncheckedConfigAcl`.
@@ -306,7 +369,7 @@ export interface AclOptions {
    * which is also the only place that could ever reach the audit store. Defaults
    * to stderr so the module stands on its own.
    */
-  onUnverified?: (event: UnverifiedAcl) => void;
+  onFinding?: (finding: AclFinding) => void;
 }
 
 /**
@@ -371,7 +434,8 @@ async function currentUserSid(signal?: AbortSignal): Promise<string | null> {
  * executed by nothing.
  *
  * Two failures say nothing about the file — icacls being absent from the machine, and
- * the check running out of time — and those are the two the caller loads anyway.
+ * the check running out of time — and those are the two the caller loads anyway even
+ * under `--strictConfigAcl`.
  * Everything else (a non-zero exit, output we could not read) is about this path.
  *
  * Which makes "absent" worth being sure of: absent *here* is not enough, because a
@@ -635,7 +699,9 @@ export function parseDacl(descriptor: string, identity: AclIdentity): AclVerdict
     const sid = resolveTrustee(trustee, accountDomain);
     if (sid !== null && allowedSids.has(sid)) continue;
 
-    grants.set(sid ?? trustee, { name: nameFor(trustee), trustee, sid });
+    grants.set(sid ?? trustee, {
+      name: nameFor(trustee), trustee, sid, writes: grantsWrite(fields[2]),
+    });
   }
 
   return grants.size === 0 ? { status: 'restricted' } : { status: 'broad', grants: [...grants.values()] };
@@ -683,7 +749,7 @@ export function aclIdentity(sid: string): AclIdentity {
   // RID 500 is the built-in Administrator. In a default configuration it belongs
   // to the Administrators group, which is already allowed, so naming the account
   // directly grants nobody new access — while refusing it is a false positive,
-  // and here that means refusing to start a server whose config is fine. (On a
+  // and here that means refusing, or at best warning, about a config that is fine. (On a
   // domain-joined host the account domain is the domain, so this authorises
   // DOMAIN\Administrator, whose local-admin status comes from Domain Admins
   // nesting — a GPO default rather than a law.)
@@ -813,7 +879,17 @@ function remediation(path: string, kind: 'file' | 'directory', grants: Grant[] =
   // reaches icacls literally, which reports "Failed processing 1 files" and
   // changes nothing. Measured. An instruction that only works in one shell is
   // the same defect as the `chmod 600` this whole change replaced.
-  const account = userInfo().username;
+  // Guarded because this is now on the *reporting* path, not only the throwing one. A
+  // Windows service under a virtual account, or a container with no loaded profile, makes
+  // `userInfo()` throw ENOENT — which escaped as a raw stack and cost the operator their
+  // config, which is #138 one environment over. A message that cannot name the account is
+  // still worth printing.
+  let account: string;
+  try {
+    account = userInfo().username;
+  } catch {
+    account = process.env.USERNAME || '<your account>';
+  }
   return (
     'Restrict it with these two commands, in this order:\n' +
     `  icacls "${path}" /inheritance:d\n` +
@@ -849,15 +925,95 @@ function relocation(path: string, kind: 'file' | 'directory', grants: Grant[]): 
 }
 
 /**
- * Refuse a config the owner is not alone in being able to read — the Windows
- * half of `checkPermissions`.
+ * What a verdict means for one subject, as text and as data — and nothing else.
  *
- * Both the file and its directory are examined. An unreadable ACL is refused rather
- * than waved through, with two exceptions: `icacls` absent from the machine, and the
- * check running out of time. Both are statements about the machine rather than about
- * the file, and refusing over a question that cannot be asked here is what #138 was.
- * `--allowUncheckedConfigAcl` is the way past the rest, so an operator is never stuck
- * with no exit.
+ * Pure, so every message is assertable without a subprocess or a `console.error` spy, and
+ * so the refusal and the report cannot drift apart: they sat fifteen lines apart and had
+ * already diverged, one calling the same condition "was not checked" and the other "could
+ * not be checked".
+ */
+function describe(path: string, kind: 'file' | 'directory', verdict: AclVerdict): AclFinding | null {
+  if (verdict.status === 'restricted') return null;
+
+  if (verdict.status === 'unknown') {
+    return {
+      path,
+      kind,
+      status: 'unchecked',
+      reason: verdict.reason,
+      detail: verdict.detail,
+      message:
+        `Config ${kind} ${path} could not be checked for access by other accounts ` +
+        `(${verdict.reason}: ${verdict.detail}).\n` +
+        'Either fix the cause, move the config under %APPDATA%\\ssh-mcp, or pass ' +
+        '--allowUncheckedConfigAcl to accept it unverified.',
+    };
+  }
+
+  // An empty grants list for a NULL DACL is deliberate: there is nothing to `/remove:g`,
+  // and the fix is to give the object an ACL at all. `remediation` reads that emptiness.
+  const grants = verdict.status === 'broad' ? verdict.grants : [];
+  const writers = grants.filter((g) => g.writes);
+  const readers = grants.filter((g) => !g.writes);
+  const what = verdict.status === 'no-dacl'
+    ? 'has no access control list at all, which on Windows means full control for every ' +
+      'account on the machine.'
+    : writers.length > 0
+      // Named as modifiable, not "readable". Calling a modify grant readable understated an
+      // integrity failure as a disclosure — and the two now decide different postures, so
+      // the wording has to tell them apart.
+      ? `can be modified by accounts other than its owner: ${writers.map((g) => g.name).join(', ')}` +
+        `${readers.length ? `, and read by ${readers.map((g) => g.name).join(', ')}` : ''}. ` +
+        'Required: this account, SYSTEM and Administrators only.'
+      : `is readable beyond its owner: access is granted to ${grants.map((g) => g.name).join(', ')}. ` +
+        'Required: this account, SYSTEM and Administrators only.';
+
+  return {
+    path,
+    kind,
+    status: verdict.status,
+    grants,
+    message:
+      `Config ${kind} ${path} ${what}\n` +
+      (isTightenable(path, kind) ? remediation(path, kind, grants) : relocation(path, kind, grants)),
+  };
+}
+
+/**
+ * Whether a finding is reported rather than refused.
+ *
+ * Three postures, two flags, and deliberately no combination that leaves an operator with
+ * no exit — the lesson of #138, and why this is a function rather than one boolean.
+ *
+ * By default: a grant that only lets another account *read* is reported, because that is
+ * where Windows is muddier than POSIX and refusing over it stranded a real operator. A
+ * grant that lets another account *change* the config is refused, because that is an
+ * authorization bypass and Windows is not muddy about it. An ACL that could not be
+ * determined is refused too — #138 was a known-bad verdict, never an undeterminable one,
+ * and flipping those open would let an attacker swap a loud finding for a vague one for
+ * free. The two exceptions stay: `icacls` absent, and the check running out of time, both
+ * statements about the machine rather than about the file.
+ *
+ * `--allowUncheckedConfigAcl` reports everything and refuses nothing — the single exit.
+ * `--strictConfigAcl` refuses everything the check objects to, read-only grants included.
+ */
+function waived(finding: AclFinding, opts: AclOptions): boolean {
+  if (opts.allowUnchecked) return true;
+  if (opts.enforce) return false;
+  if (finding.status === 'unchecked') {
+    return finding.reason === 'tool-missing' || finding.reason === 'timed-out';
+  }
+  // A NULL DACL is full control for everyone, so it is never read-only.
+  return finding.status === 'broad' && !finding.grants.some((g) => g.writes);
+}
+
+/**
+ * Report what a config's ACL grants beyond its owner, and refuse when it is not merely
+ * readable — the Windows half of `checkPermissions`.
+ *
+ * Both the file and its directory are examined. What happens to a finding is
+ * `waived`'s decision; see it for the three postures and why the default is not to refuse
+ * a read-only over-grant.
  */
 export async function assertPrivateOnWindows(
   filePath: string,
@@ -872,53 +1028,20 @@ export async function assertPrivateOnWindows(
     const signal = AbortSignal.timeout(ACL_TIMEOUT_MS);
     return raceDeadline(inspectAcl(p, signal), signal);
   });
-  const report = opts.onUnverified ?? ((e: UnverifiedAcl) => {
-    console.error(
-      `Warning: the ACL of ${e.path} was not checked (${e.reason}: ${e.detail}), so whether ` +
-      'other accounts can read your config is unverified. Loading it anyway.',
-    );
-  });
+  const report = opts.onFinding ?? ((f: AclFinding) => console.error(`Warning: ${f.message}`));
   const subjects = [
     { path: filePath, kind: 'file' as const },
     { path: parsePath(filePath).dir || '.', kind: 'directory' as const },
   ];
 
   for (const { path, kind } of subjects) {
-    const verdict = await look(path);
+    const finding = describe(path, kind, await look(path));
+    if (finding === null) continue;
 
-    if (verdict.status === 'restricted') continue;
-
-    if (verdict.status === 'broad' || verdict.status === 'no-dacl') {
-      const grants = verdict.status === 'broad' ? verdict.grants : [];
-      const what = verdict.status === 'broad'
-        ? `is readable beyond its owner: access is granted to ${grants.map((g) => g.name).join(', ')}. ` +
-          'Required: this account, SYSTEM and Administrators only.'
-        : 'has no access control list at all, which on Windows means full control for ' +
-          'every account on the machine.';
-      const message =
-        `Config ${kind} ${path} ${what}\n` +
-        (isTightenable(path, kind) ? remediation(path, kind, grants) : relocation(path, kind, grants));
-
-      if (opts.strict) throw new OperatorError(message);
-      // Advisory by default; see AclOptions.strict for why.
-      console.error(`Warning: ${message}`);
-      continue;
-    }
-
-    // status === 'unknown'
-    if (!opts.strict || verdict.reason === 'tool-missing' || verdict.reason === 'timed-out'
-      || opts.allowUnchecked) {
-      report({ path, reason: verdict.reason, detail: verdict.detail });
-      continue;
-    }
-
-    throw new OperatorError(
-      `Config ${kind} ${path} could not be checked for access by other accounts ` +
-      `(${verdict.reason}: ${verdict.detail}).\n` +
-      'Refused because --strictConfigAcl was given, and the config decides which hosts, ' +
-      'roles and policy rules this server honours.\n' +
-      'Either fix the cause, move the config under %APPDATA%\\ssh-mcp, or pass ' +
-      '--allowUncheckedConfigAcl to load it unverified.',
-    );
+    // One decision, read once. Refusing and reporting used to be decided in three places —
+    // twice on the same flag for the same question — with two `continue`s and two throw
+    // sites, and the advisory path wrote to stderr directly rather than through the sink.
+    if (!waived(finding, opts)) throw new OperatorError(finding.message);
+    report(finding);
   }
 }

--- a/src/config/windows-acl.ts
+++ b/src/config/windows-acl.ts
@@ -879,16 +879,24 @@ function remediation(path: string, kind: 'file' | 'directory', grants: Grant[] =
   // reaches icacls literally, which reports "Failed processing 1 files" and
   // changes nothing. Measured. An instruction that only works in one shell is
   // the same defect as the `chmod 600` this whole change replaced.
+  //
   // Guarded because this is now on the *reporting* path, not only the throwing one. A
   // Windows service under a virtual account, or a container with no loaded profile, makes
   // `userInfo()` throw ENOENT — which escaped as a raw stack and cost the operator their
   // config, which is #138 one environment over. A message that cannot name the account is
   // still worth printing.
+  //
+  // A visible placeholder rather than `process.env.USERNAME`, which was the first spelling
+  // of this fallback. In the environments where `userInfo()` actually throws the env var is
+  // either unset or holds something icacls will not accept — a virtual service account, or
+  // `MACHINE$` — so it would print a command that fails, which is the defect class this
+  // whole change exists to remove. A placeholder the operator has to fill in cannot be
+  // followed by mistake.
   let account: string;
   try {
     account = userInfo().username;
   } catch {
-    account = process.env.USERNAME || '<your account>';
+    account = '<your account>';
   }
   return (
     'Restrict it with these two commands, in this order:\n' +

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadConfig, getConfigPath } from './config/loader.js';
 import { OperatorError, ConfigNotFoundError, reportFatal } from './errors.js';
-import type { UnverifiedAcl } from './config/windows-acl.js';
+import type { AclFinding } from './config/windows-acl.js';
 import { ConnectionRegistry } from './ssh/connection-registry.js';
 import { PolicyEngine, HOST_GROUPS, resolvePolicyRules } from './policy/engine.js';
 import { AuditStore } from './audit/store.js';
@@ -119,12 +119,13 @@ export function resolveHostGroup(argv: Record<string, string | null>): string {
 }
 
 /**
- * ACL checks that could not be performed, in the order they happened.
+ * Every ACL finding, in the order it happened — both "readable beyond its owner" and
+ * "could not be checked".
  *
  * Collected rather than only printed so `main()` can act on them once there is somewhere
  * durable to put them; see the note at the sink below.
  */
-const unverified: UnverifiedAcl[] = [];
+const aclFindings: AclFinding[] = [];
 
 async function buildAppConfig(argv: Record<string, string | null>): Promise<AppConfig> {
   // The way past an ACL that could not be read, rather than an operator with no
@@ -135,14 +136,11 @@ async function buildAppConfig(argv: Record<string, string | null>): Promise<AppC
   // the audit store as well needs an AuditRecord variant for a startup event — that type
   // is hash-chained and tamper-evident, so it is its own change, and it is queued.
   const aclOpts = {
-    strict: flagEnabled(argv, 'strictConfigAcl'),
+    enforce: flagEnabled(argv, 'strictConfigAcl'),
     allowUnchecked: flagEnabled(argv, 'allowUncheckedConfigAcl'),
-    onUnverified: (e: UnverifiedAcl) => {
-      unverified.push(e);
-      console.error(
-        `Warning: the ACL of ${e.path} was not checked (${e.reason}: ${e.detail}), so ` +
-        'whether other accounts can read your config is unverified. Loading it anyway.',
-      );
+    onFinding: (f: AclFinding) => {
+      aclFindings.push(f);
+      console.error(`Warning: ${f.message}`);
     },
   };
 

--- a/test/unit/config/config-failure-reporting.test.ts
+++ b/test/unit/config/config-failure-reporting.test.ts
@@ -224,8 +224,30 @@ describe('buildAppConfig threads --allowUncheckedConfigAcl to the loader', () =>
     // Three reviewers pointed out the seam existed and nothing used it: the option was
     // documented as letting main() decide, while main() took the module's stderr default.
     const mock = await build({ config: '/x/config.toml' });
-    const opts = mock.mock.calls[0][1] as { onUnverified?: unknown };
-    expect(typeof opts.onUnverified).toBe('function');
+    const opts = mock.mock.calls[0][1] as { onFinding?: unknown };
+    expect(typeof opts.onFinding).toBe('function');
+  });
+
+  it.each([
+    ['strictConfigAcl', 'enforce'],
+    ['allowUncheckedConfigAcl', 'allowUnchecked'],
+  ] as const)('threads --%s to the loader as %s', async (flag, option) => {
+    // Both flags, at their wiring rather than below it. `strict: true` — reinstating the
+    // 2.3.0 default that blocked the reporter of #138 — survived the whole suite, exactly
+    // as the allowUnchecked mutations did a round earlier. The flag's presence is the
+    // evidence an operator relies on, so an unconnected flag is worse than none.
+    const on = await build({ config: '/x/config.toml', [flag]: null });
+    expect(on).toHaveBeenCalledWith('/x/config.toml', expect.objectContaining({ [option]: true }));
+
+    const off = await build({ config: '/x/config.toml' });
+    expect(off).toHaveBeenCalledWith('/x/config.toml', expect.objectContaining({ [option]: false }));
+
+    const explicit = await build({ config: '/x/config.toml', [flag]: 'false' });
+    expect(explicit).toHaveBeenCalledWith('/x/config.toml', expect.objectContaining({ [option]: false }));
+
+    // The default-path branch passes the same object, so neither can drift.
+    const viaDefault = await build({ [flag]: null });
+    expect(viaDefault).toHaveBeenCalledWith(undefined, expect.objectContaining({ [option]: true }));
   });
 
   it('honours an explicit --allowUncheckedConfigAcl=false', async () => {

--- a/test/unit/config/helpers.ts
+++ b/test/unit/config/helpers.ts
@@ -39,3 +39,14 @@ export async function makeConfigDir(prefix = 'ssh-mcp-test-'): Promise<ConfigDir
     },
   };
 }
+
+/**
+ * Ask the Windows ACL check to enforce rather than report.
+ *
+ * One spelling for both config suites: they had a frozen `STRICT` literal in one and a
+ * spreading `strict()` builder in the other, for one concept — and the literal forced
+ * `{ ...STRICT, allowUnchecked: true }` at the one call site that extends it, which is
+ * the spread a builder exists to hide.
+ */
+export const enforceAcl = <T extends object>(extra: T = {} as T) =>
+  ({ ...extra, enforce: true as const });

--- a/test/unit/config/windows-acl-decisions.test.ts
+++ b/test/unit/config/windows-acl-decisions.test.ts
@@ -410,3 +410,62 @@ describe('assertPrivateOnWindows — the three postures', () => {
     expect(String(warn.mock.calls[0][0])).toMatch(/Warning: /);
   });
 });
+
+describe('when the platform will not name the current account', () => {
+  /**
+   * `userInfo()` throws ENOENT for a process with no loaded profile — a Windows
+   * service under a virtual account, or a container. The guard around it was
+   * added because an unhandled throw there turns a *report* into a raw stack
+   * trace, which is #138 one environment over: the operator loses their config to
+   * a crash inside the code that was only trying to warn them.
+   *
+   * Untested until now, and it is the branch that runs in exactly the environment
+   * nobody reviews interactively.
+   */
+  async function messageWithBrokenUserInfo(): Promise<string> {
+    vi.resetModules();
+    // Set so the assertion below bites on every platform. Without it USERNAME is
+    // simply unset on the Linux and macOS jobs, the old code fell through to the
+    // same placeholder, and reinstating `process.env.USERNAME` would have passed.
+    vi.stubEnv('USERNAME', 'MACHINE$');
+    vi.doMock('os', async () => {
+      const actual = await vi.importActual<typeof import('os')>('os');
+      return {
+        ...actual,
+        userInfo: () => {
+          throw Object.assign(new Error('ENOENT: no such file or directory, uv_os_get_passwd'), {
+            code: 'ENOENT',
+          });
+        },
+      };
+    });
+    const acl = await import('../../../src/config/windows-acl.js');
+    const err = await acl
+      .assertPrivateOnWindows(FILE, { enforce: true }, async (p) =>
+        p === FILE ? { status: 'broad', grants: [EVERYONE] } : { status: 'restricted' },
+      )
+      .then(() => null, (e: Error) => e);
+    vi.doUnmock('os');
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    expect(err, 'expected a refusal, not a resolve').toBeInstanceOf(Error);
+    return (err as Error).message;
+  }
+
+  it('still produces the finding instead of escaping as a crash', async () => {
+    const message = await messageWithBrokenUserInfo();
+    expect(message).toContain('Everyone');
+    expect(message).toContain('/remove:g *S-1-1-0');
+  });
+
+  it('prints a placeholder the operator must fill in, not a guess', async () => {
+    // The first spelling of this fallback read process.env.USERNAME. In the
+    // environments where userInfo() actually throws that variable is either unset
+    // or holds something icacls rejects — `MACHINE$`, or a virtual service
+    // account — so it printed a command that fails while looking runnable. A
+    // command with a visible hole in it cannot be pasted by mistake.
+    const message = await messageWithBrokenUserInfo();
+    expect(message).toContain('"<your account>:F"');
+    expect(message).not.toContain('MACHINE$');
+  });
+});

--- a/test/unit/config/windows-acl-decisions.test.ts
+++ b/test/unit/config/windows-acl-decisions.test.ts
@@ -3,13 +3,14 @@ import { join, parse } from 'path';
 import {
   inspectAcl,
   type AclOptions,
-  type UnverifiedAcl,
+  type AclFinding,
   assertPrivateOnWindows,
   type AclVerdict,
   type Grant,
   type UnknownReason,
 } from '../../../src/config/windows-acl.js';
 import { OperatorError } from '../../../src/errors.js';
+import { enforceAcl } from './helpers.js';
 
 /**
  * What the Windows branch *decides*, as opposed to what the parser reads.
@@ -34,7 +35,10 @@ const PROFILE = join(ROOT, 'Users', 'me');
 const FILE = join(PROFILE, 'AppData', 'Roaming', 'ssh-mcp', 'config.toml');
 const DIR = join(PROFILE, 'AppData', 'Roaming', 'ssh-mcp');
 
-const grant = (name: string, trustee: string, sid: string | null): Grant => ({ name, trustee, sid });
+const grant = (name: string, trustee: string, sid: string | null, writes = false): Grant =>
+  ({ name, trustee, sid, writes });
+/** A grant that lets another account change the config — refused by default. */
+const writer = (name: string, trustee: string, sid: string) => grant(name, trustee, sid, true);
 const EVERYONE = grant('Everyone', 'WD', 'S-1-1-0');
 
 /** Answers `path` with `verdict`, everything else `restricted`. */
@@ -49,15 +53,19 @@ const broad = (...grants: Grant[]): AclVerdict => ({ status: 'broad', grants });
 
 /** Awaits the refusal and names the behaviour if there isn't one. */
 /** The default posture: report, do not refuse. */
-function warned(): { events: UnverifiedAcl[]; warnings: string[]; opts: AclOptions } {
-  const events: UnverifiedAcl[] = [];
+function warned(): { events: AclFinding[]; warnings: string[]; opts: AclOptions } {
+  const events: AclFinding[] = [];
   const warnings: string[] = [];
   vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => { warnings.push(String(a[0])); });
-  return { events, warnings, opts: { onUnverified: (e) => events.push(e) } };
+  // Both halves are used: `opts` wires the sink so a test can assert the structured
+  // finding, `warnings` catches the module's default when no sink is supplied. The
+  // helper returned both before and every caller ignored `opts` — which was the sink
+  // bug showing up in the tests as scaffolding nothing could use.
+  return { events, warnings, opts: { onFinding: (e) => events.push(e) } };
 }
 
 /** Refusal is opt-in now, so every refusal test says so. */
-const strict = (extra: AclOptions = {}): AclOptions => ({ ...extra, strict: true });
+const strict = enforceAcl;
 
 async function refusal(p: Promise<void>): Promise<Error> {
   const err = await p.then(() => null, (e: Error) => e);
@@ -273,138 +281,132 @@ describe('assertPrivateOnWindows — a NULL DACL', () => {
   });
 });
 
-describe('assertPrivateOnWindows — an unknown ACL', () => {
-  it('loads anyway, reporting it, when icacls is not on the machine', async () => {
-    // One of two fail-open cases. Server Core and stripped images exist, and a
-    // check that cannot run there must not be a reason to refuse the config.
-    const reported: unknown[] = [];
-    await expect(
-      assertPrivateOnWindows(
-        FILE,
-        strict({ onUnverified: (e) => reported.push(e) }),
-        only(FILE, unknown('tool-missing', 'no icacls.exe')),
-      ),
-    ).resolves.toBeUndefined();
-    expect(reported).toEqual([{ path: FILE, reason: 'tool-missing', detail: 'no icacls.exe' }]);
+describe('assertPrivateOnWindows — the three postures', () => {
+  /**
+   * Three postures, two flags, and no combination that strands anybody — which is the
+   * whole lesson of #138 and why this is a table rather than a boolean.
+   *
+   * Default: a read-only over-grant is reported, because that is where Windows is muddier
+   * than POSIX and refusing over it blocked a real operator. A grant that lets another
+   * account *change* the config is refused, because that is an authorization bypass and
+   * Windows is not muddy about it. An undeterminable ACL is refused too — #138 was a
+   * known-bad verdict, never an undeterminable one, and flipping those open would let an
+   * attacker swap a loud finding for a vague one at no cost.
+   */
+  const READ_ONLY = broad(grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545'));
+  const WRITABLE = broad(writer('Authenticated Users', 'AU', 'S-1-5-11'));
+  const UNDETERMINABLE = unknown('read-refused', 'Access is denied');
+  const MACHINE_SAYS_NOTHING = unknown('tool-missing', 'no icacls.exe');
+
+  it('reports a read-only over-grant and loads the config', async () => {
+    const { warnings, events, opts } = warned();
+    await expect(assertPrivateOnWindows(FILE, opts, only(FILE, READ_ONLY))).resolves.toBeUndefined();
+    // Through the caller's sink, not only to stderr: the advisory branch wrote straight to
+    // console.error, so the strongest finding the check can make was the one thing no
+    // caller could reach while "I could not read the ACL" was delivered structurally.
+    expect(events).toEqual([expect.objectContaining({ path: FILE, kind: 'file', status: 'broad' })]);
+    expect(warnings).toEqual([]);
   });
 
-  it('loads anyway when the check ran out of time', async () => {
-    // Also a statement about the machine: process creation under on-access
-    // scanning can outlast any budget, and refusing then is #138's shape.
-    const reported: unknown[] = [];
-    await expect(
-      assertPrivateOnWindows(
-        FILE,
-        strict({ onUnverified: (e) => reported.push(e) }),
-        only(FILE, unknown('timed-out', 'exceeded 5000ms')),
-      ),
-    ).resolves.toBeUndefined();
-    expect(reported).toHaveLength(1);
+  it('names a read-only grant as readable', async () => {
+    const { warnings } = warned();
+    await assertPrivateOnWindows(FILE, {}, only(FILE, READ_ONLY));
+    // The severity marker is part of the deliverable — it is the only thing separating an
+    // advisory finding from the fatal this used to be, in an operator's startup log.
+    expect(warnings[0]).toMatch(/^Warning: Config file /);
+    expect(warnings[0]).toMatch(/is readable beyond its owner/);
+    expect(warnings[0]).toContain('/remove:g *S-1-5-32-545');
+  });
+
+  it('refuses a write-granting ACL, and says modified rather than readable', async () => {
+    // `parseDacl` used to discard the rights mask, so a modify grant and a read grant were
+    // the same verdict with the same wording — an integrity failure described as a
+    // disclosure. The config decides which hosts, roles and approval policy this server
+    // honours, so another account being able to rewrite it is an authorization bypass.
+    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, WRITABLE)));
+    expect(err.message).toMatch(/can be modified by accounts other than its owner/);
+    expect(err.message).toContain('Authenticated Users');
+  });
+
+  it('names both when one trustee writes and another only reads', async () => {
+    const mixed = broad(
+      writer('Authenticated Users', 'AU', 'S-1-5-11'),
+      grant('BUILTIN\\Users', 'BU', 'S-1-5-32-545'),
+    );
+    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, mixed)));
+    expect(err.message).toMatch(/modified by accounts other than its owner: Authenticated Users/);
+    expect(err.message).toMatch(/and read by BUILTIN\\Users/);
+  });
+
+  it('refuses a NULL DACL, which is full control rather than read access', async () => {
+    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, { status: 'no-dacl' })));
+    expect(err.message).toContain('no access control list');
+    // Nothing to remove; the fix is to give the object an ACL at all.
+    expect(err.message).toContain('/grant:r');
+    expect(err.message).not.toContain('/remove:g');
+  });
+
+  it('refuses an undeterminable ACL by default', async () => {
+    // Not what #138 was about, and flipping it open hands an attacker a free downgrade:
+    // make the descriptor unparseable and the loud finding becomes a vague one.
+    const err = await refusal(assertPrivateOnWindows(FILE, {}, only(FILE, UNDETERMINABLE)));
+    expect(err.message).toContain('could not be checked');
+    expect(err.message).toContain('--allowUncheckedConfigAcl');
+  });
+
+  it.each(['tool-missing', 'timed-out'] as const)(
+    'reports %s and loads, because it says nothing about the file',
+    async (reason) => {
+      const { warnings } = warned();
+      await expect(
+        assertPrivateOnWindows(FILE, {}, only(FILE, unknown(reason, 'detail'))),
+      ).resolves.toBeUndefined();
+      expect(warnings.join('\n')).toMatch(/could not be checked/);
+    },
+  );
+
+  it('reports everything and refuses nothing under --allowUncheckedConfigAcl', async () => {
+    // The single exit, and it has to cover every verdict — the 2.3.0 version covered only
+    // an undeterminable ACL, which is how the reporter of #138 ended up with none.
+    for (const verdict of [READ_ONLY, WRITABLE, UNDETERMINABLE, { status: 'no-dacl' } as const]) {
+      const { warnings } = warned();
+      await expect(
+        assertPrivateOnWindows(FILE, { allowUnchecked: true }, only(FILE, verdict)),
+      ).resolves.toBeUndefined();
+      expect(warnings, JSON.stringify(verdict)).toHaveLength(1);
+    }
+  });
+
+  it('refuses everything the check objects to under --strictConfigAcl', async () => {
+    for (const verdict of [READ_ONLY, WRITABLE, UNDETERMINABLE, MACHINE_SAYS_NOTHING]) {
+      await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, verdict)));
+    }
+  });
+
+  it('refuses instead of reporting, rather than as well', async () => {
+    const { warnings, events, opts } = warned();
+    await refusal(assertPrivateOnWindows(FILE, strict(opts), only(FILE, READ_ONLY)));
+    expect(warnings).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  it('still examines the directory after reporting on the file', async () => {
+    const seen: string[] = [];
+    const { warnings } = warned();
+    await assertPrivateOnWindows(FILE, {}, async (p) => {
+      seen.push(p);
+      return READ_ONLY;
+    });
+    expect(seen).toEqual([FILE, DIR]);
+    // Two subjects, two findings — not one report covering both.
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain(FILE);
+    expect(warnings[1]).toContain(DIR);
   });
 
   it('falls back to stderr when the caller supplies no sink', async () => {
     const warn = vi.spyOn(console, 'error').mockImplementation(() => {});
-    await expect(
-      assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('tool-missing'))),
-    ).resolves.toBeUndefined();
-    expect(String(warn.mock.calls[0][0])).toMatch(/was not checked/);
-  });
-
-  it('refuses when icacls ran and would not describe the path', async () => {
-    // Access denied on a DACL read is evidence about the file. The first version
-    // collapsed every failure to "unchecked, load anyway", so breaking icacls was
-    // enough to disable the check.
-    const err = await refusal(
-      assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('read-refused', 'Access is denied'))),
-    );
-    expect(err.message).toContain('read-refused');
-    expect(err.message).toContain('--allowUncheckedConfigAcl');
-  });
-
-  it('refuses a descriptor it cannot parse', async () => {
-    const err = await refusal(
-      assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('unparsable', 'no DACL component'))),
-    );
-    expect(err.message).toContain('unparsable');
-  });
-
-  it("refuses when this account's own SID could not be read", async () => {
-    // Without an identity there is no allowlist to compare against, so a verdict
-    // would be meaningless rather than merely uncertain.
-    await refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, unknown('identity-unknown'))));
-  });
-
-  it('honours --allowUncheckedConfigAcl for the refusing reasons', async () => {
-    const reported: unknown[] = [];
-    await expect(
-      assertPrivateOnWindows(
-        FILE,
-        strict({ allowUnchecked: true, onUnverified: (e) => reported.push(e) }),
-        only(FILE, unknown('read-refused', 'Access is denied')),
-      ),
-    ).resolves.toBeUndefined();
-    expect(reported).toHaveLength(1);
-  });
-
-  it('does not let the escape hatch turn a broad ACL into a warning', async () => {
-    // The flag is about an unanswered question, not about a known-bad answer.
-    await expect(
-      assertPrivateOnWindows(FILE, strict({ allowUnchecked: true }), only(FILE, broad(EVERYONE))),
-    ).rejects.toThrow(/Everyone/);
-  });
-});
-
-describe('assertPrivateOnWindows — advisory by default', () => {
-  /**
-   * The posture this settled on, and why.
-   *
-   * 2.3.0 refused a broad ACL, and on the first day it blocked a reporter's config at the
-   * documented `%APPDATA%` location: their ACL carried a principal the allowlist did not
-   * know about, because the allowlist was measured on one machine. `--allowUncheckedConfigAcl`
-   * deliberately did not cover a known-bad verdict, so there was no way past it — a check
-   * whose worst outcome is stranding an operator in their own config.
-   */
-  it('reports a broad ACL and loads the config', async () => {
-    const { warnings } = warned();
-    await expect(
-      assertPrivateOnWindows(FILE, {}, only(FILE, broad(EVERYONE))),
-    ).resolves.toBeUndefined();
-    expect(warnings.join('\n')).toMatch(/readable beyond its owner/);
-    // The commands are still printed: the finding is worth stating, and stating it is not
-    // the same act as refusing.
-    expect(warnings.join('\n')).toContain('/remove:g *S-1-1-0');
-  });
-
-  it('reports a NULL DACL and loads the config', async () => {
-    const { warnings } = warned();
-    await expect(
-      assertPrivateOnWindows(FILE, {}, only(FILE, { status: 'no-dacl' })),
-    ).resolves.toBeUndefined();
-    expect(warnings.join('\n')).toMatch(/no access control list/);
-  });
-
-  it('reports an undeterminable ACL and loads the config', async () => {
-    const { warnings } = warned();
-    await expect(
-      assertPrivateOnWindows(FILE, {}, only(FILE, unknown('read-refused', 'Access is denied'))),
-    ).resolves.toBeUndefined();
-    expect(warnings.join('\n')).toMatch(/was not checked/);
-  });
-
-  it('still examines the directory after warning about the file', async () => {
-    // Warning must not short-circuit what refusing used to.
-    const seen: string[] = [];
-    warned();
-    await assertPrivateOnWindows(FILE, {}, async (p) => {
-      seen.push(p);
-      return broad(EVERYONE);
-    });
-    expect(seen).toEqual([FILE, DIR]);
-  });
-
-  it('refuses only when --strictConfigAcl asks it to', async () => {
-    await expect(
-      refusal(assertPrivateOnWindows(FILE, strict(), only(FILE, broad(EVERYONE)))),
-    ).resolves.toBeInstanceOf(OperatorError);
+    await assertPrivateOnWindows(FILE, {}, only(FILE, READ_ONLY));
+    expect(String(warn.mock.calls[0][0])).toMatch(/Warning: /);
   });
 });

--- a/test/unit/config/windows-acl.live.test.ts
+++ b/test/unit/config/windows-acl.live.test.ts
@@ -6,17 +6,14 @@ import { tmpdir, platform } from 'os';
 import { join } from 'path';
 import { checkPermissions } from '../../../src/config/loader.js';
 import { inspectAcl } from '../../../src/config/windows-acl.js';
-import { MINIMAL_CONFIG } from './helpers.js';
+import { MINIMAL_CONFIG, enforceAcl } from './helpers.js';
 
 const run = promisify(execFile);
 const shell = promisify(exec);
 
-/**
- * Refusal is opt-in since the reporter of #138 was blocked by the default.
- * These cases are about what the check *finds*, so they ask it to enforce; the
- * default posture gets its own case at the end.
- */
-const STRICT = { strict: true } as const;
+// Refusal is opt-in since the reporter of #138 was blocked by the default. These cases
+// are about what the check *finds*, so they ask it to enforce; the default posture gets
+// its own describe at the end.
 const onWindows = platform() === 'win32';
 
 /**
@@ -66,34 +63,34 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
   }
 
   it('accepts a file that only its owner can reach', async () => {
-    await expect(checkPermissions(file, STRICT)).resolves.toBeUndefined();
+    await expect(checkPermissions(file, enforceAcl())).resolves.toBeUndefined();
   });
 
   it('refuses a file granted to Everyone', async () => {
     await run('icacls', [file, '/grant', '*S-1-1-0:(R)']);
-    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/Everyone/);
+    await expect(checkPermissions(file, enforceAcl())).rejects.toThrow(/Everyone/);
   });
 
   it('refuses a file granted to BUILTIN\\Users', async () => {
     await run('icacls', [file, '/grant', '*S-1-5-32-545:(R)']);
-    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/Users/);
+    await expect(checkPermissions(file, enforceAcl())).rejects.toThrow(/Users/);
   });
 
   it('refuses a file granted to a group no denylist would have named', async () => {
     // Power Users is the point of the allowlist rewrite: it is neither Everyone
     // nor Users, and the first version passed it as owner-only.
     await run('icacls', [file, '/grant', '*S-1-5-32-547:(R)']);
-    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/Power Users/);
+    await expect(checkPermissions(file, enforceAcl())).rejects.toThrow(/Power Users/);
   });
 
   it('refuses when the directory is open even though the file is not', async () => {
     await run('icacls', [dir, '/grant', '*S-1-1-0:(R)']);
-    await expect(checkPermissions(file, STRICT)).rejects.toThrow(/directory/);
+    await expect(checkPermissions(file, enforceAcl())).rejects.toThrow(/directory/);
   });
 
   it('names the principal and the path, not just the fact of a refusal', async () => {
     await run('icacls', [file, '/grant', '*S-1-1-0:(R)']);
-    const err = await refusal(checkPermissions(file, STRICT));
+    const err = await refusal(checkPermissions(file, enforceAcl()));
     expect(err.message).toContain('Everyone');
     expect(err.message).toContain(file);
     expect(err.message).toContain('icacls');
@@ -126,19 +123,19 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
   async function fixUntilClean(path: string): Promise<void> {
     const subjects: string[] = [];
     for (let round = 0; round < 3; round++) {
-      const err = await checkPermissions(path, STRICT).then(() => null, (e: Error) => e);
+      const err = await checkPermissions(path, enforceAcl()).then(() => null, (e: Error) => e);
       if (err === null) break;
       subjects.push(err.message.match(/^Config (?:file|directory) (\S+)/)?.[1] ?? '?');
       await runPrescription(err.message);
     }
-    await expect(checkPermissions(path, STRICT)).resolves.toBeUndefined();
+    await expect(checkPermissions(path, enforceAcl())).resolves.toBeUndefined();
     expect(new Set(subjects).size, `a subject needed fixing twice: ${subjects.join(', ')}`)
       .toBe(subjects.length);
   }
 
   it('prescribes commands that actually fix an explicit grant', async () => {
     await run('icacls', [file, '/grant', '*S-1-1-0:(R)']);
-    await expect(checkPermissions(file, STRICT)).rejects.toThrow();
+    await expect(checkPermissions(file, enforceAcl())).rejects.toThrow();
 
     await fixUntilClean(file);
     expect((await inspectAcl(file)).status).toBe('restricted');
@@ -166,7 +163,7 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
     // too, and the file is examined first, so the message would be about the
     // file and this test would silently exercise the arm it already covers.
     await run('icacls', [dir, '/grant', '*S-1-1-0:(R)']);
-    const err = await refusal(checkPermissions(file, STRICT));
+    const err = await refusal(checkPermissions(file, enforceAcl()));
     expect(err.message).toContain('directory');
     expect(err.message).toContain('(OI)(CI)F');
 
@@ -199,7 +196,7 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
     // The fail-closed direction, end to end: a path whose ACL icacls will not
     // report must not become "unchecked, loaded anyway".
     await expect(
-      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), STRICT),
+      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), enforceAcl()),
     ).rejects.toThrow(/could not be checked/);
   });
 
@@ -207,7 +204,7 @@ describe.runIf(onWindows)('Windows ACL check, against real ACLs', () => {
     await expect(
       // Both flags: without `strict` the load happens anyway, so the assertion would
       // pass whether or not allowUnchecked did anything.
-      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), { ...STRICT, allowUnchecked: true }),
+      checkPermissions(join(dir, 'no-such-dir', 'config.toml'), enforceAcl({ allowUnchecked: true })),
     ).resolves.toBeUndefined();
   });
 });
@@ -237,7 +234,7 @@ describe.runIf(onWindows)('the default posture, against a real ACL', () => {
       expect(warnings.join('\n')).toContain('/remove:g *S-1-5-32-545');
 
       // And the same ACL still refuses when asked to enforce.
-      await expect(checkPermissions(file, STRICT)).rejects.toThrow(/readable beyond its owner/);
+      await expect(checkPermissions(file, enforceAcl())).rejects.toThrow(/readable beyond its owner/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/unit/config/windows-acl.test.ts
+++ b/test/unit/config/windows-acl.test.ts
@@ -362,3 +362,51 @@ describe('classifyReadFailure — what a failed descriptor read means', () => {
       .toMatchObject({ failure: 'read-refused' });
   });
 });
+
+describe('the rights field decides read from write', () => {
+  // The classifier, not the decision above it. The decisions suite builds Grant objects
+  // by hand, so `grantsWrite` could return a constant and nothing would fail — which is
+  // the gap that let a modify grant be reported as merely readable in the first place.
+  const grantsOf = (rights: string) => {
+    const v = parseDacl(`D:(A;;${rights};;;WD)`, ALLOWED);
+    return v.status === 'broad' ? v.grants[0] : null;
+  };
+
+  it('reads a real read-and-execute mask as read-only', () => {
+    // 0x1200a9 is what a file under C:\ inherits for BUILTIN\Users. Measured.
+    expect(grantsOf('0x1200a9')?.writes).toBe(false);
+  });
+
+  it('reads a real modify mask as write', () => {
+    // 0x1301bf is what the same inheritance gives Authenticated Users. Measured.
+    expect(grantsOf('0x1301bf')?.writes).toBe(true);
+  });
+
+  it.each(['FA', 'FW', 'WD', 'WO', 'SD', 'GA', 'GW'])('treats %s as write', (rights) => {
+    // WD here is WRITE_DAC, not Everyone: whoever can rewrite the DAC can grant
+    // themselves anything, so it is a write however narrow the other bits look.
+    expect(grantsOf(rights)?.writes).toBe(true);
+  });
+
+  it.each(['FR', 'FX', 'GR', 'FRFX'])('treats %s as read-only', (rights) => {
+    expect(grantsOf(rights)?.writes).toBe(false);
+  });
+
+  it('treats a rights field it cannot classify as write', () => {
+    // The safe direction: an unrecognised code refuses rather than reporting.
+    for (const rights of ['ZZ', 'FRZZ', 'F', '']) {
+      expect(grantsOf(rights)?.writes ?? true, rights).toBe(true);
+    }
+  });
+
+  it('distinguishes the two principals of a real drive-root descriptor', () => {
+    const v = parseDacl(DRIVE_ROOT, ALLOWED);
+    expect(v.status).toBe('broad');
+    if (v.status !== 'broad') return;
+    const byName = Object.fromEntries(v.grants.map((g) => [g.name, g.writes]));
+    // The whole basis of the default posture: one of these is a disclosure, the other is
+    // an authorization bypass, and they arrive in the same descriptor.
+    expect(byName['BUILTIN\\Users']).toBe(false);
+    expect(byName['Authenticated Users']).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #141, from a review round on it. Addresses [#138](https://github.com/tufantunc/ssh-mcp/issues/138) again.

## The finding that drove this

2.3.1 retreated too far. The ACL check never looked at the **rights** an ACE granted, so these two produced the same verdict, the same wording, and the same shrug:

```
(A;ID;0x1200a9;;;BU)   BUILTIN\Users          read & execute
(A;ID;0x1301bf;;;AU)   Authenticated Users    modify
```

Both are what a config under `C:\` inherits. The first is a disclosure; the second means any authenticated account can rewrite the file that decides which hosts, roles, approval policy and command classes this server honours — an authorization bypass. 2.3.1 reported both as "readable beyond its owner" and started.

The ambiguity that justified making the check advisory is real, but it is specific to **read** access on a shared volume. "An ACE grants a non-owner `FILE_WRITE_DATA` or `WRITE_DAC`" is exactly as unambiguous on Windows as `0o022` is on POSIX.

## The posture

| The ACL lets another account… | Default | `--strictConfigAcl` | `--allowUncheckedConfigAcl` |
|---|---|---|---|
| only **read** | reported | refused | reported |
| **change** | refused | refused | reported |
| everything (NULL DACL) | refused | refused | reported |
| ACL unreadable | refused¹ | refused | reported |

¹ except `icacls` absent or the check timing out — both statements about the machine rather than the file.

No combination leaves an operator without an exit. That is the lesson of #138 and it is now a property of the table rather than of a comment.

## Also from the round

- **Every finding reaches the caller's sink.** The advisory branch wrote straight to `console.error` — for the *strongest* verdict, while "could not check" was delivered structurally. Three reviewers independently called that the ladder upside down, and `onFinding`'s own doc forbids it.
- **One decision instead of three.** Refuse-or-report was decided in three places, twice on the same flag, with two `continue`s and two throw sites. Now: one pure `describe()`, one `waived()`, one sink. Message text is unchanged — a reviewer diffed all 12 broad/no-dacl messages against `0b49929` byte-for-byte.
- **`userInfo()` throwing turned a report into a crash.** Reachable on a Windows service under a virtual account; escaped as a raw stack, which is #138 one environment over.
- **A CodeQL claim of mine was wrong.** I wrote that the pinned action already shipped CLI 2.26.3, so no bump was needed. `defaults.json` at that SHA says 2.26.2 — 2.26.3 was released eight days later. The run *did* use 2.26.3, because the runner's toolcache had it: `Found CodeQL tools version 2.26.3 in the toolcache`. So the analysing version floats with the runner image, not with our pin. Corrected in the workflow comment and on #143.
- `echo '${{ toJSON(needs) }}'` moved into an env var; Actions scope widened from `.github/workflows` to `.github` so a composite action added later cannot fall silently out of scope.

## Verification

- 612 tests against the live containers, 29 e2e, 460 unit+property.
- **Three mutations that previously survived now fail:** reinstating 2.3.0's default (`enforce: true`), removing the read/write split, and bypassing the sink. The classifier itself is pinned separately — `grantsWrite` returning a constant survived until this PR, because the decisions suite builds `Grant` objects by hand and never went through it.
- Both flags are now tested **at their wiring** in `buildAppConfig`, not only below it. `strict: true` — reinstating the regression — survived the whole suite before that test existed, exactly as the sibling flag's mutations did one round earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)