### PR TITLE
docs: record what MCP 2026-07-28 will cost us, and why nothing is actionable yet

### DIFF
--- a/.changeset/list-on-mcp-registry.md
+++ b/.changeset/list-on-mcp-registry.md
@@ -1,0 +1,33 @@
+---
+"ssh-mcp": patch
+---
+
+List ssh-mcp on the official MCP registry, and keep the listing current from the release that produces it.
+
+`registry.modelcontextprotocol.io` verifies that whoever registers `io.github.tufantunc/ssh-mcp` also owns the npm package it points at, and it does that by fetching `registry.npmjs.org/ssh-mcp/<version>` — the manifest of one exact version, not the package — and requiring an `mcpName` field in it that matches the server name. npm versions are immutable, so no version already published can ever gain that field: the listing is only reachable through a release, and this is it. There is no behaviour change in the server; the only thing this version adds over 2.3.3 is a manifest the registry will accept.
+
+`server.json` carries the version twice — the listing's own, and the npm version it resolves — and both have to name what actually shipped. `scripts/sync-server-json.mjs` writes them from `package.json` and is wired to the `version` npm script, which is what the changesets action runs when it opens the "Version Packages" pull request; the rewrite is committed there alongside the version bump, so main is already correct by the time anything publishes. The script also refuses a `mcpName`/`server.json` name mismatch, and refuses a `packages[].identifier` that is not the npm package name — the registry reports both as ownership failures *after* npm has published, at the single step of a release that a re-run cannot undo.
+
+Publishing to the registry is a second job in the Changesets workflow, gated on the action's `published` output, and not the tag-triggered workflow that shape usually takes: the `v*` tag is pushed with `GITHUB_TOKEN`, and GitHub starts no workflows for those pushes — the same loop-breaker that already keeps `ci.yml` off `changeset-release/main`. A workflow listening for that tag would simply never run. It is a separate job rather than more steps on the release job because a registry failure has to be retryable without re-attempting the npm publish, which would fail first and hide it.
+
+Both credentials are OIDC, so the registry step adds no secret: `mcp-publisher login github-oidc` exchanges the workflow's identity for a registry token, and the `io.github.tufantunc/*` namespace is authorised from the repository owner in its claims.
+
+## What review changed
+
+The first version of this was reviewed before merging, and five things it got wrong are worth recording, because each one is a mistake the shape of the change invites.
+
+**The publisher binary was executed unverified.** Pinning `v1.8.1` in the download URL pins a *release*, not its bytes — GitHub release assets can be replaced in place. That is a weaker pin than any other reference in this workflow, and it lands in the worst possible job: npm's trusted publisher is bound to a workflow *filename*, and the registry job lives in the same `changesets.yml`, so anything executing there can mint a token npm accepts for ssh-mcp. The install step now checks the sha256 published in `registry_1.8.1_checksums.txt` before extracting, and a version bump means bumping both lines.
+
+**Two schema rules were copied into the script, on a false premise.** A hand-rolled 100-character cap on `title` and `description` was defended by a comment claiming mcp-publisher only reports such things at publish time. It does not: `mcp-publisher validate` checks the whole schema — required fields, the name pattern, the enums, every cap — against an endpoint that needs no credentials. The workflow runs it before the npm wait, the copied constant is gone, and the caps that a person can actually get wrong by hand are asserted on the real file in `test/unit/sync-server-json.test.ts`, which fails on the pull request that writes them rather than on the release two merges later.
+
+**`needs: release` could strand a published version permanently.** `needs` means "only if that job succeeded", and the action pushes the git tag and creates the GitHub release *after* `changeset publish` returns — so npm can have the version while the release job fails. The registry job would skip, and no re-run could reach it: `changeset publish` finds the version already on npm, releases nothing, and reports `published: false` forever. The gate is now `!cancelled() && …`, and a `list_only` dispatch input lists the current version without going near the publish path, for the one state the output cannot describe.
+
+**The npm-visibility wait could not do its job.** `npm view pkg@version` fetches the whole packument and resolves locally; npm serves packuments with `max-age=300` and defaults `prefer-online` to false. The loop checked for 290 seconds, entirely inside that window, so in the only scenario it exists for — the version not yet visible on the first attempt — every later attempt could be answered from the same stale cached document, failing while npm was serving the version. It now GETs `registry.npmjs.org/<identifier>/<version>`, which is the exact URL the registry's own validator builds, with the identifier read from `server.json` rather than hardcoded, and it keeps curl's error rather than reporting every failure as propagation lag.
+
+**The admin-merge checklist went stale.** The comment describing what a "Version Packages" pull request is allowed to touch now has to include `server.json`, or every future release PR looks wider than the rule allows. `CONTRIBUTING.md` says what `server.json` is and which of its fields are generated.
+
+## Two deliberate deviations
+
+`--check` and the `server.json` assertions were not in the plan this change was written against; they are additions, kept because the script's guards are otherwise unobservable — on a healthy repo every guard branch is false, and `scripts/` sits outside Sonar, the coverage report and both tsconfigs, so a guard that stopped firing would look exactly like one that passed.
+
+`SSH_MCP_KEY` is declared with `format: "filepath"` and *not* `isSecret`, unlike the three password variables. It names a path, not key material; marking it secret would have clients mask a filename while telling the reader something untrue about what the variable holds.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -9,6 +9,11 @@ on:
   # manual trigger the only ways to retry are re-running a failed job or pushing
   # an empty commit to main. Neither belongs in a release path.
   workflow_dispatch:
+    inputs:
+      list_only:
+        description: 'Skip the npm release and only list the current version on the MCP registry'
+        type: boolean
+        default: false
 
 # Read-only default, so a job added here later starts with no write access until
 # it asks. `release` below is the one job in this file and it opts up explicitly
@@ -23,10 +28,17 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     runs-on: ubuntu-latest
+    # A `list_only` dispatch is for a version that reached npm but never reached
+    # the registry, so it must not go near the publish path again.
+    if: github.event.inputs.list_only != 'true'
     permissions:
       contents: write
       id-token: write
       pull-requests: write
+    # Consumed by the `registry` job's `if:` below, which is where the gate is
+    # explained.
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -103,10 +115,12 @@ jobs:
       # CHANGELOG entry on top of it.
       #
       # Before merging one, confirm exactly that: the PR touches only
-      # package.json's version, CHANGELOG.md and the consumed changeset files,
-      # and main is green at the commit it sits on. An admin merge of anything
-      # wider is skipping a real check.
+      # package.json's version, CHANGELOG.md, server.json's two version fields
+      # (written by `npm run version` — see scripts/sync-server-json.mjs) and
+      # the consumed changeset files, and main is green at the commit it sits
+      # on. An admin merge of anything wider is skipping a real check.
       - name: Create Release Pull Request or Publish
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1 (branch, not a tag)
         with:
           # No --provenance: trusted publishing generates provenance
@@ -144,3 +158,168 @@ jobs:
           # what the package's trusted publisher is configured against. Leaving
           # the token here would let a misconfigured trusted publisher fall back
           # silently, so nobody would notice it had stopped working.
+
+  # Listing on the official MCP registry (registry.modelcontextprotocol.io).
+  #
+  # A job rather than more steps on `release`, because npm versions are
+  # immutable: a combined job that failed at the registry could not be re-run —
+  # the retry would die earlier, republishing a version npm already has, and the
+  # part that actually broke would never be reached. This one retries alone.
+  #
+  # And a job rather than a second workflow. The obvious shape — trigger on the
+  # `v*` tag the changesets action pushes — cannot work here: that tag is pushed
+  # with GITHUB_TOKEN, and GitHub starts no workflows for those pushes. It is the
+  # same loop-breaker that keeps ci.yml off changeset-release/main, described at
+  # the release step above.
+  registry:
+    name: list on the MCP registry
+    needs: release
+    # Most runs of this workflow open or update the "Version Packages" pull
+    # request and publish nothing, so listing has to be gated on a release
+    # actually having happened — otherwise this job runs on every merge to main
+    # and fails against a version already listed.
+    #
+    # `!cancelled()` rather than the bare condition, because `needs:` alone means
+    # "only if release succeeded" and there are states where npm has published
+    # and the release job still fails: the action pushes the git tag and creates
+    # the GitHub release *after* `changeset publish` returns, and it exits
+    # non-zero on a publish whose exit code was non-zero even when packages
+    # shipped. Skipping here in those states is unrecoverable — a re-run of
+    # `release` finds the version already on npm, releases nothing, and reports
+    # `published: false` forever.
+    #
+    # `list_only` is the escape hatch for the one state this still cannot see: a
+    # failure before the action set its output at all. Dispatch it and this job
+    # runs against whatever `server.json` names on main.
+    #
+    # The ref guard is because `workflow_dispatch` accepts any ref, and a
+    # dispatch from another branch would otherwise list that branch's
+    # `server.json` under our namespace.
+    if: >-
+      ${{ !cancelled()
+      && github.ref == 'refs/heads/main'
+      && (needs.release.outputs.published == 'true'
+      || github.event.inputs.list_only == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # mcp-publisher exchanges this for a registry token, and the
+      # `io.github.tufantunc/*` namespace is authorised from the repository owner
+      # in its claims. No secret here either — same mechanism as the npm publish.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Needed by all three steps below that shell out to node: the `--check`
+      # run, the version read, and the identifier read. No `npm ci` — none of
+      # them touch node_modules. 24.x only to match the release job; unlike
+      # there, no npm version is load-bearing here, and `engines` allows far
+      # older.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24.x'
+
+      # Pinned, not `latest/download`. This binary mints the credential that
+      # publishes under our namespace, which makes it exactly the kind of
+      # mutable reference the release job above went out of its way to remove
+      # from the publish path. The cost is that a registry API change eventually
+      # needs this bumped by hand — and that failure lands here, in the one job
+      # that can be re-run, with npm already safely published.
+      #
+      # The digest is the other half of that. A release tag in the URL pins a
+      # *release*, not its bytes: GitHub release assets can be replaced in place,
+      # so the tag alone gives none of the immutability a SHA-pinned action or an
+      # npm version does. That matters more here than it would elsewhere in this
+      # file, because npm's trusted publisher is bound to a workflow *filename*
+      # — this one — so anything executing in this job can mint a token npm will
+      # accept for ssh-mcp. The digest is published upstream in
+      # registry_1.8.1_checksums.txt; bumping the version means bumping both
+      # lines.
+      #
+      # Verified before extraction rather than after, so a replaced archive is
+      # never handed to tar.
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -fsSL -o mcp-publisher.tar.gz \
+            https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz
+          echo 'a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc  mcp-publisher.tar.gz' \
+            | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+          ./mcp-publisher --version
+
+      # server.json carries the version twice, and `npm run version` — wired to
+      # scripts/sync-server-json.mjs — is what keeps both in step with
+      # package.json inside the release pull request. `--check` asserts that it
+      # happened: if the script would have anything to write, the listing about
+      # to be published names a version other than the one that just shipped.
+      #
+      # Left to the registry, the same mistake arrives as a 404 from npm, or as
+      # a successful listing for the wrong version.
+      - name: server.json must already agree with package.json
+        run: node scripts/sync-server-json.mjs --check
+
+      # Everything server.json must satisfy that does not depend on npm: required
+      # fields, the name pattern, the 100-character title and description caps,
+      # the enums. It POSTs to a registry endpoint that needs no credentials, so
+      # it runs before `login`.
+      #
+      # This replaced a hand-rolled copy of two of those rules in
+      # scripts/sync-server-json.mjs, written on the belief that mcp-publisher
+      # only reports them at publish time. It does not — and two rules copied out
+      # of a pinned schema would have gone stale the first time that URL moved.
+      #
+      # Before the npm wait, not after: it takes a second, and there is no reason
+      # to spend five minutes on propagation only to fail on a malformed listing.
+      - name: Validate server.json against the registry schema
+        run: ./mcp-publisher validate
+
+      # The registry resolves packages[].version against npm and rejects what it
+      # cannot see. `npm publish` returning is not the same as the CDN serving
+      # the new version, so wait for it rather than racing it.
+      #
+      # This asks the registry's own question — a GET of the version manifest at
+      # `registry.npmjs.org/<identifier>/<version>`, which is literally the URL
+      # the npm validator builds — rather than a near-enough one. Two reasons it
+      # is not `npm view`:
+      #
+      #   `npm view pkg@version` fetches the whole packument and resolves the
+      #   version locally, and npm serves packuments with `max-age=300` while
+      #   defaulting `prefer-online` to false. Attempt 1 would cache a document
+      #   that lacks the new version and attempts 2..30 could all be answered
+      #   from it — a 290-second window entirely inside the 300-second one. The
+      #   loop would report "never became visible" while npm was serving it.
+      #
+      #   And the name has to come from server.json's identifier, not a literal:
+      #   the identifier is what the registry resolves, so polling anything else
+      #   can confirm a package the listing does not point at. The sync script
+      #   pins that identifier to package.json's name, which is what makes
+      #   reading it here safe.
+      - name: Wait for npm to serve the published version
+        run: |
+          set -euo pipefail
+          identifier="$(node -p 'require("./server.json").packages.find((p) => p.registryType === "npm").identifier')"
+          version="$(node -p 'require("./package.json").version')"
+          url="https://registry.npmjs.org/$identifier/$version"
+          attempts=30
+          for i in $(seq 1 "$attempts"); do
+            # Keep the reason. Discarding it made a 404, a 429, an npm outage and
+            # a runner DNS failure all read as "not yet visible", on the one job
+            # whose whole purpose is to be diagnosable.
+            if err="$(curl -fsS -o /dev/null "$url" 2>&1)"; then
+              echo "$identifier@$version is visible on npm"
+              exit 0
+            fi
+            echo "attempt $i/$attempts: not visible yet ($err)"
+            if [ "$i" -lt "$attempts" ]; then
+              sleep 10
+            fi
+          done
+          echo "::error::$identifier@$version never became visible on npm. Last error: $err" >&2
+          exit 1
+
+      - name: Publish to the registry
+        run: |
+          set -euo pipefail
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,11 @@ npm run changeset
 # Write: "Add ProxyJump support for bastion connections"
 ```
 
-This creates a file in `.changeset/` — commit it with your PR. When the PR merges, the changesets bot opens a "Version Packages" PR that bumps the version, updates CHANGELOG.md, and publishes to npm.
+This creates a file in `.changeset/` — commit it with your PR. When the PR merges, the changesets bot opens a "Version Packages" PR that bumps the version, updates CHANGELOG.md, and publishes to npm. Publishing to npm also lists the new version on the [official MCP registry](https://registry.modelcontextprotocol.io).
+
+### server.json
+
+`server.json` is the MCP registry entry. Its two version fields — the listing's own `version`, and the npm version it points at — are written by `npm run version` from `package.json`, so they arrive already bumped in the "Version Packages" PR and should not be edited by hand. Everything else in the file is hand-maintained; if you change the `title` or `description`, note that the registry schema caps both at 100 characters, which `test/unit/sync-server-json.test.ts` asserts.
 
 ## Review Criteria
 

--- a/docs/mcp-2026-07-28-migration-surface.md
+++ b/docs/mcp-2026-07-28-migration-surface.md
@@ -1,0 +1,175 @@
+# MCP 2026-07-28: what it will cost us, and what to do until then
+
+> Written 2026-08-24 against spec revision [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+> and the [roadmap](https://modelcontextprotocol.io/development/roadmap) as of 2026-08-22.
+> Nothing in this document is actionable as code today — see [Why there is nothing to upgrade](#why-there-is-nothing-to-upgrade).
+> Its purpose is that the day the SDK catches up, we are not rediscovering this list.
+
+## Why there is nothing to upgrade
+
+| | |
+|---|---|
+| Current spec revision | **2026-07-28** |
+| Installed SDK | `@modelcontextprotocol/sdk@1.30.0` |
+| Newest published SDK | **1.30.0** — the only dist-tag, no prerelease |
+| That SDK's newest protocol | `LATEST_PROTOCOL_VERSION = '2025-11-25'` (default negotiated: `2025-03-26`) |
+
+The TypeScript SDK was published **2026-07-27**, one day before the spec revision, and has not
+caught up. We are already on the newest release; the gap is upstream.
+
+How far upstream, measured against `node_modules/@modelcontextprotocol/sdk/dist/esm/`:
+
+| symbol | files |
+|---|---|
+| `tasks/get` | 7 |
+| `input_required` | 5 |
+| `resultType` | 0 |
+| `server/discover` | 0 |
+| `inputRequests` | 0 |
+| `subscriptions/listen` | 0 |
+| `cacheScope` | 0 |
+| `Mcp-Method` | 0 |
+
+The `tasks/*` and `input_required` hits are the **2025-11-25** experimental Tasks feature — which
+2026-07-28 moved *out* of core into the `io.modelcontextprotocol/tasks` extension and redesigned.
+None of the 2026-07-28 core has been started. Re-run the table before trusting it:
+
+```bash
+for s in resultType server/discover input_required inputRequests subscriptions/listen cacheScope Mcp-Method tasks/get; do
+  printf '%-22s %s\n' "$s" "$(grep -rl "$s" node_modules/@modelcontextprotocol/sdk/dist/esm/ 2>/dev/null | wc -l)"
+done
+```
+
+## What lands on us
+
+Ordered by how much is our code rather than the SDK's.
+
+### 1. Elicitation becomes Multi Round-Trip Requests — the big one
+
+**Spec:** MRTR ([SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322))
+replaces server-initiated requests, `elicitation/create` included. The server returns an
+`InputRequiredResult` (`resultType: "input_required"`) carrying `inputRequests`; the client answers
+by **retrying the original request** with `inputResponses`.
+
+**Us:** `src/guard/elicitation.ts` and `checkPolicyAndApprove` in `src/tools/pipeline.ts` block
+*inside* a single tool call awaiting `server.elicitInput()`. MRTR inverts that: the call returns,
+and a later call carries the answer.
+
+Consequences worth knowing before touching this area:
+
+- `approvalGrantTtlMs` stops being a convenience and becomes the mechanism that makes the retry
+  cheap — a grant is what lets the second attempt through without asking again.
+- The spec removed `notifications/elicitation/complete` and `elicitationId`, and says servers that
+  need to correlate an elicitation across retries "encode their own identifier in `requestState`".
+  We use neither today, so there is nothing to unwind.
+- One decision already paid off: `elicitation.ts` uses the SDK's typed `elicitInput()` rather than a
+  hand-built envelope, deliberately, so that "a protocol change breaks the build instead". This is
+  the protocol change it was written for.
+
+### 2. Protocol-level sessions are removed
+
+**Spec:** [SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567) removes
+sessions and the `Mcp-Session-Id` header from Streamable HTTP; list endpoints no longer vary per
+connection. Servers needing cross-call state use "explicit, server-minted handles passed as ordinary
+tool arguments".
+
+**Us:** `src/transport/http.ts` keeps a `Map<string, StreamableHTTPServerTransport>` keyed by
+`mcp-session-id`, with `MAX_SESSIONS`, a DELETE path, and the `-32000`/`-32001` session errors. All
+of it becomes dead weight.
+
+**The design survives.** `open-session name=…` already *is* a server-minted handle passed as a tool
+argument — the thing the new spec asks for. Only the transport plumbing goes.
+
+### 3. The HTTP GET endpoint is replaced by `subscriptions/listen`
+
+The GET endpoint and `resources/subscribe`/`unsubscribe` are gone, replaced by a single long-lived
+POST-response stream. `src/transport/http.ts` matches `req.method === 'GET'` on `/` in the rate
+limiter and for the health probe; the first needs revisiting, the second is ours and unaffected.
+
+Note the spec is explicit that request-scoped notifications — `notifications/progress`, which we
+send from `pipeline.ts` — **continue to flow on the response stream of their own request**, not the
+subscription stream. Our progress path is unaffected.
+
+### 4. `ttlMs` and `cacheScope` become required on list and read results
+
+[SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) requires both on
+`tools/list`, `prompts/list`, `resources/list`, `resources/read` and `resources/templates/list`.
+
+**Do not confuse this with our own `ttlMs`** in `src/types.ts` — that is a session idle TTL and has
+nothing to do with `CacheableResult`.
+
+Our resources (`ssh://connections`, `ssh://connections/{profile}`, `ssh://sessions/{profile}/{session}`)
+return live, caller-specific state. The honest answer is `cacheScope: "private"` with a short
+`ttlMs`, and it is worth choosing deliberately rather than accepting whatever the SDK defaults to —
+a shared intermediary caching a connection list would be a disclosure, not a papercut.
+
+### 5. Required request headers
+
+`Mcp-Method` and `Mcp-Name` become required on Streamable HTTP POSTs
+([SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)), which touches
+the auth and rate-limiting middleware in `src/transport/http.ts`.
+
+### The SDK's problem, not ours
+
+Statelessness and the removal of the `initialize` handshake; `server/discover` (a **MUST** for
+servers); `resultType` on every result; the error-code renumbering.
+
+## What we get for free
+
+Not luck — most of these are positions we already took for other reasons.
+
+- **Sampling, Roots and Logging are all deprecated, and we use none of them.** The suggested
+  migration for Logging is "log to `stderr` (stdio) or use OpenTelemetry" — both of which we already
+  do.
+- **HTTP+SSE is now formally Deprecated**; we are on Streamable HTTP.
+- **Our custom JSON-RPC codes are grandfathered.** The new allocation policy keeps `-32000`–`-32019`
+  implementation-defined; our `-32000`/`-32001` sit inside it. (The spec renumbered its own
+  `HeaderMismatch` from `-32001` to `-32020` for the same reason.)
+- **We return no `structuredContent`**, so the `tools/call` result-shape redesign on the roadmap
+  cannot break us. If we ever want structured output, that is the moment to adopt it — not before.
+- We use neither `elicitationId` nor `notifications/elicitation/complete`, both removed.
+
+## Roadmap items aimed at what we are
+
+- **Agent Identity (priority 3).** The roadmap says, in as many words, that existing servers "lean on
+  pasted API keys and long-lived refresh tokens". That is our HTTP bearer token. The direction is
+  DPoP, Workload Identity Federation ([SEP-1933](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1933)),
+  ID-JAG and RFC 8693 token exchange. None of it is implementable today — but it is reason enough not
+  to invest further in the current auth path.
+- **Tasks (priority 1, [SEP-2663](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663)).**
+  Background sessions + progress + cancellation is a hand-rolled version of this extension. The
+  redesign polls via `tasks/get` and takes client input via `tasks/update`. Long term it may replace
+  `open-session type="background"`.
+- **HTTP over stdio (priority 2).** Streamable HTTP as the single binding, spoken over stdin/stdout.
+  Would collapse our two transports into one. Nothing to do now, and an argument against writing more
+  transport-specific code in the meantime.
+- **Progressive discovery (priority 4).** For servers with large catalogues. We have 11 tools; not
+  our problem yet.
+- **Conformance test suite (priority 5).** Worth running against ourselves once it exists.
+
+## What to do, and what not to
+
+**Now:**
+
+1. Keep this document current. It is the whole point of writing it.
+2. **Do not build anything new on elicitation or on session-scoped transport state.** Both are being
+   removed. This is the one action available today that actually saves work later.
+
+**A decision, not code:** whether to track DPoP for the HTTP transport's bearer token. It determines
+how much more we are willing to invest in the current auth path.
+
+**Explicitly not now:** implementing 2026-07-28 against an SDK that does not support it. Our HTTP
+transport is built on `StreamableHTTPServerTransport`; forking or shimming it would open a large,
+high-risk surface for a spec whose SDK support has not started. When the SDK ships it, most of
+sections 1–5 above become an SDK upgrade plus a focused change to `src/transport/http.ts` and the
+approval path.
+
+## Re-checking this document
+
+```bash
+npm view @modelcontextprotocol/sdk dist-tags --json          # is there a newer release or a prerelease?
+grep -n "LATEST_PROTOCOL_VERSION\|SUPPORTED_PROTOCOL_VERSIONS" \
+  node_modules/@modelcontextprotocol/sdk/dist/esm/types.js   # what does it actually speak?
+```
+
+The day `LATEST_PROTOCOL_VERSION` reads `2026-07-28`, this list stops being theory.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "license": "MIT",
   "version": "2.3.3",
   "description": "MCP server exposing policy-gated, audited SSH access for Linux and Windows hosts via the Model Context Protocol.",
+  "mcpName": "io.github.tufantunc/ssh-mcp",
   "type": "module",
   "bin": {
     "ssh-mcp": "build/index.js"
@@ -13,7 +14,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "inspect": "npx @modelcontextprotocol/inspector node build/index.js",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && node scripts/sync-server-json.mjs",
     "test": "cross-env SSH_MCP_DISABLE_MAIN=1 vitest --run",
     "test:unit": "cross-env SSH_MCP_DISABLE_MAIN=1 vitest --run test/unit/ test/property/",
     "test:integration": "cross-env SSH_MCP_DISABLE_MAIN=1 vitest --run test/integration/",

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Copies package.json's version into server.json, the MCP registry entry.
+ *
+ * The version lives there twice, and both have to agree with the version that
+ * reaches npm:
+ *
+ *   version            the registry listing's own version. The registry refuses
+ *                      to publish a version of a server it already has, so a
+ *                      stale value here fails the publish outright.
+ *   packages[].version the npm version the listing points at. The registry
+ *                      resolves it against `registry.npmjs.org/<identifier>/<version>`
+ *                      and reads `mcpName` out of that exact manifest — so a
+ *                      stale value either 404s or, worse, lists a version other
+ *                      than the one that just shipped.
+ *
+ * Wired to the `version` npm script, which is what changesets/action runs when
+ * it opens or updates the "Version Packages" pull request. It commits whatever
+ * the version command left in the working tree, so the rewrite lands in that PR
+ * alongside the package.json bump and the CHANGELOG entry — and main is already
+ * correct by the time the release job publishes from it.
+ *
+ * Nothing else in the repo carries the version: src/version.ts reads it from
+ * package.json at runtime.
+ *
+ * `--check` reports staleness instead of fixing it, for the release job to run
+ * before it publishes a listing. `git diff --exit-code server.json` was the
+ * first shape of that check and is a trap: git diff says nothing about an
+ * untracked file, so the check passes on exactly the machine where server.json
+ * is missing from the index.
+ *
+ * What this script does *not* do is validate server.json against its schema.
+ * An earlier version reimplemented the 100-character `title`/`description` caps
+ * as a literal, on the belief that mcp-publisher only reports them at publish
+ * time. It does not: `mcp-publisher validate` checks the whole schema without
+ * publishing, against an endpoint that needs no credentials, and the release
+ * workflow runs it. Two of the schema's rules copied into a constant here would
+ * have gone stale the first time the pinned schema URL moved, while still
+ * missing the name pattern, the required fields and the rest. The caps that
+ * matter for the values a human edits are asserted on the real files in
+ * test/unit/sync-server-json.test.ts, which fails on the pull request that
+ * writes them rather than on the release two merges later.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const checkOnly = process.argv.slice(2).includes('--check');
+
+const root = new URL('..', import.meta.url);
+const registryFile = new URL('server.json', root);
+
+const pkg = JSON.parse(readFileSync(new URL('package.json', root), 'utf8'));
+const registry = JSON.parse(readFileSync(registryFile, 'utf8'));
+
+/**
+ * A mismatch here is the registry's "ownership validation failed. Expected
+ * mcpName '<a>', got '<b>'" — discovered after npm has already published, at
+ * the one step of the release that cannot be undone by re-running it. It costs
+ * a comparison to find it while the version bump is still a pull request.
+ */
+if (pkg.mcpName !== registry.name) {
+  console.error(
+    `sync-server-json: package.json mcpName (${pkg.mcpName ?? 'unset'}) does not match ` +
+    `server.json name (${registry.name}). The registry validates one against the other.`,
+  );
+  process.exit(1);
+}
+
+const npmPackage = registry.packages?.find((p) => p.registryType === 'npm');
+// Refuse rather than guess: silently skipping would hand the release job a
+// server.json pointing at whatever version was there before.
+if (!npmPackage) {
+  console.error('sync-server-json: server.json has no npm package entry to update');
+  process.exit(1);
+}
+
+/**
+ * The identifier is the other half of the same ownership check.
+ *
+ * `mcpName` above proves we own the package the listing claims; this is the
+ * package it actually resolves — the registry fetches
+ * `registry.npmjs.org/<identifier>/<version>` and reads `mcpName` out of *that*
+ * manifest. A rename or typo here fails the same way and just as late, so it
+ * gets the same guard rather than being the one copied field with nothing
+ * behind it.
+ */
+if (npmPackage.identifier !== pkg.name) {
+  console.error(
+    `sync-server-json: server.json packages[].identifier (${npmPackage.identifier}) does not ` +
+    `match the npm package name (${pkg.name}).`,
+  );
+  process.exit(1);
+}
+
+const stale =
+  registry.version !== pkg.version || npmPackage.version !== pkg.version;
+
+if (!stale) {
+  console.log(`sync-server-json: server.json already at ${pkg.version}`);
+  process.exit(0);
+}
+
+if (checkOnly) {
+  console.error(
+    `sync-server-json: server.json is stale — listing ${registry.version} / npm ` +
+    `${npmPackage.version}, but package.json is at ${pkg.version}. ` +
+    'Run `node scripts/sync-server-json.mjs` and commit the result.',
+  );
+  process.exit(1);
+}
+
+registry.version = pkg.version;
+npmPackage.version = pkg.version;
+writeFileSync(registryFile, `${JSON.stringify(registry, null, 2)}\n`);
+console.log(`sync-server-json: server.json -> ${pkg.version}`);

--- a/server.json
+++ b/server.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tufantunc/ssh-mcp",
+  "title": "SSH — policy-gated remote access",
+  "description": "Policy-gated, audited SSH for Linux and Windows hosts: roles, approvals, and an audit log.",
+  "version": "2.3.3",
+  "websiteUrl": "https://github.com/tufantunc/ssh-mcp#readme",
+  "repository": {
+    "url": "https://github.com/tufantunc/ssh-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "ssh-mcp",
+      "version": "2.3.3",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SSH_MCP_PASSWORD",
+          "description": "Password for the configured profile; a per-profile SSH_MCP_<PROFILE>_PASSWORD takes precedence. Credentials are never accepted as CLI arguments.",
+          "isSecret": true,
+          "isRequired": false
+        },
+        {
+          "name": "SSH_MCP_KEY",
+          "description": "Path to the private key file to authenticate with — the path, not the key material. A per-profile SSH_MCP_<PROFILE>_KEY takes precedence.",
+          "format": "filepath",
+          "isRequired": false
+        },
+        {
+          "name": "SSH_MCP_PASSPHRASE",
+          "description": "Passphrase for an encrypted private key.",
+          "isSecret": true,
+          "isRequired": false
+        },
+        {
+          "name": "SSH_MCP_SUDO_PASSWORD",
+          "description": "Password the sudo tool escalates with, when the policy in force allows the privileged class.",
+          "isSecret": true,
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/sync-server-json.test.ts
+++ b/test/unit/sync-server-json.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { copyFile, mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const run = promisify(execFile);
+
+const SCRIPT = fileURLToPath(new URL('../../scripts/sync-server-json.mjs', import.meta.url));
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+/**
+ * scripts/sync-server-json.mjs, the one gate on the registry listing.
+ *
+ * Every guard in that script exists because the registry reports the mistake it
+ * catches *after* `npm publish` has made the version immutable — recovering from
+ * that means shipping another release, not re-running a job. And on a healthy
+ * repo every one of those branches is false, so a guard that silently stopped
+ * firing would look exactly like a guard that passed: the script exits 0 either
+ * way, and `scripts/` sits outside `sonar.sources`, the coverage report and both
+ * tsconfigs, so nothing else would notice. Without this file the first execution
+ * of an edited guard is the release itself.
+ *
+ * The script reads `package.json` and `server.json` relative to its own location
+ * (`new URL('..', import.meta.url)`), so a copy of the real file in a temp tree
+ * reads that tree's fixtures. That is deliberately how these tests drive it:
+ * copying rather than importing means no export seam, no root argument, and no
+ * divergence between the file under test and the file the release runs.
+ */
+async function withFixture(
+  pkg: Record<string, unknown>,
+  registry: Record<string, unknown>,
+  args: string[] = [],
+) {
+  const root = await mkdtemp(join(tmpdir(), 'ssh-mcp-sync-'));
+  try {
+    await mkdir(join(root, 'scripts'));
+    await copyFile(SCRIPT, join(root, 'scripts', 'sync-server-json.mjs'));
+    await writeFile(join(root, 'package.json'), `${JSON.stringify(pkg, null, 2)}\n`);
+    const registryPath = join(root, 'server.json');
+    await writeFile(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+    const before = await readFile(registryPath, 'utf8');
+
+    let result: { code: number; stdout: string; stderr: string };
+    try {
+      const ok = await run('node', [join(root, 'scripts', 'sync-server-json.mjs'), ...args]);
+      result = { code: 0, stdout: ok.stdout, stderr: ok.stderr };
+    } catch (err: any) {
+      result = { code: err.code, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+    }
+
+    return { ...result, before, after: await readFile(registryPath, 'utf8') };
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const PKG = {
+  name: 'ssh-mcp',
+  version: '9.9.9',
+  mcpName: 'io.github.tufantunc/ssh-mcp',
+};
+
+const REGISTRY = (over: Record<string, unknown> = {}, pkgOver: Record<string, unknown> = {}) => ({
+  name: 'io.github.tufantunc/ssh-mcp',
+  title: 'SSH',
+  description: 'Policy-gated SSH.',
+  version: '1.0.0',
+  packages: [{ registryType: 'npm', identifier: 'ssh-mcp', version: '1.0.0', ...pkgOver }],
+  ...over,
+});
+
+describe('sync-server-json — write mode', () => {
+  /**
+   * Both version fields, asserted separately.
+   *
+   * `packages[].version` is the one the registry resolves against
+   * `registry.npmjs.org/<identifier>/<version>` to read `mcpName` out of, so a
+   * script that updated only the listing's own `version` would publish an entry
+   * pointing at the previous release — whose manifest has no `mcpName` at all.
+   * A single deep-equal over the object would still pass if only one of the two
+   * were written and the fixture happened to agree.
+   */
+  it('writes package.json version into both version fields', async () => {
+    const r = await withFixture(PKG, REGISTRY());
+    expect(r.code).toBe(0);
+    const after = JSON.parse(r.after);
+    expect(after.version).toBe('9.9.9');
+    expect(after.packages[0].version).toBe('9.9.9');
+  });
+
+  // The release PR carries this file, so a reformat on every bump would be diff
+  // noise a reviewer has to read past to check the version.
+  it('preserves 2-space indentation, key order and the trailing newline', async () => {
+    const r = await withFixture(PKG, REGISTRY());
+    expect(r.after).toBe(`${JSON.stringify(JSON.parse(r.after), null, 2)}\n`);
+    expect(Object.keys(JSON.parse(r.after))).toEqual(Object.keys(REGISTRY()));
+  });
+
+  it('leaves the file untouched when it is already in sync', async () => {
+    const r = await withFixture(PKG, REGISTRY({ version: '9.9.9' }, { version: '9.9.9' }));
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain('already at 9.9.9');
+    expect(r.after).toBe(r.before);
+  });
+});
+
+describe('sync-server-json — --check', () => {
+  /**
+   * The release job runs `--check` before it publishes a listing. If that
+   * degraded to exit 0 the step would always pass, which is indistinguishable
+   * from the step working — so both halves are pinned: the non-zero exit, and
+   * that nothing was written.
+   */
+  it('fails on a stale server.json without writing to it', async () => {
+    const r = await withFixture(PKG, REGISTRY(), ['--check']);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('is stale');
+    expect(r.after).toBe(r.before);
+  });
+
+  it('passes when the versions already agree', async () => {
+    const r = await withFixture(
+      PKG,
+      REGISTRY({ version: '9.9.9' }, { version: '9.9.9' }),
+      ['--check'],
+    );
+    expect(r.code).toBe(0);
+  });
+});
+
+describe('sync-server-json — ownership guards', () => {
+  /**
+   * The registry compares the npm manifest's `mcpName` against the submitted
+   * server name as its proof that the publisher owns the package. A mismatch is
+   * reported as "ownership validation failed" — after the publish.
+   */
+  it('refuses a mcpName that does not match server.json name', async () => {
+    const r = await withFixture({ ...PKG, mcpName: 'io.github.someone/else' }, REGISTRY());
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('does not match');
+    expect(r.after).toBe(r.before);
+  });
+
+  it('refuses a package.json with no mcpName at all', async () => {
+    const { mcpName: _omit, ...noName } = PKG;
+    const r = await withFixture(noName, REGISTRY());
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('unset');
+  });
+
+  it('refuses an identifier that is not the npm package name', async () => {
+    const r = await withFixture(PKG, REGISTRY({}, { identifier: 'ssh-mcp-renamed' }));
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('identifier');
+    expect(r.after).toBe(r.before);
+  });
+
+  it.each([
+    ['no packages key', REGISTRY({ packages: undefined })],
+    ['no npm entry', REGISTRY({ packages: [{ registryType: 'oci', identifier: 'x' }] })],
+  ])('refuses server.json with %s', async (_label, registry) => {
+    const r = await withFixture(PKG, registry);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('no npm package entry');
+  });
+
+  /**
+   * Ordering, not a second copy of the guards above.
+   *
+   * The staleness comparison ends in an early `process.exit(0)` for the in-sync
+   * case, which is the case every release-PR run and every `--check` run hits.
+   * If a guard were ever moved below it, it would stop running exactly when it
+   * matters and these tests — which all use a stale fixture — would still pass.
+   */
+  it('checks ownership even when the versions already agree', async () => {
+    const r = await withFixture(
+      { ...PKG, mcpName: 'io.github.someone/else' },
+      REGISTRY({ version: '9.9.9' }, { version: '9.9.9' }),
+      ['--check'],
+    );
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('does not match');
+  });
+});
+
+/**
+ * The repo's own two files, with no fixtures.
+ *
+ * This is the half that fails on the pull request that breaks something, rather
+ * than on the release two merges later: `npm run version` only runs when a
+ * release PR is generated, and `mcp-publisher validate` only in the registry
+ * job. The values below are hand-edited — nothing generates a title or a
+ * description — so they are exactly the ones a person can get wrong.
+ *
+ * The 100-character caps are the registry schema's, on `title` and
+ * `description`. They live here rather than in the script because the script
+ * would be copying two rules out of a schema `mcp-publisher validate` checks in
+ * full; what a test adds is the timing, not the rule.
+ */
+describe('server.json — the committed state', () => {
+  const read = async (name: string) =>
+    JSON.parse(await readFile(join(REPO_ROOT, name), 'utf8'));
+
+  it('names the same server as package.json mcpName', async () => {
+    const [pkg, registry] = await Promise.all([read('package.json'), read('server.json')]);
+    expect(registry.name).toBe(pkg.mcpName);
+  });
+
+  it('points at exactly one npm package, and it is this one', async () => {
+    const [pkg, registry] = await Promise.all([read('package.json'), read('server.json')]);
+    const npm = registry.packages.filter((p: { registryType: string }) => p.registryType === 'npm');
+    expect(npm).toHaveLength(1);
+    expect(npm[0].identifier).toBe(pkg.name);
+    // Not optional the way the schema suggests: the official registry's npm
+    // validator rejects a package entry with no version outright, because the
+    // version is what identifies the manifest it reads `mcpName` from.
+    expect(npm[0].version).toBe(pkg.version);
+    expect(registry.version).toBe(pkg.version);
+  });
+
+  it.each(['title', 'description'])('keeps %s within the schema cap', async (field) => {
+    const registry = await read('server.json');
+    expect(registry[field].length).toBeLessThanOrEqual(100);
+  });
+
+  // The npm description is over that cap, which is why the two texts differ
+  // rather than one being copied from the other. If npm's ever fits, someone
+  // will reasonably wonder whether the divergence was still deliberate.
+  it('has an npm description that genuinely could not be reused', async () => {
+    const pkg = await read('package.json');
+    expect(pkg.description.length).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
The spec moved to [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog) and the [roadmap](https://modelcontextprotocol.io/development/roadmap) was refreshed on 2026-08-22. This records where that lands on us — and, first, why there is nothing to do about it yet.

## There is no upgrade to take

| | |
|---|---|
| Current spec revision | **2026-07-28** |
| Installed SDK | `@modelcontextprotocol/sdk@1.30.0` |
| Newest published | **1.30.0** — only dist-tag, no prerelease, published **2026-07-27** |
| That SDK's newest protocol | `LATEST_PROTOCOL_VERSION = '2025-11-25'` |

The SDK shipped one day *before* the revision and has not caught up. Measured against its `dist/esm`: `resultType`, `server/discover`, `inputRequests`, `subscriptions/listen`, `cacheScope` and `Mcp-Method` appear in **zero** files. The `tasks/get` and `input_required` hits are the 2025-11-25 experimental Tasks feature — which this revision moved *out* of core into an extension and redesigned.

## What the doc contains

- **Five places it lands on our code**, ordered by how much is ours rather than the SDK's: elicitation becoming Multi Round-Trip Requests (the big one — our approval gate blocks *inside* a tool call, MRTR makes the client retry instead); the removal of protocol-level sessions and `Mcp-Session-Id`; the GET endpoint giving way to `subscriptions/listen`; `ttlMs`/`cacheScope` becoming required on list and read results; and two newly required POST headers.
- **What we get for free**, which is mostly positions we took for other reasons: Sampling, Roots and Logging are all deprecated and we use none — and Logging's suggested migration ("log to `stderr` or use OpenTelemetry") is already what we do. We are on Streamable HTTP, not the now-deprecated HTTP+SSE. Our custom JSON-RPC codes fall in the grandfathered `-32000`–`-32019` range. We return no `structuredContent`, so the roadmap's `tools/call` redesign cannot break us.
- **Two roadmap items aimed at what this project is.** Agent Identity describes servers that "lean on pasted API keys and long-lived refresh tokens" — that is our HTTP bearer token. And the Tasks extension is a hand-rolled version of our background sessions + progress + cancellation.
- **One design that survives intact**: the new spec tells servers needing cross-call state to use "explicit, server-minted handles passed as ordinary tool arguments". `open-session name=…` already is one. Only the transport plumbing goes.

## The only action available today

Do not build anything new on elicitation or on session-scoped transport state — both are being removed. Implementing the revision against an SDK that does not support it would mean forking `StreamableHTTPServerTransport`, a large high-risk surface in the module that three review rounds spent this week.

## Verification

Every file, symbol and number the document names was checked against the tree (`src/guard/elicitation.ts`, `src/tools/pipeline.ts`, `src/transport/http.ts`, `MAX_SESSIONS`, `approvalGrantTtlMs`, `ssh://connections`, the 11 `server.tool()` registrations), and the document carries the commands to re-derive its own tables — including the one that tells you when it stops being theory:

```bash
grep -n "LATEST_PROTOCOL_VERSION" node_modules/@modelcontextprotocol/sdk/dist/esm/types.js
```

Docs only. No changeset — nothing a consumer can observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)