### PR TITLE
ci: grade the supply chain with OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,97 @@
+name: Scorecard
+
+# OpenSSF Scorecard: an automated, third-party read of this repo's supply-chain
+# posture — is there a security policy, are releases signed, are dependencies
+# pinned, is code scanning on, can a maintainer force-push to main. It grades what
+# we already claim in SECURITY.md, from outside, on a schedule, so a regression
+# shows up as a falling number rather than as nobody noticing.
+#
+# Deliberately NOT a job in ci.yml, for three reasons:
+#   1. It must not run on pull requests. Scorecard analyses the repository, not a
+#      diff, and `publish_results` from a fork PR would either fail or publish a
+#      fork's result under our name.
+#   2. `ci` is the required check in the branch ruleset. A job added there becomes
+#      required, and this one has nothing to say about a PR.
+#   3. It needs `id-token: write`, which ci.yml — the workflow that does run on
+#      pull requests — should not be handed.
+
+on:
+  # The published score is a property of the default branch, so it is recomputed
+  # when the default branch changes.
+  push:
+    branches: [main]
+  # Several checks (Branch-Protection above all) read repository settings rather
+  # than repository contents, so they can change with no commit at all. This event
+  # fires on exactly that, and is why a weekly cron alone would be too coarse.
+  branch_protection_rule:
+  schedule:
+    # Mondays, off the hour: GitHub queues scheduled jobs heavily at :00.
+    - cron: '27 5 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the SARIF so findings land in the repo's Security tab next to
+      # CodeQL's, rather than only in a log nobody opens.
+      security-events: write
+      # Mint the OIDC token that publishes the result to the OpenSSF API. This is
+      # what makes the README badge resolve; without it the run still scores but
+      # the badge stays unknown.
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Scorecard only reads. Leaving the token in .git/config would hand every
+          # subsequent step in this job a credential none of them need.
+          persist-credentials: false
+
+      # What this SHA pin does and does not buy, since the repo's own rule is that a
+      # pin should mean something. `action.yaml` at this commit is nine lines of
+      # `runs: using: docker, image: docker://ghcr.io/ossf/scorecard-action:v2.4.4`,
+      # so the pin freezes the wrapper and *not* the code that executes — the image
+      # tag is mutable and resolves at run time. Same shape as the semgrep action
+      # documented in ci.yml.
+      #
+      # Kept anyway, unlike semgrep, because the alternative is worse here: running
+      # the image directly would let us pin a digest but would also mean
+      # reimplementing the OIDC token exchange this action performs to publish
+      # results, which is the whole reason the badge resolves. The exposure is a tag
+      # controlled by the OpenSSF release process, on a job that has `contents: read`
+      # and touches no secret of ours.
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes to the public OpenSSF dataset, which is what the badge reads.
+          # Only meaningful because this repository is public; the results say
+          # nothing that `git log` and the Settings page do not already show.
+          publish_results: true
+          # Note on Branch-Protection: this repo protects `main` with a *ruleset*
+          # rather than a classic branch-protection rule, and the check reads those
+          # settings through an API the default GITHUB_TOKEN cannot fully see. That
+          # check may therefore score lower than the protection actually in force.
+          # Fixing it means a fine-grained PAT with read access to administration,
+          # stored as a secret and passed here as `repo_token` — a standing
+          # credential in exchange for one sub-score, which is not obviously worth
+          # it. Left unset on purpose; revisit if the number misleads.
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![NPM Version](https://img.shields.io/npm/v/ssh-mcp)](https://www.npmjs.com/package/ssh-mcp)
 [![Downloads](https://img.shields.io/npm/dm/ssh-mcp)](https://www.npmjs.com/package/ssh-mcp)
 [![CI](https://github.com/tufantunc/ssh-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tufantunc/ssh-mcp/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tufantunc/ssh-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/tufantunc/ssh-mcp)
 [![codecov](https://codecov.io/gh/tufantunc/ssh-mcp/graph/badge.svg?branch=main)](https://codecov.io/gh/tufantunc/ssh-mcp)
 [![License](https://img.shields.io/github/license/tufantunc/ssh-mcp)](./LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/tufantunc/ssh-mcp)](https://github.com/tufantunc/ssh-mcp/issues)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,6 +121,20 @@ dispatched but never took, and from one that could not be dispatched at all.
 
 SSH MCP Server v2 implements controls that map to common security frameworks. This mapping documents which features support specific control requirements — it does **not** constitute formal certification. The **deployer** is responsible for the full deployment's compliance posture.
 
+### Independent assessment
+
+Everything in the tables below is **self-assessed**. The one continuous outside reading is
+[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/tufantunc/ssh-mcp), which
+re-grades the repository weekly and on every change to `main` or to branch protection, and
+publishes the result. Findings also land in the repository's Security tab alongside CodeQL's.
+
+Read it for what it measures: the **supply chain and development process** — is there a
+security policy, are dependencies pinned and updated, is code scanning on, are releases
+signed, can history be rewritten. It says nothing about the runtime controls the tables
+below describe; no automated grader executes the policy engine. A high score means this
+project is built in a way that makes tampering hard to hide, not that a deployment of it
+is secure.
+
 ### SOC 2 (AICPA Trust Services Criteria)
 
 | Control | Description | SSH MCP v2 Feature |


### PR DESCRIPTION
Adds an OpenSSF Scorecard workflow and its badge.

This started as a suggestion to add `.well-known/security.txt` (RFC 9116). That standard is real, but its discovery mechanism is domain-based — a researcher fetches it from the host they are investigating. This project has no host: `has_pages=false`, the repo homepage is empty, and package.json's points at a README anchor. A file committed here would be served by nothing, and RFC 9116 makes `Expires` mandatory, so it would also commit us to renewing a date nothing reads. The need it addresses is already met by `SECURITY.md` and by GitHub private vulnerability reporting, which is already enabled.

Scorecard is the version of that goal that measures something.

## What it does

Runs weekly, on pushes to `main`, and on `branch_protection_rule` changes — several checks read repository *settings*, which change with no commit. Uploads SARIF to the Security tab beside CodeQL, and publishes the result so the badge resolves.

## Two limits, documented in the workflow

**Branch-Protection may under-report.** It reads settings through an API the default `GITHUB_TOKEN` cannot fully see, and this repo uses a *ruleset* rather than a classic branch-protection rule. Fixing it costs a standing PAT with administration read — left unset on purpose.

**The SHA pin buys less than it looks like.** `action.yaml` at the pinned commit is nine lines pointing at `docker://ghcr.io/ossf/scorecard-action:v2.4.4`, a mutable tag. The pin freezes the wrapper, not the code that executes — the same shape `ci.yml` already documents for the semgrep action. Running the image directly would allow a digest pin but would mean reimplementing the OIDC exchange that publishes results.

## Expected score

Verified present before writing this: `SECURITY.md`, CodeQL, Dependabot, branch ruleset, npm provenance (SLSA v1 attestation on 2.4.0), and **10/10 GitHub Actions pinned by SHA**.

## Notes

- The badge shows unknown until the first run publishes from `main`, i.e. shortly after merge.
- No changeset: CI and docs only, no package change.
- All four actions pinned by SHA; each verified as a real commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)