### PR TITLE
fix: require approval for a command the server cannot name (GHSA-fj9r-f47j-c73x)

### DIFF
--- a/.changeset/unnameable-command-word.md
+++ b/.changeset/unnameable-command-word.md
@@ -1,0 +1,21 @@
+---
+"ssh-mcp": patch
+---
+
+Require approval for a command this server cannot name ([GHSA-fj9r-f47j-c73x](https://github.com/tufantunc/ssh-mcp/security/advisories/GHSA-fj9r-f47j-c73x)).
+
+`classifyCommand` decides the class — and with it whether the approval gate fires — from the literal text of the command word. When that word is a shell variable expansion, what will actually run is not knowable here, and the unresolvable word was treated as an ordinary binary: `safe`. The remote shell then expanded it and ran whatever it named.
+
+```
+S=sudo; $S id    ->  safe   (allowed, no prompt)
+$S id            ->  safe
+xargs $S         ->  safe
+```
+
+Measured against the compiled-in defaults on the `prod` tier — where `privileged` is granted to no role at all and `safe` to both `operator` and `admin` — that reached root with no prompt and an audit record reading `safe`.
+
+Distinct from [GHSA-v8jh-gv7v-3gvq](https://github.com/tufantunc/ssh-mcp/security/advisories/GHSA-v8jh-gv7v-3gvq), fixed in 2.4.1, and **not** fixed by it: that one hid elevation inside a carrier — `$(...)`, backticks, `sh -c` — which is statically readable and is now read. This hides it behind a name, which is not readable at all. Resolving the variable is not available as a fix: a session run keeps the caller's shell state, so `S=sudo` and `$S id` can arrive as two separate calls, and a variable exported in the target's own profile is never visible to this process.
+
+So the classifier now says what it knows. A segment whose command word carries `$` or a backtick is classified `destructive` — not `privileged`, because this is "cannot tell" rather than "this is root". It requires approval instead of refusing outright, which keeps `$PREFIX/bin/tool` usable.
+
+**One behaviour change worth planning for.** Only the command word counts, never the arguments, so `echo $HOME` and `grep $PATTERN file` are untouched. But a command whose *name* comes from a variable now needs the `destructive` class on the tier. Under the default rules that means such a command is refused for `operator` on `prod` where it previously ran, and prompts for `admin`. If a deployment runs `$PREFIX/bin/...` on production under an operator role, grant that role `destructive` on the tier or spell the path literally.

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -606,6 +606,63 @@ export function extractBinary(command: string): string {
   return parts[0] || '';
 }
 
+/**
+ * The word a segment will actually execute, read past anything that is not it.
+ *
+ * Distinct from `elevatedBinary`, which answers "does this ask for elevation".
+ * This answers "what is the name of the thing that runs", so it can be asked
+ * whether that name is knowable at all.
+ */
+function effectiveCommandWord(words: string[]): string | null {
+  let i = 0;
+  while (i < words.length) {
+    const raw = words[i];
+    const word = stripPath(unquote(raw));
+
+    if (PRIVILEGE_PREFIXES.has(word) || EXEC_WRAPPERS.has(word)) {
+      i++;
+      while (i < words.length && words[i].startsWith('-')) {
+        const consumesValue = PREFIX_VALUE_FLAGS.has(words[i]);
+        i++;
+        if (consumesValue) i++;
+      }
+      continue;
+    }
+    if (ASSIGNMENT.test(raw) || raw.startsWith('-') || BARE_NUMERIC.test(raw)) {
+      i++;
+      continue;
+    }
+    return raw;
+  }
+  return null;
+}
+
+/**
+ * Whether any segment runs a command this process cannot name.
+ *
+ * The class — and with it the approval gate — is decided from the literal text of
+ * the command word. A word carrying `$` or a backtick is a name the shell resolves
+ * at run time, so `$S id` was classified as though `$S` were a binary, and came
+ * out `safe` (GHSA-fj9r-f47j-c73x).
+ *
+ * Resolving the variable is not the answer and cannot be: a session run keeps the
+ * caller's shell state, so `S=sudo` and `$S id` can arrive as two separate calls,
+ * and a variable exported in the target's own profile is never visible here at
+ * all. What is answerable is whether we know the name — and when we do not, saying
+ * so is the only honest class.
+ *
+ * Only the command word, never the arguments. `echo $HOME` names a command we know;
+ * promoting that would put a prompt on most ordinary shell usage.
+ */
+function hasUnnameableCommand(command: string): boolean {
+  for (const raw of command.split(/[;&|\n]/)) {
+    const words = raw.trim().split(/\s+/).filter(Boolean);
+    const head = effectiveCommandWord(words);
+    if (head !== null && /[$`]/.test(head)) return true;
+  }
+  return false;
+}
+
 export function classifyCommand(command: string, depth = 0): ParsedCommand {
   const trimmed = command.trim();
   const binary = extractBinary(trimmed);
@@ -651,6 +708,18 @@ export function classifyCommand(command: string, depth = 0): ParsedCommand {
   }
 
   if (isDestructive(trimmed) || hasDisqualifyingArgs(trimmed)) {
+    return { binary, fullCommand, class: 'destructive' as CommandClass };
+  }
+
+  // Below this point every branch assumes the command word names something we
+  // recognised. When it is a variable expansion it names nothing we can check, so
+  // the allowlist must not be consulted — `$S` is not on it, and falling through to
+  // the default made an unknown command `safe`.
+  //
+  // `destructive` rather than `privileged`: this is "we cannot tell", not "this is
+  // root". It gates on approval instead of refusing outright, which keeps
+  // `$PREFIX/bin/tool` usable for a role that holds `destructive` on the tier.
+  if (hasUnnameableCommand(trimmed)) {
     return { binary, fullCommand, class: 'destructive' as CommandClass };
   }
 

--- a/test/unit/policy/variable-command-word.test.ts
+++ b/test/unit/policy/variable-command-word.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { classifyCommand } from '../../../src/policy/classifier.js';
+
+/**
+ * Commands whose *name* is not knowable (GHSA-fj9r-f47j-c73x).
+ *
+ * `classifyCommand` decides the class — and with it whether the approval gate
+ * fires — from the literal text of the command word. When that word is a shell
+ * variable expansion, what will actually run is not knowable statically, and the
+ * unresolvable word was treated as an ordinary binary: `safe`. The remote shell
+ * then expanded it and ran whatever it named.
+ *
+ * Distinct from GHSA-v8jh-gv7v-3gvq, which hid elevation inside a *carrier*
+ * (`$(...)`, backticks, `sh -c`) — statically readable, and now read. This hides
+ * it behind a *name*, which is not readable at all: `src/tools/command-tools.ts`
+ * notes that a session run keeps the caller's shell state, so `S=sudo` and
+ * `$S id` can arrive as two separate calls, and a variable exported in the
+ * target's own profile is never visible to this process.
+ *
+ * So the answer is not to resolve the variable but to stop pretending it was
+ * resolved. `destructive` rather than `privileged` deliberately: it requires
+ * approval instead of refusing outright, which keeps `$HOME/bin/tool` usable for
+ * a role that holds `destructive` on the tier.
+ */
+
+describe('a command whose name is a variable', () => {
+  it.each([
+    ['assignment then use', 'S=sudo; $S id'],
+    ['bare use', '$S id'],
+    ['braced', '${S} id'],
+    ['substitution as the name', '$(which sudo) id'],
+    ['behind a wrapper', 'xargs $S'],
+    ['behind env', 'env $S id'],
+    ['behind nohup', 'nohup $S id'],
+    ['path-like', '$PREFIX/bin/tool --version'],
+    ['second segment of a pipeline', 'echo id | $S'],
+    ['after a legitimate first segment', 'ls -la; $S id'],
+  ])('%s requires approval rather than passing as safe', (_label, command) => {
+    expect(classifyCommand(command).class).toBe('destructive');
+  });
+
+  it('does not fire when the variable is only an argument', () => {
+    // The name is known here; only what it operates on is not. Promoting these
+    // would put a prompt on most ordinary shell usage. They sit at `safe` rather
+    // than `read-only` because `$` is a shell metacharacter and the allowlist
+    // branch demotes on those — behaviour that predates this fix and stays.
+    expect(classifyCommand('echo $HOME').class).toBe('safe');
+    expect(classifyCommand('ls $HOME/bin').class).toBe('safe');
+    expect(classifyCommand('cat $CONFIG').class).toBe('safe');
+    expect(classifyCommand('grep $PATTERN file.txt').class).toBe('safe');
+  });
+
+  it('still lets a real elevation win over the weaker class', () => {
+    // A variable command word is `destructive`; an actual sudo is `privileged`.
+    // The higher one has to survive.
+    expect(classifyCommand('sudo $S').class).toBe('privileged');
+    expect(classifyCommand('echo $(sudo id)').class).toBe('privileged');
+    // A variable *prefix* on a known binary is still the known binary: `stripPath`
+    // reduces `$PREFIX/bin/sudo` to `sudo`, so the elevation scan reaches it first
+    // and answers with the stronger class rather than "cannot tell".
+    expect(classifyCommand('$PREFIX/bin/sudo id').class).toBe('privileged');
+  });
+
+  it('leaves everything else where it was', () => {
+    expect(classifyCommand('ls -la').class).toBe('read-only');
+    expect(classifyCommand('echo hi').class).toBe('read-only');
+    expect(classifyCommand('echo $(date)').class).toBe('safe');
+    expect(classifyCommand('rm -rf /tmp/x').class).toBe('destructive');
+  });
+});


### PR DESCRIPTION
Fixes [GHSA-fj9r-f47j-c73x](https://github.com/tufantunc/ssh-mcp/security/advisories/GHSA-fj9r-f47j-c73x). Self-reported while reviewing the fix for GHSA-v8jh-gv7v-3gvq; developed in that advisory's temporary private fork.

## The bug

`classifyCommand` decides the class — and with it whether the approval gate fires — from the **literal text** of the command word. When that word is a shell variable expansion, what will actually run is not knowable here, and the unresolvable word was treated as an ordinary binary: `safe`. The remote shell then expanded it and ran whatever it named.

```
S=sudo; $S id    ->  safe   (allowed, no prompt, audit says "safe")
$S id            ->  safe
xargs $S         ->  safe
$(which sudo) id ->  safe
```

On the `prod` tier — where `privileged` is granted to **no role at all** and `safe` to both `operator` and `admin` — that reached root with no prompt.

## Not the same bug as GHSA-v8jh-gv7v-3gvq, and not fixed by it

That one hid elevation inside a **carrier** — `$(...)`, backticks, process substitution, `sh -c` — which is statically readable, and 2.4.1 reads it. This hides elevation behind a **name**, which is not readable at all. Verified against the parent of that fix: pre-existing, unchanged by it.

Resolving the variable is not available as a fix. `src/tools/command-tools.ts` notes that a session run keeps the caller's shell state, so `S=sudo` and `$S id` can arrive as two separate MCP calls against a persistent shell — and a variable exported in the target's own profile is never visible to this process at all. Substituting same-command assignments would close one spelling and leave the likelier one open.

## What changed

`effectiveCommandWord` reads past privilege prefixes, exec wrappers, assignments and flags to find the word a segment will actually run. If it carries `$` or a backtick, the command is classified `destructive`.

**`destructive`, not `privileged`, deliberately.** This is "cannot tell", not "this is root". It gates on approval instead of refusing outright, which keeps `$PREFIX/bin/tool` usable for a role that holds that class.

**Only the command word, never the arguments.** `echo $HOME` names something we know; promoting that would put a prompt on most ordinary shell usage. A mutation widening the check to arguments fails the suite.

## Behaviour change worth planning for

Measured on `prod` under the default rules:

| | before | after |
|---|---|---|
| `operator`, `$S id` | allow, no prompt | **deny** |
| `admin`, `$S id` | allow, no prompt | **require-approval** |
| either, `echo $HOME` | allow | allow |

A deployment that runs `$PREFIX/bin/...` on production under an operator role will start being refused. Remedy: grant that role `destructive` on the tier, or spell the path literally. Stated in the changeset too.

## Verification

- **774 tests pass.** 13 new.
- **Both mutations die**: removing the check fails ten tests, widening it to arguments fails two.
- **22 spellings tried** — brace forms, `${S:-sudo}`, every exec wrapper (`env`, `nice`, `timeout`, `command`, `exec`, `setsid`, `xargs`), quoted and escaped variants, all three segment separators. None classify below `destructive`.
- A variable *prefix* on a known binary keeps the stronger class: `stripPath` reduces `$PREFIX/bin/sudo` to `sudo`, so the elevation scan answers `privileged`. My first test asserted `destructive` there and was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
