### PR TITLE
fix: stop a timed-out or cancelled command on the host, not just in the reply

### DIFF
--- a/.changeset/exec-timeout-actually-kills.md
+++ b/.changeset/exec-timeout-actually-kills.md
@@ -1,0 +1,26 @@
+---
+"ssh-mcp": patch
+---
+
+Stop a timed-out or cancelled command on the host, instead of only reporting that we did.
+
+Reported as [#146](https://github.com/tufantunc/ssh-mcp/issues/146). `exec` closes stdin as soon as the command is dispatched, because a command that reads stdin would otherwise wait for input nobody will send. ssh2's `Channel.signal()` writes the request only while the channel is `writable` and its outgoing state is `open`, and closing stdin clears both — without throwing or reporting anything. So every signal sent to stop a command was discarded inside ssh2, and the command ran to completion on the host while the caller was told it had timed out.
+
+Measured against OpenSSH 10.3p1, one channel per row, a 30-second `sleep` as the victim:
+
+| what the client did | at +4s | at +9s |
+| --- | --- | --- |
+| `end()`, then INT / TERM / `close()` — the shipped behaviour | alive | alive |
+| INT / TERM without closing stdin first | gone | gone |
+| `end()`, then `close()` and no signal | alive | alive |
+| `end()`, then the signal sent past ssh2's check | gone | gone |
+
+Two things follow. A delivered signal is the only thing that stops a non-tty command — closing the channel does not, for the same reason killing a local `ssh host 'sleep 30'` leaves the sleep running. And this was never visible in the error: the message said "timed out" and was correct about the timeout.
+
+**Cancellation was affected too**, which the report did not mention: the same closed stdin sits in front of the abort handler, so a command an operator explicitly cancelled also kept running. For a server whose job is to gate what an agent may run, "stopped" is a claim it makes on every timeout and every cancellation, and it was not true for either.
+
+The signal now goes out past ssh2's check, so the fix needs no upstream release ([mscdex/ssh2#1510](https://github.com/mscdex/ssh2/pull/1510) is the proper repair, and ssh2 releases roughly annually). The escalation gained a rung: `INT`, `TERM`, `KILL`, then drop the channel — the old last rung was `close()`, which was measured to stop nothing, so a command ignoring the first two signals used to run forever.
+
+`KILL` never being deliverable would now be said out loud rather than assumed: if no signal reaches the wire, the error adds *"The remote command could not be signalled and may still be running on the host."* That should be unreachable today; it exists so that a future ssh2 which moves what this depends on brings back a visible failure rather than a silent one.
+
+Interactive sessions were never affected — they write `^C` into a live pty and do not close stdin while a command runs.

--- a/src/ssh/channel-signal.ts
+++ b/src/ssh/channel-signal.ts
@@ -1,0 +1,139 @@
+import type { ClientChannel } from 'ssh2';
+
+/**
+ * Stop a command running behind an exec channel — reliably, which ssh2's own
+ * `signal()` is not once stdin has been closed.
+ *
+ * `SSHConnection.exec()` closes stdin the moment the command is dispatched, because
+ * a command that reads stdin would otherwise wait for input nobody is going to send.
+ * ssh2 1.17's `Channel.signal()` (lib/Channel.js) writes the request only while
+ *
+ *     this.type === 'session' && this.writable && this.outgoing.state === 'open'
+ *
+ * and `end()` clears the last two: `_final` calls `eof()`, moving the outgoing state
+ * to `'eof'`, and sets `writable = false`. It does not throw or report anything — it
+ * simply returns. So every signal sent to stop a timed-out command was discarded
+ * inside ssh2, and the command ran to completion on the host while the caller was
+ * told it had timed out (#146).
+ *
+ * Measured against OpenSSH 10.3p1, one channel per row, a 30s `sleep` as the victim:
+ *
+ *   end() then INT/TERM/close()          alive at +4s, alive at +9s
+ *   no end(), INT/TERM                   gone by +4s
+ *   end() then close() alone             alive at +9s
+ *   eof() then INT/TERM                  alive at +9s
+ *   end() then the protocol call below   gone by +4s
+ *
+ * Two things follow. A delivered signal is the *only* thing that stops a non-tty
+ * command — closing the channel does not, which is the same reason killing a local
+ * `ssh host 'sleep 30'` leaves the sleep running. And the reporter's proposed
+ * `end()` → `eof()` change does nothing on its own, because `'eof'` fails ssh2's
+ * gate exactly as `writable === false` does; it only works together with
+ * mscdex/ssh2#1510, which relaxes the gate to accept `'eof'`.
+ *
+ * Rather than wait for that (ssh2 releases roughly annually — 1.16.0 to 1.17.0 was
+ * eleven months), this sends the request through the protocol object ssh2's own
+ * method would have used. The SSH protocol allows a channel request after EOF: EOF
+ * ends the data stream, not the channel. Only ssh2's bookkeeping objected.
+ *
+ * When ssh2 relaxes the gate the public path starts covering the `'eof'` case by
+ * itself, this fallback stops being reached, and it can be deleted — the tests in
+ * channel-signal.test.ts pin the ssh2 shape this depends on, so the upgrade that
+ * makes it unnecessary announces itself.
+ */
+
+/** The parts of a channel ssh2 does not put in its public typings. */
+type ChannelInternals = {
+  type?: string;
+  writable?: boolean;
+  outgoing?: { id?: number; state?: string };
+  _client?: { _protocol?: { signal?: (id: number, name: string) => void } };
+};
+
+/** Outgoing states in which the far end still has a channel to receive a request. */
+const OPEN_STATES = new Set(['open', 'eof']);
+
+/**
+ * Send `name` to the process behind `channel`.
+ *
+ * Returns whether the request left the client. That answer is the point: a signal
+ * that goes nowhere while reporting success is the defect this module exists to
+ * remove, so "I could not signal it" has to be sayable.
+ */
+export function signalChannel(channel: ClientChannel, name: string): boolean {
+  const ch = channel as ClientChannel & ChannelInternals;
+  const state = ch.outgoing?.state;
+
+  // Only session channels carry a process. ssh2 gates on this too, and a
+  // forwarded-tcpip channel has nothing to signal.
+  if (ch.type !== undefined && ch.type !== 'session') return false;
+  // Already closing or closed: the request would have no channel to arrive on, and
+  // ssh2 may have handed the id to a new channel.
+  if (state !== undefined && !OPEN_STATES.has(state)) return false;
+
+  // The supported path, taken whenever ssh2 will actually write the request. This is
+  // also the path that grows once ssh2 accepts `'eof'`.
+  if (ch.writable === true && state === 'open') {
+    try {
+      channel.signal(name);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const id = ch.outgoing?.id;
+  const protocol = ch._client?._protocol;
+  if (typeof id === 'number' && typeof protocol?.signal === 'function') {
+    try {
+      protocol.signal(id, name);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // A shape we do not recognise. Ask ssh2 and report failure anyway: we cannot tell
+  // whether it sent anything, and claiming delivery we cannot verify is what made
+  // this bug invisible for so long. An unnecessary "may still be running" warning is
+  // the better way to be wrong.
+  try { channel.signal(name); } catch { /* nothing left to try */ }
+  return false;
+}
+
+/** How long each signal is given to work before the next one is tried. */
+const ESCALATION_MS = 1000;
+
+/**
+ * Escalate until the command is gone: INT, then TERM, then KILL, then drop the
+ * channel.
+ *
+ * KILL is last because it denies the command any chance to clean up; it exists
+ * because the rung below it used to be `close()`, and closing a channel was measured
+ * not to stop anything. A command that ignores INT and TERM used to run forever.
+ *
+ * Returns whether the *first* signal left the client — known synchronously, so the
+ * caller can say "and it may still be running" in the same breath as the timeout it
+ * is already reporting.
+ */
+export function terminateChannel(channel: ClientChannel): boolean {
+  const delivered = signalChannel(channel, 'INT');
+
+  const pending: NodeJS.Timeout[] = [];
+  const later = (fn: () => void, ms: number) => {
+    // Unreferenced: this ladder outlives the promise it settled by up to three
+    // seconds, and a referenced timer would add that to the exit of any process
+    // whose last act was a timed-out command.
+    pending.push(setTimeout(fn, ms).unref());
+  };
+
+  const stop = () => { for (const t of pending) clearTimeout(t); pending.length = 0; };
+  // Nothing more to send once the channel is gone, and the id may be reused.
+  channel.once('close', stop);
+
+  later(() => { signalChannel(channel, 'TERM'); }, ESCALATION_MS);
+  later(() => { signalChannel(channel, 'KILL'); }, ESCALATION_MS * 2);
+  later(() => { try { channel.close(); } catch { /* already gone */ } }, ESCALATION_MS * 3);
+
+  return delivered;
+}

--- a/src/ssh/connection.ts
+++ b/src/ssh/connection.ts
@@ -8,6 +8,19 @@ import { tracer } from '../observability/tracer.js';
 import { redactText } from '../guard/redactor.js';
 import { shellSingleQuote } from '../guard/sanitizer.js';
 import { openWithRetry } from './channel-retry.js';
+import { terminateChannel } from './channel-signal.js';
+
+/**
+ * Appended when a command was stopped on our side but the signal never left the
+ * client, so the process may still be running on the host.
+ *
+ * It should be unreachable: `terminateChannel` only reports failure when ssh2 has
+ * neither a usable public method nor the internals to route around it. That is
+ * exactly the case a future ssh2 could introduce, and the whole of #146 was a
+ * stop that silently did nothing — so if it ever comes back, it says so instead.
+ */
+const MAY_STILL_RUN =
+  ' The remote command could not be signalled and may still be running on the host.';
 
 export class SSHConnection {
   readonly profile: Profile;
@@ -224,16 +237,13 @@ export class SSHConnection {
       const timeoutId = setTimeout(() => {
         if (!resolved) {
           resolved = true;
-          if (activeStream) {
-            try { activeStream.signal('INT'); } catch { /* */ }
-            setTimeout(() => {
-              try { activeStream?.signal('TERM'); } catch { /* */ }
-              setTimeout(() => { try { activeStream?.close(); } catch { /* */ } }, 1000);
-            }, 1000);
-          }
+          // No stream means the channel never opened, so there is nothing running
+          // on the host to stop — and nothing to warn about.
+          const unstopped = activeStream !== null && !terminateChannel(activeStream);
           span.setAttribute('ssh.timedOut', true);
+          if (unstopped) span.setAttribute('ssh.unstopped', true);
           span.end();
-          reject(new Error(`Command timed out after ${timeoutMs}ms`));
+          reject(new Error(`Command timed out after ${timeoutMs}ms${unstopped ? MAY_STILL_RUN : ''}`));
         }
       }, timeoutMs);
 
@@ -283,27 +293,26 @@ export class SSHConnection {
           if (opts.abortSignal.aborted) {
             resolved = true;
             clearTimeout(timeoutId);
+            // Decremented here rather than on 'close', because the close listener
+            // below is never attached on this path. The channel now outlives the
+            // count by as long as the kill ladder takes.
             this.activeChannels--;
             // client.exec() has already dispatched the command, so rejecting
             // without signalling left it running to completion on the host and
-            // held a channel until it finished.
-            try { stream.signal('INT'); } catch { /* */ }
-            try { stream.close(); } catch { /* */ }
+            // held a channel until it finished. Closing the channel does not stop
+            // it either — only a delivered signal does (#146).
+            const unstopped = !terminateChannel(stream);
             span.end();
-            reject(new Error('Command aborted before execution'));
+            reject(new Error(`Command aborted before execution${unstopped ? MAY_STILL_RUN : ''}`));
             return;
           }
           const onAbort = () => {
             if (!resolved) {
               resolved = true;
               clearTimeout(timeoutId);
-              try { stream.signal('INT'); } catch { /* */ }
-              setTimeout(() => {
-                try { stream.signal('TERM'); } catch { /* */ }
-                setTimeout(() => { try { stream.close(); } catch { /* */ } }, 1000);
-              }, 1000);
+              const unstopped = !terminateChannel(stream);
               span.end();
-              reject(new Error('Command aborted'));
+              reject(new Error(`Command aborted${unstopped ? MAY_STILL_RUN : ''}`));
             }
           };
           opts.abortSignal.addEventListener('abort', onAbort, { once: true });

--- a/test/integration/exec-kill.test.ts
+++ b/test/integration/exec-kill.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { checkAllServers, allServersUp, setupEnv, createConnection, type ServerStatus } from './fixtures.js';
+import type { SSHConnection } from '../../src/ssh/connection.js';
+
+/**
+ * #146: a timed-out or cancelled exec must not leave the command running on the host.
+ *
+ * The existing cancellation test asserts that the promise rejects with "timed out",
+ * which it always did — the defect was never in the error, it was in what happened
+ * on the other end of the connection. So every assertion here is about the remote
+ * process table, observed over a second channel.
+ *
+ * Distinctive sleep durations act as process names: `pgrep -f "^sleep 4711"` matches
+ * the command and nothing else, including not the shell that sshd wraps it in.
+ */
+let status: ServerStatus;
+let env: ReturnType<typeof setupEnv>;
+let conn: SSHConnection;
+
+const TIMEOUT_MARKER = 4711;
+const ABORT_MARKER = 4712;
+
+beforeAll(async () => {
+  status = await checkAllServers();
+  if (!allServersUp(status)) return;
+  env = setupEnv();
+  conn = await createConnection('admin');
+});
+
+afterAll(async () => { await conn?.close(); env?.restore(); });
+
+afterEach(async () => {
+  // A leaked process would otherwise sit in the container for its full duration and
+  // make the next run's count wrong rather than the next run's *behaviour* wrong.
+  await conn?.exec('pkill -f "^sleep 47" || true', { timeoutMs: 5000 }).catch(() => {});
+});
+
+/** How many copies of the marker command are running, seen over a fresh channel. */
+async function running(marker: number): Promise<number> {
+  const { stdout } = await conn.exec(`pgrep -f "^sleep ${marker}" | wc -l`, { timeoutMs: 5000 });
+  return Number(stdout.trim());
+}
+
+/** Polls, because the kill ladder is asynchronous by design (INT, then TERM, then close). */
+async function goneWithin(marker: number, ms: number): Promise<boolean> {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    if (await running(marker) === 0) return true;
+    if (Date.now() > deadline) return false;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+describe.skipIf(!allServersUp(await checkAllServers()))('a stopped exec stops on the host too', () => {
+  it('kills the remote process when the command times out', async () => {
+    const started = conn.exec(`sleep ${TIMEOUT_MARKER}`, { timeoutMs: 1500 });
+    // Sampled while the command is in flight, not after the timeout. Checking
+    // afterwards raced the fix and lost: the signal goes out synchronously with the
+    // rejection, so by the time a second channel is open the process is already
+    // gone — and a `0` there is indistinguishable from a marker that never matched.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await running(TIMEOUT_MARKER), 'the marker never matched the running command')
+      .toBeGreaterThan(0);
+
+    const err = await started.then(() => null, (e: Error) => e);
+    expect(err?.message).toMatch(/timed out/i);
+    // The other half of the contract: a stop that worked must not warn. A warning
+    // on every timeout would be as useless as the silence it replaced.
+    expect(err?.message).not.toMatch(/may still be running/);
+
+    expect(await goneWithin(TIMEOUT_MARKER, 8000), 'the remote process outlived the timeout').toBe(true);
+  }, 30000);
+
+  it('kills the remote process when the caller aborts', async () => {
+    const ac = new AbortController();
+    const started = conn.exec(`sleep ${ABORT_MARKER}`, { timeoutMs: 60000, abortSignal: ac.signal });
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await running(ABORT_MARKER), 'the marker never matched the running command')
+      .toBeGreaterThan(0);
+
+    ac.abort();
+    const err = await started.then(() => null, (e: Error) => e);
+    expect(err?.message).toMatch(/abort/i);
+    expect(err?.message).not.toMatch(/may still be running/);
+
+    expect(await goneWithin(ABORT_MARKER, 8000), 'the remote process outlived the cancellation').toBe(true);
+  }, 30000);
+});

--- a/test/integration/exec-unstoppable.test.ts
+++ b/test/integration/exec-unstoppable.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { checkAllServers, allServersUp, setupEnv, createConnection, type ServerStatus } from './fixtures.js';
+import type { SSHConnection } from '../../src/ssh/connection.js';
+
+/**
+ * The other half of #146: what the caller is told when the command *cannot* be
+ * stopped.
+ *
+ * `terminateChannel` reports failure only when ssh2 offers neither a usable public
+ * method nor the internals to route around it — which is what a future ssh2 could
+ * introduce, and is precisely the shape of this bug (a stop that silently did
+ * nothing). So the warning has to be wired, and a wired-but-untested warning is the
+ * same class of defect one layer up.
+ *
+ * It is forced here rather than waited for: the real `terminateChannel` still runs,
+ * so the command is really killed and nothing leaks, but it reports failure. That
+ * makes this a test of the message, which is the only part a real ssh2 change would
+ * leave to us.
+ */
+vi.mock('../../src/ssh/channel-signal.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/ssh/channel-signal.js')>(
+    '../../src/ssh/channel-signal.js',
+  );
+  return { ...actual, terminateChannel: (channel: never) => { actual.terminateChannel(channel); return false; } };
+});
+
+let status: ServerStatus;
+let env: ReturnType<typeof setupEnv>;
+let conn: SSHConnection;
+
+beforeAll(async () => {
+  status = await checkAllServers();
+  if (!allServersUp(status)) return;
+  env = setupEnv();
+  conn = await createConnection('admin');
+});
+
+afterAll(async () => {
+  await conn?.exec('pkill -f "^sleep 4713" || true', { timeoutMs: 5000 }).catch(() => {});
+  await conn?.close();
+  env?.restore();
+});
+
+describe.skipIf(!allServersUp(await checkAllServers()))('when the command cannot be signalled', () => {
+  it('says so instead of reporting a bare timeout', async () => {
+    const err = await conn.exec('sleep 4713', { timeoutMs: 1000 }).then(() => null, (e: Error) => e);
+    expect(err?.message).toMatch(/timed out/i);
+    expect(err?.message).toMatch(/may still be running on the host/);
+  }, 30000);
+
+  it('says so instead of reporting a bare cancellation', async () => {
+    const ac = new AbortController();
+    const started = conn.exec('sleep 4713', { timeoutMs: 60000, abortSignal: ac.signal });
+    await new Promise((r) => setTimeout(r, 300));
+    ac.abort();
+    const err = await started.then(() => null, (e: Error) => e);
+    expect(err?.message).toMatch(/abort/i);
+    expect(err?.message).toMatch(/may still be running on the host/);
+  }, 30000);
+});

--- a/test/unit/ssh/channel-signal.test.ts
+++ b/test/unit/ssh/channel-signal.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ClientChannel } from 'ssh2';
+import { signalChannel, terminateChannel } from '../../../src/ssh/channel-signal.js';
+
+/**
+ * #146: every signal ssh-mcp sent to stop a timed-out command was a silent no-op,
+ * so the command ran to completion on the host while the caller was told it had
+ * timed out.
+ *
+ * The fake channel below mirrors ssh2 1.17's `Channel.signal()` *including its
+ * silence* — the real method checks `type === 'session' && writable &&
+ * outgoing.state === 'open'` and, when that fails, returns without writing
+ * anything. A fake that recorded the call instead would pass on the broken code:
+ * we did call `signal()`, and that was exactly the problem. So there is one
+ * observation point here, `wire`, and it means "this actually left the client".
+ */
+
+interface WireEntry { id: number; name: string }
+
+function fakeChannel(overrides: Record<string, unknown> = {}) {
+  const wire: WireEntry[] = [];
+  const closeHandlers: Array<() => void> = [];
+  const channel = {
+    type: 'session',
+    writable: true,
+    outgoing: { id: 7, state: 'open' },
+    _client: { _protocol: { signal: (id: number, name: string) => { wire.push({ id, name }); } } },
+    // The real gate, reproduced.
+    signal(name: string) {
+      const self = channel as unknown as { type: string; writable: boolean; outgoing: { id: number; state: string } };
+      if (self.type === 'session' && self.writable && self.outgoing.state === 'open') {
+        channel._client._protocol.signal(self.outgoing.id, name);
+      }
+    },
+    close: vi.fn(() => { (channel.outgoing as { state: string }).state = 'closing'; }),
+    on: vi.fn((event: string, cb: () => void) => { if (event === 'close') closeHandlers.push(cb); return channel; }),
+    once: vi.fn((event: string, cb: () => void) => { if (event === 'close') closeHandlers.push(cb); return channel; }),
+    removeListener: vi.fn(),
+    ...overrides,
+  };
+  return { channel: channel as unknown as ClientChannel, wire, fireClose: () => closeHandlers.forEach((h) => h()) };
+}
+
+/**
+ * The state ssh2 leaves a channel in after `stream.end()`: EOF sent, no longer writable.
+ *
+ * A factory, not a constant. As a shared literal its `outgoing` object was shared by
+ * every fake that spread it, so the first ladder's `close()` moved *every later
+ * fake* to `'closing'` and three tests silently stopped testing anything.
+ */
+const afterStdinClosed = () => ({ writable: false, outgoing: { id: 7, state: 'eof' } });
+
+describe('signalChannel', () => {
+  it('uses ssh2\'s own method while it will still send', () => {
+    const { channel, wire } = fakeChannel();
+    const spy = vi.spyOn(channel, 'signal');
+    expect(signalChannel(channel, 'INT')).toBe(true);
+    expect(spy).toHaveBeenCalledWith('INT');
+    expect(wire).toEqual([{ id: 7, name: 'INT' }]);
+  });
+
+  // The defect itself. This is the state exec() puts every channel into, one line
+  // after dispatching the command.
+  it('still reaches the wire after stdin has been closed', () => {
+    const { channel, wire } = fakeChannel(afterStdinClosed());
+    expect(signalChannel(channel, 'TERM')).toBe(true);
+    expect(wire).toEqual([{ id: 7, name: 'TERM' }]);
+  });
+
+  it('does not call ssh2\'s method when calling it would send nothing', () => {
+    // Not cosmetic: a call that silently does nothing, reported as success, is the
+    // bug. If the public method is unusable we must know it and route around it.
+    const { channel } = fakeChannel(afterStdinClosed());
+    const spy = vi.spyOn(channel, 'signal');
+    signalChannel(channel, 'TERM');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it.each(['closing', 'closed'])('sends nothing on a %s channel', (state) => {
+    const { channel, wire } = fakeChannel({ writable: false, outgoing: { id: 7, state } });
+    expect(signalChannel(channel, 'KILL')).toBe(false);
+    expect(wire).toEqual([]);
+  });
+
+  it('sends nothing on a channel that is not a session', () => {
+    // ssh2 gates on this too: a forwarded-tcpip channel has no process to signal.
+    const { channel, wire } = fakeChannel({ type: 'direct-tcpip' });
+    expect(signalChannel(channel, 'INT')).toBe(false);
+    expect(wire).toEqual([]);
+  });
+
+  it('reports failure rather than throwing when the internals are not there', () => {
+    // The cost of routing around ssh2's public API: a future version may not
+    // expose this shape. Then the answer has to be "could not signal", not a crash
+    // and not a false success.
+    const { channel } = fakeChannel({ ...afterStdinClosed(), _client: undefined });
+    expect(signalChannel(channel, 'INT')).toBe(false);
+  });
+
+  it('reports failure when the protocol call throws', () => {
+    const { channel } = fakeChannel({
+      ...afterStdinClosed,
+      _client: { _protocol: { signal: () => { throw new Error('closed'); } } },
+    });
+    expect(signalChannel(channel, 'INT')).toBe(false);
+  });
+
+  it('reports failure when ssh2\'s own method throws', () => {
+    const { channel } = fakeChannel({ signal: () => { throw new Error('server mode'); } });
+    expect(signalChannel(channel, 'INT')).toBe(false);
+  });
+});
+
+describe('terminateChannel', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('escalates INT, TERM, KILL and then drops the channel', () => {
+    const { channel, wire } = fakeChannel(afterStdinClosed());
+    terminateChannel(channel);
+    expect(wire.map((w) => w.name)).toEqual(['INT']);
+    vi.advanceTimersByTime(1000);
+    expect(wire.map((w) => w.name)).toEqual(['INT', 'TERM']);
+    vi.advanceTimersByTime(1000);
+    expect(wire.map((w) => w.name)).toEqual(['INT', 'TERM', 'KILL']);
+    expect(channel.close).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(channel.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports whether the first signal left the client', () => {
+    expect(terminateChannel(fakeChannel(afterStdinClosed()).channel)).toBe(true);
+    expect(terminateChannel(fakeChannel({ ...afterStdinClosed(), _client: undefined }).channel)).toBe(false);
+  });
+
+  it('stops escalating once the channel closes', () => {
+    // KILL costs the command its chance to clean up, so it is only for a process
+    // that ignored the gentler two. Sending it after the process is already gone
+    // also races a channel id that ssh2 may have reused.
+    const { channel, wire, fireClose } = fakeChannel(afterStdinClosed());
+    terminateChannel(channel);
+    fireClose();
+    vi.advanceTimersByTime(5000);
+    expect(wire.map((w) => w.name)).toEqual(['INT']);
+    expect(channel.close).not.toHaveBeenCalled();
+  });
+
+  it('does not hold the process open while it waits', () => {
+    // The ladder outlives the promise it settled by up to three seconds. Left
+    // referenced, that is three seconds added to every `--version`-style exit and
+    // to every vitest file that timed a command out.
+    vi.useRealTimers();
+    const handles: Array<{ hasRef?: () => boolean }> = [];
+    const real = globalThis.setTimeout;
+    const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((fn: never, ms: never) => {
+      const h = real(fn, ms);
+      handles.push(h as unknown as { hasRef?: () => boolean });
+      return h;
+    }) as never);
+    try {
+      terminateChannel(fakeChannel(afterStdinClosed()).channel);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(handles.length).toBeGreaterThan(0);
+    expect(handles.every((h) => h.hasRef?.() === false)).toBe(true);
+    handles.forEach((h) => clearTimeout(h as never));
+  });
+});
+
+describe('the ssh2 internals this depends on', () => {
+  /**
+   * A tripwire, not a test of our code. `signalChannel` falls back to
+   * `channel._client._protocol.signal(id, name)` because ssh2's public method
+   * refuses to send after EOF (mscdex/ssh2#1510). If a future ssh2 renames or
+   * removes that path, the failure should say so here rather than surface as a
+   * mysterious integration test about a `sleep` that would not die.
+   */
+  it('still exposes Protocol.prototype.signal', async () => {
+    // Loaded through createRequire: this is a deep path into ssh2 that its typings
+    // do not describe, which is itself part of what makes the fallback a liability
+    // worth a tripwire.
+    const { createRequire } = await import('module');
+    const Protocol = createRequire(import.meta.url)('ssh2/lib/protocol/Protocol.js');
+    expect(typeof Protocol.prototype.signal).toBe('function');
+  });
+
+  it('still refuses to signal a channel whose stdin is closed', async () => {
+    // The reason the fallback exists, read out of ssh2 rather than assumed. If
+    // this stops being true, the fallback is dead weight and can go.
+    const { readFile } = await import('fs/promises');
+    const source = await readFile(
+      new URL('../../../node_modules/ssh2/lib/Channel.js', import.meta.url),
+      'utf8',
+    );
+    const signalMethod = source.slice(source.indexOf('  signal(signalName) {'));
+    expect(signalMethod).toContain('this.writable');
+    expect(signalMethod.slice(0, signalMethod.indexOf('}'))).toContain("outgoing.state === 'open'");
+  });
+});


### PR DESCRIPTION
Fixes #146. Thanks to @paulcakeface — the report was right on every point, and the ssh2-layer analysis in it saved most of the work.

## The defect

`exec` closes stdin as soon as the command is dispatched ([connection.ts:280](https://github.com/tufantunc/ssh-mcp/blob/main/src/ssh/connection.ts#L280)), because a command that reads stdin would otherwise wait for input nobody will send. ssh2 1.17's `Channel.signal()` writes the request only while

```js
this.type === 'session' && this.writable && this.outgoing.state === 'open'
```

and `end()` clears the last two: `_final` calls `eof()` (state → `'eof'`) and sets `writable = false`. It does not throw. It returns. So every signal we sent to stop a timed-out command was discarded inside ssh2, and the command ran to completion on the host.

## What I measured

Against a real OpenSSH 10.3p1 target, one channel per row, a 30-second `sleep` as the victim, observed over a second channel:

| what the client did | +4s | +9s |
|---|---|---|
| `end()`, then INT / TERM / `close()` — **shipped behaviour** | **alive** | **alive** |
| INT / TERM without closing stdin | gone | gone |
| `end()`, then `close()`, no signal | alive | alive |
| `eof()`, then INT / TERM (unpatched ssh2) | alive | alive |
| `end()`, then the signal sent past ssh2's check | gone | gone |
| any variant with a pty | gone | gone |

Three conclusions. A **delivered signal is the only thing that stops a non-tty command** — closing the channel does not, which is the same reason killing a local `ssh host 'sleep 30'` leaves the sleep running. `tty: true` profiles were never affected, because closing a pty channel hangs up the session. And row 4 matters for the proposed fix: **`end()` → `eof()` does nothing on its own**, because `'eof'` fails ssh2's check exactly as `writable === false` does — it works only together with mscdex/ssh2#1510.

## Why not wait for upstream

[mscdex/ssh2#1510](https://github.com/mscdex/ssh2/pull/1510) is the correct repair and I hope it lands. But ssh2 ships roughly annually (1.16.0 → 1.17.0 was eleven months), so "we'll fix it when that releases" is an open-ended deferral of a live defect. Row 6 of the table is the way out: the request goes through the protocol object ssh2's own method would have used. A channel request after EOF is legal SSH — EOF ends the data stream, not the channel. Only ssh2's bookkeeping objected.

When ssh2 relaxes the check, the public path starts covering `'eof'` by itself, the fallback stops being reached, and it can be deleted.

## Cancellation was broken too

Not in the report, and worse than the timeout: the same closed stdin sits in front of the abort handler, so a command an operator **explicitly cancelled** also kept running. Both the abort path and the abort-before-execution path are fixed; the latter used to `close()` the channel immediately, which stopped nothing.

For a server whose job is to gate what an agent may run, "stopped" is a claim it makes on every timeout and every cancellation. It was true for neither.

## Two behaviour changes worth naming

- **The ladder gained a rung: `INT` → `TERM` → `KILL` → drop the channel.** The old last rung was `close()`, measured to stop nothing, so a command that ignored INT and TERM ran forever. `KILL` is last because it denies the command any chance to clean up.
- **If no signal reaches the wire, the error says so**: *"The remote command could not be signalled and may still be running on the host."* That should be unreachable today — it needs an ssh2 with neither a usable public method nor the internals to route around it. It exists so that a future ssh2 which moves what this depends on brings back a *visible* failure rather than the silent one this PR is about. A tripwire test pins the ssh2 shape, so the upgrade that makes the fallback unnecessary announces itself as a unit-test failure rather than a mysterious `sleep` that will not die.

## Why this survived the existing tests

[cancellation.test.ts:20](https://github.com/tufantunc/ssh-mcp/blob/main/test/integration/cancellation.test.ts#L20) asserted that the promise rejects with `/timed out/` — which it always did. The error was never wrong; the effect was. So every new assertion here is about the **remote process table**, observed over a second channel, and one of them checks that a successful stop does *not* warn, so the warning cannot become noise on every timeout.

Verified:

- the two integration cases fail on the parent commit and pass here;
- six mutations die — removing the fallback (7 tests), dropping the `KILL` rung, dropping the `unref` on the ladder's timers, dropping the cancel-on-close, never appending the warning, and restoring the old timeout path;
- full suite 633 passed / 21 skipped against the live containers, 29 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)