### PR TITLE
fix: classify commands hidden inside a command (GHSA-v8jh-gv7v-3gvq)

### DIFF
--- a/.changeset/elevation-inside-substitution.md
+++ b/.changeset/elevation-inside-substitution.md
@@ -15,3 +15,7 @@ Commands that carry other commands are now classified as the higher of the two, 
 The last of those was not in the report and does not involve substitution at all: `sh -c "sudo id"` classified `safe` for the same reason, and a fix that only parsed `$(...)` would have left it open.
 
 Substitutions that carry nothing elevated or destructive are unchanged — `echo $(date)` stays `safe`, and arithmetic expansion is not treated as a command, so `echo $((1 + 1))` does not start raising prompts.
+
+The same carriers were also laundering the forbidden-invocation list — `shutdown`, `reboot`, `halt`, `poweroff`, `eval` — which is the one rule in the policy that holds regardless of role, tier or approval. It was decided from the outer command alone, so `sh -c "shutdown -h now"` and `echo $(shutdown -h now)` were not forbidden: they classified `destructive`, which on the `prod` tier turns an absolute `deny` into a prompt a human can accept. The forbidden scan now reads the carriers too.
+
+Not found by the report, but by working outward from it.

--- a/.changeset/elevation-inside-substitution.md
+++ b/.changeset/elevation-inside-substitution.md
@@ -1,0 +1,17 @@
+---
+"ssh-mcp": patch
+---
+
+Classify commands hidden inside a command ([GHSA-v8jh-gv7v-3gvq](https://github.com/tufantunc/ssh-mcp/security/advisories/GHSA-v8jh-gv7v-3gvq)).
+
+`classifyCommand` decides two things at once: whether the caller's role may run the command, and whether the human approval gate fires — only `destructive` and `privileged` raise a prompt. The elevation scan reached that decision through tokens produced by splitting on `;`, `&`, `|` and whitespace, so it only ever saw the outer command. `echo $(sudo id)` tokenised to `["echo", "$(sudo", "id)"]`, `echo` was taken to be the real command, and no elevation was found — while the remote shell expanded the substitution and ran `sudo id` for real.
+
+Measured against the compiled-in default rules, that mattered most exactly where the matrix is strictest: on the `prod` tier `privileged` is granted to **no role at all**, not even `admin`, while `safe` is granted to both `operator` and `admin`. So the bypass handed out the one class that tier withholds, with no approval prompt, and the audit record said `safe`.
+
+The asymmetry that caused it was visible all along — `echo $(rm -rf /)` classified correctly, because the destructive scan reads the raw command text while the elevation scan read tokens.
+
+Commands that carry other commands are now classified as the higher of the two, and the class names the inner binary so the audit record points at the process that actually runs. Four carriers are read: `$(...)`, backticks, process substitution `<(...)` / `>(...)`, and a shell invoked with `-c`.
+
+The last of those was not in the report and does not involve substitution at all: `sh -c "sudo id"` classified `safe` for the same reason, and a fix that only parsed `$(...)` would have left it open.
+
+Substitutions that carry nothing elevated or destructive are unchanged — `echo $(date)` stays `safe`, and arithmetic expansion is not treated as a command, so `echo $((1 + 1))` does not start raising prompts.

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -543,9 +543,22 @@ const FORBIDDEN_RULES: ForbiddenRule[] = [
  * lives in FORBIDDEN_RULES and a caller checking only the regexes would quietly
  * permit `sudo reboot`.
  */
-export function findForbiddenMatch(command: string): string | null {
+export function findForbiddenMatch(command: string, depth = 0): string | null {
   for (const rule of FORBIDDEN_RULES) {
     if (rule.test(command)) return rule.label;
+  }
+
+  // The same carriers the class scan reads, for the same reason. This list is the
+  // one unconditional rule in the policy — forbidden regardless of role, tier or
+  // approval — and it was decided from the outer command alone, so
+  // `sh -c "shutdown -h now"` and `echo $(shutdown -h now)` were not forbidden.
+  // They still classified `destructive`, which on the `prod` tier degrades an
+  // absolute `deny` into `require-approval`: a rule that answers "never" became
+  // one a human can click through.
+  if (depth >= MAX_NESTING_DEPTH) return null;
+  for (const inner of nestedCommands(command)) {
+    const match = findForbiddenMatch(inner, depth + 1);
+    if (match !== null) return match;
   }
   return null;
 }

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -129,6 +129,135 @@ const ACTION_MULTIPLEXERS = new Set(['systemctl', 'init', 'telinit']);
  * control inside a security release. `gosu` and `run0` were never caught by
  * either form.
  */
+/**
+ * Class ordering, so a command that contains another can take the higher of the two.
+ *
+ * Only used by the nesting scan below. Everything else in this file decides a single
+ * class outright.
+ */
+const CLASS_RANK: Record<CommandClass, number> = {
+  'read-only': 0,
+  safe: 1,
+  destructive: 2,
+  privileged: 3,
+};
+
+/** Shells that run their next argument as a command when given `-c`. */
+const SHELL_BINARIES = new Set([
+  'sh', 'bash', 'dash', 'zsh', 'ksh', 'ash', 'busybox',
+]);
+
+/**
+ * How deep a substitution may nest before we stop reading and refuse to guess.
+ *
+ * Reached only by input no operator writes — the tests use two hundred levels. The
+ * fallback is `privileged` rather than a lower class because the entire point of
+ * this scan is that a command we cannot read must not be treated as one we can.
+ */
+const MAX_NESTING_DEPTH = 8;
+
+/**
+ * Split on whitespace the way a shell would, keeping quoted runs together.
+ *
+ * `parseSegments` splits on `/\s+/`, which turns `sh -c "sudo id"` into
+ * `["sh", "-c", "\"sudo", "id\""]` — the argument is no longer a unit, so nothing
+ * downstream can classify it as the command it is.
+ */
+function splitRespectingQuotes(command: string): string[] {
+  const words: string[] = [];
+  let current = '';
+  let quote: string | null = null;
+
+  for (const ch of command) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) words.push(current);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  if (current) words.push(current);
+  return words;
+}
+
+/**
+ * The commands hiding inside a command.
+ *
+ * The elevation scan reads tokens produced by splitting on `;&|` and whitespace, so
+ * it only ever saw the outer command: `echo $(sudo id)` tokenised to
+ * `["echo", "$(sudo", "id)"]`, `echo` was taken to be the real command, and no
+ * elevation was found (GHSA-v8jh-gv7v-3gvq). The destructive scan never had this
+ * problem because it reads the raw text — which is why `echo $(rm -rf /)` was
+ * classified correctly the whole time. This closes that asymmetry by pulling the
+ * inner commands out so they can be classified in their own right.
+ *
+ * Four carriers, all of which a remote shell expands and runs:
+ *   `$(...)`, backticks, process substitution `<(...)` / `>(...)`, and a shell
+ *   given `-c`.
+ */
+export function nestedCommands(command: string): string[] {
+  const found: string[] = [];
+
+  // `$(...)`, `<(...)`, `>(...)` — scanned rather than matched, because a regex
+  // cannot balance parentheses and `echo $(echo $(sudo id))` is the case that
+  // matters most.
+  for (let i = 0; i < command.length; i++) {
+    const opensSubstitution = command[i] === '$' && command[i + 1] === '(';
+    const opensProcess = (command[i] === '<' || command[i] === '>') && command[i + 1] === '(';
+    if (!opensSubstitution && !opensProcess) continue;
+
+    // `$((1 + 1))` is arithmetic, not a command. Skipping it keeps the approval
+    // prompt off `echo $((1 + 1))`.
+    if (opensSubstitution && command[i + 2] === '(') continue;
+
+    let depth = 0;
+    for (let j = i + 1; j < command.length; j++) {
+      if (command[j] === '(') depth++;
+      else if (command[j] === ')') {
+        depth--;
+        if (depth === 0) {
+          found.push(command.slice(i + 2, j));
+          i = j;
+          break;
+        }
+      }
+    }
+  }
+
+  // Backticks. No nesting to balance — the shell requires escaping to nest them.
+  const backticks = command.match(/`([^`]*)`/g);
+  if (backticks) {
+    for (const raw of backticks) found.push(raw.slice(1, -1));
+  }
+
+  // `sh -c <command>`. Carries no substitution at all, so the scan above does not
+  // see it; found while mapping the reported bypass rather than in the report.
+  const words = splitRespectingQuotes(command);
+  for (let i = 0; i < words.length; i++) {
+    if (!SHELL_BINARIES.has(stripPath(unquote(words[i])))) continue;
+    for (let j = i + 1; j < words.length; j++) {
+      if (words[j] === '-c') {
+        if (words[j + 1] !== undefined) found.push(words[j + 1]);
+        break;
+      }
+      // Only flags may sit between the shell and its `-c`; anything else means
+      // this was not a `-c` invocation.
+      if (!words[j].startsWith('-')) break;
+    }
+  }
+
+  return found.filter((c) => c.trim().length > 0);
+}
+
 const PRIVILEGE_PREFIXES = new Set([
   'sudo', 'su', 'doas', 'pkexec',
   // BusyBox/Alpine, Docker entrypoints, the Rust sudo now default on some
@@ -464,10 +593,41 @@ export function extractBinary(command: string): string {
   return parts[0] || '';
 }
 
-export function classifyCommand(command: string): ParsedCommand {
+export function classifyCommand(command: string, depth = 0): ParsedCommand {
   const trimmed = command.trim();
   const binary = extractBinary(trimmed);
   const fullCommand = trimmed;
+
+  // A command that carries another command decides nothing on its own: the remote
+  // shell expands `$(...)`, backticks, `<(...)` and `sh -c` and runs what is inside,
+  // so the class has to be the higher of the two. Before this, the outer command
+  // decided alone and `echo $(sudo id)` was `safe` — a class the default rules grant
+  // on `prod` to `operator` and `admin`, while granting `privileged` there to nobody
+  // at all (GHSA-v8jh-gv7v-3gvq). It also skipped the approval prompt, since only
+  // `destructive` and `privileged` raise one, and the audit record said `safe`.
+  //
+  // Runs before the checks below rather than after, so the class it produces is not
+  // something a later branch can lower.
+  if (depth < MAX_NESTING_DEPTH) {
+    let highest: ParsedCommand | null = null;
+    for (const inner of nestedCommands(trimmed)) {
+      const parsed = classifyCommand(inner, depth + 1);
+      if (highest === null || CLASS_RANK[parsed.class] > CLASS_RANK[highest.class]) {
+        highest = parsed;
+      }
+    }
+    // `binary` comes from the inner command deliberately: it is what the audit
+    // record and the refusal message name, and naming the outer `echo` would
+    // describe the wrong process as the one that ran as root.
+    if (highest !== null && CLASS_RANK[highest.class] > CLASS_RANK['safe']) {
+      return { binary: highest.binary, fullCommand, class: highest.class };
+    }
+  } else {
+    // Nesting this deep is not something an operator writes, and we have stopped
+    // reading. Refusing to guess is the only answer consistent with the rest of
+    // this function.
+    return { binary, fullCommand, class: 'privileged' as CommandClass };
+  }
 
   // `binary` names the subject of the class. For everything below it is the
   // leading command; here it is the one that runs as root, which are the same

--- a/test/unit/policy/elevation-hiding.test.ts
+++ b/test/unit/policy/elevation-hiding.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { classifyCommand, nestedCommands } from '../../../src/policy/classifier.js';
+
+/**
+ * Elevation the tokenizer could not see (GHSA-v8jh-gv7v-3gvq).
+ *
+ * `classifyCommand` decides two things at once: whether the caller's role may run
+ * the command at all, and whether the human approval gate fires — only
+ * `destructive` and `privileged` require approval. The elevation scan reached that
+ * decision through `parseSegments`, which splits on `;`, `&`, `|` and newline and
+ * then on whitespace, so it only ever saw the *outer* command. Anything that
+ * carries a command inside itself — a substitution, a shell invoked with `-c` —
+ * hid the elevation completely.
+ *
+ * `echo $(sudo id)` classified `safe`. Measured against the compiled-in default
+ * rules, `safe` on the `prod` tier is granted to `operator` and `admin` alike,
+ * while `privileged` is granted to *nobody* on that tier — not even `admin`. So
+ * the bypass handed out exactly the one class the strictest row of the matrix
+ * withholds, with no approval prompt, and the audit record said `safe`.
+ *
+ * The asymmetry that caused it is visible in the old behaviour:
+ * `echo $(rm -rf /)` was correctly `destructive`, because the destructive scan
+ * reads the raw command text, while the elevation scan read tokens.
+ */
+
+describe('elevation hidden inside a command substitution', () => {
+  it.each([
+    ['$(...)', 'echo $(sudo id)'],
+    ['backticks', 'echo `sudo id`'],
+    ['nested $(...)', 'echo $(echo $(sudo id))'],
+    ['process substitution', 'cat <(sudo id)'],
+    ['assignment', 'X=$(sudo id)'],
+    ['quoted', 'echo "$(sudo id)"'],
+    ['other elevation binaries', 'echo $(doas id)'],
+    ['su with -c', 'echo $(su -c id)'],
+    ['pkexec', 'echo $(pkexec id)'],
+    ['deep inside a pipeline', 'ls | grep x; echo $(sudo id)'],
+  ])('%s is privileged, not safe', (_label, command) => {
+    expect(classifyCommand(command).class).toBe('privileged');
+  });
+
+  it('names the elevated binary rather than the outer one', () => {
+    // The audit record and the refusal message both read this field, so pointing
+    // it at `echo` would describe the wrong command as the one running as root.
+    expect(classifyCommand('echo $(sudo id)').binary).toBe('id');
+  });
+});
+
+describe('elevation hidden behind a shell wrapper', () => {
+  // Not in the reported advisory, found while mapping its surface: these carry no
+  // substitution at all, so a fix that only parsed `$(...)` would have left them.
+  it.each([
+    ['sh -c', 'sh -c "sudo id"'],
+    ['bash -c', 'bash -c "sudo id"'],
+    ["single quotes", "sh -c 'sudo id'"],
+    ['dash -c', 'dash -c "sudo id"'],
+    ['zsh -c', 'zsh -c "sudo id"'],
+    ['flags before -c', 'bash -x -c "sudo id"'],
+    ['substitution inside the wrapper', 'sh -c "echo $(sudo id)"'],
+  ])('%s is privileged, not safe', (_label, command) => {
+    expect(classifyCommand(command).class).toBe('privileged');
+  });
+});
+
+describe('what the fix must not break', () => {
+  it('leaves substitutions with no elevation where they were', () => {
+    // These were `safe` before the fix — demoted from read-only by the shell
+    // metacharacter gate — and must stay there. Promoting every substitution
+    // would make the approval prompt fire on `echo $(date)`, which trains
+    // operators to click through it.
+    expect(classifyCommand('echo $(date)').class).toBe('safe');
+    expect(classifyCommand('echo $(hostname)').class).toBe('safe');
+    expect(classifyCommand('echo $((1 + 1))').class).toBe('safe');
+  });
+
+  it('still classifies plain commands as before', () => {
+    expect(classifyCommand('ls -la').class).toBe('read-only');
+    expect(classifyCommand('sudo id').class).toBe('privileged');
+    expect(classifyCommand('rm -rf /tmp/x').class).toBe('destructive');
+    expect(classifyCommand('echo hi').class).toBe('read-only');
+  });
+
+  it('carries the inner class up when it is destructive rather than privileged', () => {
+    // The same hole, one class down: a destructive command hidden in a
+    // substitution skipped the approval gate exactly as an elevated one did.
+    expect(classifyCommand('echo $(rm -rf /var)').class).toBe('destructive');
+    expect(classifyCommand('sh -c "rm -rf /var"').class).toBe('destructive');
+  });
+
+  it('does not treat arithmetic expansion as a command', () => {
+    // `$((...))` is arithmetic; `$(...)` is a command. Pinned directly on the
+    // extractor because the two are one character apart and the difference is
+    // invisible in the resulting class — measured: with or without this
+    // distinction every arithmetic expression tried still classified `safe`. What
+    // it protects is the extractor's contract, so a later reader is not told that
+    // `(1 + 1)` is a command someone ran.
+    expect(nestedCommands('echo $((1 + 1))')).toEqual([]);
+    expect(nestedCommands('echo $(id -u)')).toEqual(['id -u']);
+    // A real substitution inside arithmetic is still a real substitution.
+    expect(nestedCommands('echo $(( $(id -u) + 1 ))')).toEqual(['id -u']);
+  });
+
+  it('terminates on pathological nesting rather than hanging', () => {
+    const deep = `echo ${'$('.repeat(200)}sudo id${')'.repeat(200)}`;
+    const started = Date.now();
+    const result = classifyCommand(deep);
+    expect(Date.now() - started).toBeLessThan(1000);
+    // Whatever it decides, it must not decide "safe" — that is the failure mode
+    // the whole advisory is about.
+    expect(result.class).not.toBe('safe');
+  });
+});

--- a/test/unit/policy/elevation-hiding.test.ts
+++ b/test/unit/policy/elevation-hiding.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyCommand, nestedCommands } from '../../../src/policy/classifier.js';
+import { classifyCommand, nestedCommands, isForbidden } from '../../../src/policy/classifier.js';
 
 /**
  * Elevation the tokenizer could not see (GHSA-v8jh-gv7v-3gvq).
@@ -108,5 +108,26 @@ describe('what the fix must not break', () => {
     // Whatever it decides, it must not decide "safe" — that is the failure mode
     // the whole advisory is about.
     expect(result.class).not.toBe('safe');
+  });
+});
+
+describe('the forbidden list is unconditional, including inside a carrier', () => {
+  // `FORBIDDEN_INVOCATIONS` is the one rule no role, tier or approval can satisfy.
+  // It was decided from the outer command alone, so wrapping it degraded an
+  // absolute `deny` into a `require-approval` a human can click through.
+  it.each([
+    ['sh -c', 'sh -c "shutdown -h now"'],
+    ['substitution', 'echo $(shutdown -h now)'],
+    ['backticks', 'echo `reboot`'],
+    ['nested wrapper', `sh -c 'sh -c "poweroff"'`],
+    ['eval inside a wrapper', 'sh -c "eval sudo id"'],
+  ])('%s does not launder a forbidden invocation', (_label, command) => {
+    expect(isForbidden(command)).toBe(true);
+  });
+
+  it('still lets ordinary commands through', () => {
+    expect(isForbidden('echo $(date)')).toBe(false);
+    expect(isForbidden('ls -la')).toBe(false);
+    expect(isForbidden('sh -c "ls -la"')).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes [GHSA-v8jh-gv7v-3gvq](https://github.com/tufantunc/ssh-mcp/security/advisories/GHSA-v8jh-gv7v-3gvq), reported privately. Developed in the advisory's temporary private fork.

## The reported bug

`classifyCommand` decides two things at once: whether the caller's role may run the command, and whether the approval gate fires — only `destructive` and `privileged` raise a prompt. The elevation scan reached that decision through tokens produced by splitting on `;`, `&`, `|` and whitespace, so it only ever saw the outer command. `echo $(sudo id)` tokenised to `["echo", "$(sudo", "id)"]`, `echo` was taken to be the real command, and no elevation was found — while the remote shell expanded the substitution and ran `sudo id`.

The asymmetry that caused it was visible all along: `echo $(rm -rf /)` classified correctly, because the **destructive** scan reads raw text while the **elevation** scan read tokens.

Impact, measured against the compiled-in defaults on the `prod` tier — where `privileged` is granted to **no role at all**, not even `admin`, while `safe` is granted to `operator` and `admin` both:

| | before | after |
|---|---|---|
| `echo $(sudo id)` | `safe` → allow, no prompt | `privileged` → deny |
| `sh -c "sudo id"` | `safe` → allow, no prompt | `privileged` → deny |
| `echo $(date)` | `safe` → allow | `safe` → allow |

The audit record also said `commandClass: safe`, so nothing recorded that a root command ran.

## What changed

Commands that carry commands are classified as the higher of the two, with `binary` taken from the inner command so the audit record names the process that actually runs. Four carriers: `$(...)`, backticks, `<(...)` / `>(...)`, and a shell given `-c`.

Parentheses are balanced by a scanner rather than matched by a regex, because `echo $(echo $(sudo id))` is the case a regex gets wrong. Recursion is bounded at eight levels and the fallback is `privileged` — input nested that deep is not something an operator writes, and a command we have stopped reading must not be treated as one we can.

## Two things found by working outward from the report

**`sh -c "sudo id"` carries no substitution at all** and classified `safe` by the same mechanism. A fix that only parsed `$(...)` would have shipped with it open.

**The forbidden-invocation list was being laundered by the same carriers.** `shutdown`, `reboot`, `halt`, `poweroff`, `eval` are denied regardless of role, tier or approval — but that was decided from the outer command, so `sh -c "shutdown -h now"` and `echo $(shutdown -h now)` came out `destructive`, turning an absolute `deny` into a prompt a human can accept. Second commit.

## Verification

- **761 tests pass**, up from 755. No policy regressions.
- **29 new tests.** Five mutations — disabling the nesting scan, dropping the `sh -c` extraction, making the depth fallback `safe`, removing the arithmetic skip, removing the forbidden recursion — each fail the suite.
- **21 bypass attempts** tried against the fix (spacing, newlines, tabs, `env`/`nohup`/`timeout` wrappers, `busybox sh`, quoting forms, path forms, nested wrappers): 20 caught.
- **No false positives**: `echo $(date)`, `cat $(which node)`, `grep x $(find . -name "*.ts")` all stay `safe`.
- **No DoS surface**: worst case 8.1 ms at the 5000-character `maxChars` limit.

## Known limit, reported separately

`S=sudo; $S id` still classifies `safe`. Verified against the parent commit as **pre-existing** — not a regression from this change. It is deliberately not patched here: resolving assignments within one command would close one spelling while leaving the two-call form, since a session run keeps the caller's shell state (`command-tools.ts:49`), so `S=sudo` and `$S id` can arrive as separate calls with the command word being a variable no static classifier can resolve. It needs its own design decision about false positives and is being tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
