### PR TITLE
docs: use the current host for the Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM Version](https://img.shields.io/npm/v/ssh-mcp)](https://www.npmjs.com/package/ssh-mcp)
 [![Downloads](https://img.shields.io/npm/dm/ssh-mcp)](https://www.npmjs.com/package/ssh-mcp)
 [![CI](https://github.com/tufantunc/ssh-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tufantunc/ssh-mcp/actions/workflows/ci.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/tufantunc/ssh-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/tufantunc/ssh-mcp)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tufantunc/ssh-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/tufantunc/ssh-mcp)
 [![codecov](https://codecov.io/gh/tufantunc/ssh-mcp/graph/badge.svg?branch=main)](https://codecov.io/gh/tufantunc/ssh-mcp)
 [![License](https://img.shields.io/github/license/tufantunc/ssh-mcp)](./LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/tufantunc/ssh-mcp)](https://github.com/tufantunc/ssh-mcp/issues)


### PR DESCRIPTION
`api.scorecard.dev` is the name the project uses now; `api.securityscorecards.dev` is the older spelling. Both 302 to the same `img.shields.io/ossf-scorecard/...` endpoint, so this changes nothing today — it is for the day the legacy host stops redirecting.

**Explicitly not a fix for the "invalid repo path" the badge currently shows.** I checked both hosts against both this repo and `review-pro`: the message appears for `ssh-mcp` on *both* hosts and for neither on `review-pro`, so the host was never the cause. It comes from shields.io, which reads the OpenSSF dataset — and that dataset has no record for us yet:

```
/projects/github.com/tufantunc/ssh-mcp     -> 404
/projects/github.com/tufantunc/review-pro  -> score 7, date 2026-08-21
```

Our Scorecard workflow has run several times successfully with `publish_results: true`; publishing and being ingested are separate steps. Measured from `review-pro`'s own history — first successful run 2026-08-17, score visible 2026-08-21 — the lag is about four days, so this should resolve on its own around 2026-08-28.

No changeset: docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)