### PR TITLE
ci: build the Docker image, and prove it starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
   # review round reasoned from it that a Windows-only regression could still ship.
   ci:
     runs-on: ubuntu-latest
-    needs: [test, windows, security-scan, codeql]
+    needs: [test, windows, security-scan, codeql, docker]
     # Not `always()`: that reports red for a run someone cancelled on purpose.
     if: ${{ !cancelled() }}
     steps:
@@ -335,3 +335,105 @@ jobs:
 
       - name: Analyze
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+
+  # Build the image this repo ships, and prove it starts.
+  #
+  # It was documented in the README, wired into docker-compose, and built by
+  # nothing: the only assertion about it anywhere was `packaging.e2e` reading the
+  # Dockerfile as *text*. So `--ignore-scripts`, the non-root UID, the base image
+  # digest and the entry point were all load-bearing and unverified — a Dockerfile
+  # that stopped building would have been found by a user, not by us.
+  #
+  # In the required set (see `ci` above), because a shipped artifact that does not
+  # build is a broken release, not a warning. No `if:` on the job for the same
+  # reason: that gate counts `skipped` as failure.
+  #
+  # Deliberately does not push anywhere. Publishing an image is a separate decision
+  # with its own costs — a `:latest` that ages into CVEs, a second artifact needing
+  # its own provenance and SBOM to match the npm one, and `packages: write` landing
+  # in the workflow npm's trusted publisher is bound to.
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Same reasoning as the test job: anonymous Docker Hub pulls are rate limited
+      # per IP and runners share addresses. The base image is digest-pinned, so this
+      # is a pull of exactly one manifest — but it is the one the whole job rests on.
+      - name: Log in to Docker Hub
+        # Skipped on pull requests from forks, which are never given secrets. Those
+        # pull anonymously; the retry below is what covers them.
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build
+        run: |
+          for attempt in 1 2 3; do
+            if docker build -t ssh-mcp:ci .; then exit 0; fi
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 20))
+              echo "::warning::Image build failed (attempt $attempt/3); retrying in ${delay}s"
+              sleep "$delay"
+            fi
+          done
+          echo "::error::Could not build the image after 3 attempts"
+          exit 1
+
+      # Building proves the Dockerfile parses and npm ci succeeds. It does not prove
+      # the result runs — a wrong ENTRYPOINT, a permission the non-root user does not
+      # have on its config dir, or a build stage that copied the wrong path all
+      # produce an image that builds and dies on start.
+      #
+      # The image has no config, so this exercises the unconfigured path the server
+      # gained in 2.4.0: it must answer the handshake, list every tool, and refuse a
+      # call. That is also what an MCP directory does to it, which is the behaviour
+      # the release existed to fix.
+      - name: Smoke test the built image
+        env:
+          TOOL_COUNT: '11'
+        run: |
+          set -euo pipefail
+          {
+            echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}}'
+            echo '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+            echo '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"run-command","arguments":{"command":"echo hi"}}}'
+          } | timeout 60 docker run --rm -i ssh-mcp:ci > out.jsonl 2> err.txt || true
+
+          node -e '
+            const fs = require("fs");
+            const lines = fs.readFileSync("out.jsonl", "utf8").split("\n").filter(Boolean);
+            const err = fs.readFileSync("err.txt", "utf8");
+            const replies = lines.map((l) => JSON.parse(l));
+            const byId = (id) => replies.find((r) => r.id === id);
+            const fail = (m) => { console.error(`::error::${m}\n--- stderr ---\n${err}`); process.exit(1); };
+
+            const init = byId(1);
+            if (init?.result?.serverInfo?.name !== "SSH MCP Server") fail("no initialize reply from the image");
+
+            const tools = byId(2)?.result?.tools;
+            if (!Array.isArray(tools)) fail("no tools/list reply from the image");
+            const want = Number(process.env.TOOL_COUNT);
+            if (tools.length !== want) fail(`image listed ${tools.length} tools, expected ${want}`);
+
+            const call = byId(3)?.result;
+            if (call?.isError !== true) fail("unconfigured image did not refuse a tool call");
+            const text = JSON.stringify(call.content);
+            if (!/No config file found/.test(text)) fail(`refusal did not name the config path: ${text}`);
+
+            console.log(`image ok: ${tools.length} tools, tool call refused, warning on stderr: ${/starting unconfigured/.test(err)}`);
+          '
+
+      # The README says "non-root UID 65532". Asserted rather than trusted, because
+      # a base image change or a reordered COPY can silently drop the USER line's
+      # effect and nothing else here would notice.
+      - name: The image must not run as root
+        run: |
+          set -euo pipefail
+          uid="$(docker run --rm --entrypoint id ssh-mcp:ci -u)"
+          echo "container uid: $uid"
+          [ "$uid" = "65532" ] || { echo "::error::image runs as uid $uid, expected 65532" >&2; exit 1; }


### PR DESCRIPTION
Came from a suggestion to publish the image to GHCR. That premise did not hold, but it pointed at a real gap.

## The premise

> "CI zaten GHCR kullanıyor" — CI already uses GHCR.

It does not. GHCR appears only as the **source** of the sshd test fixture (`ghcr.io/linuxserver/openssh-server`) that CI *pulls*. There is no publish path, no GHCR credential, and no `packages: write` anywhere. The Docker Hub login that does exist is there to avoid anonymous pull rate limits.

## The real gap

**Nothing builds the image.** It is documented in the README, wired into `docker-compose.yml`, and the only assertion about it anywhere is `packaging.e2e` reading the Dockerfile as *text*. So `--ignore-scripts`, the non-root UID, the base image digest and the entry point were all load-bearing and unverified.

## What this adds

| Check | Why it is not covered by building |
|---|---|
| **Build** (login + 3× retry, mirroring the test job) | fork PRs get no secrets and pull anonymously |
| **Start** — handshake, **11 tools**, tool call refused with the config path | a wrong ENTRYPOINT, a missing permission on the config dir, or a stage that copied the wrong path all build fine and die on start |
| **UID 65532** | the README claims it; a base image change or reordered COPY drops it silently |

The start check exercises the unconfigured path added in 2.4.0 — which is exactly what an MCP directory does to this image, so the behaviour that release existed to fix is now checked at the image boundary rather than only at `build/index.js`.

Added to the required set (`ci`), because a shipped artifact that does not build is a broken release rather than a warning. No `if:` on the job, since that gate counts `skipped` as failure.

## Verified, not assumed

Built and ran locally: `image ok: 11 tools, tool call refused, warning on stderr: true`, and `id -u` → `65532`. All three assertions mutation-tested — expecting 12 tools, an empty reply stream, and `--user 0` each fail the check.

## Not pushing anywhere, on purpose

Publishing is a separate decision with ongoing costs: a `:latest` that ages into CVEs while npm users always get current Node; a second artifact that would need its own provenance and SBOM to match what the npm tarball now carries, or else be the weaker artifact under the same name; and `packages: write` landing in the workflow npm's trusted publisher is bound to — the one we just spent a review round narrowing.

Worth revisiting if someone asks for the image, or a directory requires one.

## Notes

- No changeset: CI only, nothing published changes.
- One aside found while checking: TOFU host-key state is an in-memory `Map` in `ConnectionRegistry`, never persisted. So "verify after" holds within a process lifetime, not across restarts. Pre-existing and out of scope here, but it is why a container — restarted more often than a native process — would make the weakest case the common one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
