### PR TITLE
ci: give the SBOM upload a repo to upload to

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -333,7 +333,13 @@ jobs:
         run: |
           set -euo pipefail
           tag="$(cat release-tag.txt)"
-          gh release upload "$tag" sbom.cdx.json sbom.spdx.json --clobber
+          # `--repo` because this job downloads artifacts and never checks out, so
+          # there is no git remote for `gh` to infer the repository from. Without it
+          # the upload died with "fatal: not a git repository" on the 2.4.1 release —
+          # after the attestation had been signed and published, which is the split
+          # working as intended: the verifiable artifact shipped, only the readable
+          # copies were missing.
+          gh release upload "$tag" sbom.cdx.json sbom.spdx.json --clobber --repo "$GITHUB_REPOSITORY"
 
   # Listing on the official MCP registry (registry.modelcontextprotocol.io).
   #


### PR DESCRIPTION
`gh release upload` infers the repository from a git remote, and `sbom-assets` has none — it downloads artifacts and never checks out, which is exactly why it was split away from the job holding `id-token: write`. On the 2.4.1 release it failed with `fatal: not a git repository`.

`--repo` rather than a checkout, so the job stays as narrow as designed.

**What did not break:** the attestation was signed, published and recorded before this step ran. Verified against the published 2.4.1 tarball — CycloneDX predicate exits 0, SPDX exits 0, a bogus predicate exits 1, and 2.4.0 exits 1 because the job did not exist then. The failure cost two readable JSON files on the release page and nothing else, which is the split behaving as intended.

No changeset: CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)