### PR TITLE
docs: add the Glama listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,3 +719,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md). Please follow the [security checklist]
 ## Support
 
 If you find SSH MCP Server helpful, consider starring the repository or [sponsoring](https://github.com/sponsors/tufantunc)!
+
+## Listed on
+
+[![SSH MCP Server on Glama](https://glama.ai/mcp/servers/tufantunc/ssh-mcp/badge)](https://glama.ai/mcp/servers/tufantunc/ssh-mcp)
+
+Also on the [official MCP registry](https://registry.modelcontextprotocol.io) as `io.github.tufantunc/ssh-mcp`.


### PR DESCRIPTION
Glama auto-detected the repo. This adds its card badge to the README.

## What the badge actually shows

Fetched rather than assumed:

| | |
|---|---|
| license | **A** |
| quality | **–** (not graded) |
| maintenance | **A** |
| | 49,165 weekly downloads · 644 stars · TypeScript · MIT |

Both URLs were checked (`200 image/png` and `200 text/html`), and a deliberately bogus slug returns a *different* image — so the endpoint is slug-specific, not a blanket placeholder that would render for anything. The `@owner` form returns byte-identical output, so the plain slug is used.

## Placement

Under a new `## Listed on` heading at the end, not in the badge row. It is a 760×400 card rather than a shields.io pill, and putting it between the badges and the lethal-trifecta callout would push the one paragraph in this README that most needs reading below the fold. The MCP registry listing is named beside it, since 2.3.4 is the release that made that reachable.

One line to move if you'd rather it sat at the top.

## About the grey dash

The quality score is ungraded, and it is worth knowing why before the badge goes in. Glama's [methodology](https://glama.ai/mcp/methodology) grades quality from tool-definition quality (70%) and server coherence (30%) — but only for a server whose build answers introspection. Measured against our own image:

```
$ printf '%s\n%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' \
                    '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
  | docker run --rm -i ssh-mcp
No config file found and missing required --host/--user.
Either create a config file at /home/appuser/.config/ssh-mcp/config.toml or pass --config <path>.
```

No JSON-RPC response at all — the container exits on the config check before the handshake, so the harness never reaches `tools/list`. That is why the page says the server "cannot be installed" and the score is a dash.

Not fixed here: separating "no config" from "no server" is a product decision with its own review, not a README change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)