### PR TITLE
ci: pin the base image by digest, and make the security contact machine-readable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,17 @@
-FROM node:22-slim AS builder
+# Pinned by digest, with the tag left readable beside it.
+#
+# `node:22-slim` is a moving tag: two builds of the same commit could resolve to
+# different base images, which is exactly the reproducibility hole OpenSSF
+# Scorecard's Pinned-Dependencies check flags — it scored this file 8/10. The
+# digest is the multi-platform OCI index, so linux/amd64 and linux/arm64 both
+# still resolve from it.
+#
+# Pinning is only safe because something refreshes it: .github/dependabot.yml
+# watches the `docker` ecosystem monthly and rewrites the digest while keeping
+# the tag, the same arrangement the four sshd images in docker-compose.yml
+# already use. Without that, a digest pin is how a base image quietly stays on
+# unpatched CVEs for a year — strictly worse than the moving tag it replaced.
+FROM node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS builder
 WORKDIR /app
 COPY package*.json ./
 # --ignore-scripts because `prepare` runs `npm run build`, and at this layer neither
@@ -12,7 +25,7 @@ COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
 
-FROM node:22-slim
+FROM node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
 WORKDIR /app
 
 RUN groupadd -r -g 65532 appgroup && useradd -r -u 65532 -g appgroup appuser

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,14 +5,26 @@
 If you discover a security vulnerability in SSH MCP Server, please report it responsibly:
 
 1. **DO NOT** open a public GitHub issue.
-2. Email: **security [at] tufantunc [dot] com** (or use [GitHub Security Advisories](https://github.com/tufantunc/ssh-mcp/security/advisories/new)).
+2. Report it privately, either way:
+   - [Open a private security advisory](https://github.com/tufantunc/ssh-mcp/security/advisories/new) — preferred, since it keeps the report, the fix and the CVE in one thread; or
+   - email <security@tufantunc.com>.
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce
    - Affected versions
    - Potential impact
 
-You will receive a response within 72 hours. Please do not disclose the vulnerability publicly until a fix is released.
+### Disclosure timeline
+
+| When | What |
+|---|---|
+| Within 72 hours | Acknowledgement that the report arrived, and whether it is reproducible |
+| Within 7 days | An assessment: affected versions, severity, and whether a fix is planned |
+| Within 90 days | Coordinated public disclosure, or sooner once a fixed release is published |
+
+Please keep the vulnerability private until a fixed release is out, or until the 90 days
+elapse — whichever comes first. Reporters are credited in the advisory unless they ask not
+to be.
 
 ## Threat Model
 


### PR DESCRIPTION
Two of the weak checks from the first Scorecard run on `main`.

## Pinned-Dependencies: 8 → expected 10

`node:22-slim` is a moving tag. Both stages now pin the multi-platform OCI index digest (`sha256:d649c27d…`, resolved with `docker buildx imagetools inspect`, and independently matching Scorecard's own remediation hint), with the readable tag kept beside it.

The pin is only safe because something refreshes it — `.github/dependabot.yml` already watches the `docker` ecosystem monthly and says exactly why: *"Pinning without an updater is how a fixture quietly ends up years old."* The Dockerfile was simply the one place that had not been pinned yet.

Verified: the image builds, and running it with no config answers `initialize`, lists **11 tools**, and refuses `list-connections` with the operator message. That is the image-level check the introspection work never had — and the image is what a directory harness actually runs.

## Security-Policy: 3 → expected 10

Six of that check's ten points come from a probe that asks only whether the policy contains a link **or** an email; one more asks for more than one disclosure-related hint. Read from the check's source, not guessed.

- The address was `security [at] tufantunc [dot] com`, which matches no email pattern. Now plain.
- The policy promised a 72-hour response and nothing else. Now a table: acknowledgement, assessment, and a 90-day coordinated-disclosure window.
- Private advisories are named as the preferred route, since they keep report, fix and CVE in one thread.

All three probes evaluate true against Scorecard's own regexes, checked locally.

**Consequence worth stating:** de-obfuscating the address exposes it to scrapers. That is the trade the check asks for, and an unparseable security contact is not doing its job.

## One thing I could not explain

The links probe returned `false` on a file that contained two matching URLs at the analysed commit, and the disclosure probe wants more than one text hit where the file has 89. I ruled out the `.review-pro/*/security.md` files (0 and 8 hits — neither matches the implied count) and could not reproduce locally, since the action image is not a CLI. This change improves the policy under any explanation; the next scheduled run will show whether the score moves.

## Notes

- No changeset: CI and docs only, nothing published changes.
- The local `packaging.e2e` pnpm test failed on registry `ECONNRESET`, unrelated — the six assertions that read the Dockerfile all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
