### PR TITLE
fix(deps): zod 4, and restore the config guard it silently disabled

### DIFF
--- a/.changeset/zod-4.md
+++ b/.changeset/zod-4.md
@@ -12,4 +12,9 @@ The bump alone does not build. Three things had to move with it.
 
 **And the reserved-key guard stopped working.** `[policy.roleBindings."__proto__"]` was rejected with "Reserved name" under zod 3. Under zod 4, `z.record` never hands `__proto__` to the key schema — it drops the key and returns an object without it, so the config parses *cleanly* and comes out empty. This is not prototype pollution; zod 4 declines to write the key at all, which is the safe half. What is lost is the refusal: an operator naming that role gets a clean startup and a role that silently does not exist, which is the exact failure the guard was written for. `constructor` and `prototype` still reach the key schema and are still rejected. The check now runs against the raw object before `z.record` sees it, and covers all three.
 
-Nothing changes for a valid config. `tools/list` schemas, config parsing and every policy decision are unaffected — the one behaviour difference is that an invalid role or tier name is refused again instead of being dropped.
+Nothing changes for a valid config: parsing, every policy decision and the runtime validation of tool arguments are unchanged. Two client-visible differences, both measured by diffing the emitted `tools/list` schemas across the upgrade:
+
+- **`additionalProperties: false` is no longer emitted** on tool input schemas. Runtime behaviour is identical — an extra argument is accepted and dropped before the handler sees it, on both versions — so what changed is what the schema *advertises*, and zod 3's version was the inaccurate one: it told clients extra properties were rejected while they were silently stripped. A client that validates locally against the schema will now allow a call it used to refuse, and the server will behave exactly as before.
+- **Key order inside the schemas differs**, and `$schema` moves. Not semantic.
+
+The one behaviour difference in config handling is that an invalid role or tier name is refused again instead of being dropped.

--- a/.changeset/zod-4.md
+++ b/.changeset/zod-4.md
@@ -1,20 +1,24 @@
 ---
-"ssh-mcp": patch
+"ssh-mcp": minor
 ---
 
-Upgrade zod to 4.x, and restore a config guard that it silently disabled.
+Upgrade zod to 4.x.
 
-The bump alone does not build. Three things had to move with it.
+`minor` rather than `patch` for the reason 2.3.0 used it: the version reflects what upgrading can do to you, not how large the change is. Nothing that started on 2.4.2 refuses to start here and no config that loaded then fails now — but `tools/list` changes on ten of the eleven tools, and every config validation message is reworded. A client or a wrapper can observe this release.
 
-**The `zod-to-json-schema` override had to go.** It was pinned to `3.24.6` to fix a startup crash under zod 3 (#47), and that pin requires zod `^3.24.1` — so npm satisfied the MCP SDK with a *nested* zod 3 while our own code used zod 4. Two copies in one tree means the SDK types our schemas against internals they do not have, which is why a bare version bump reports `Type 'ZodString' is not assignable to type 'AnySchema'` at every tool definition. Dropping the override lets `zod-to-json-schema` move to 3.25.2, which accepts zod 4, and the whole tree dedupes onto a single `zod@4.4.3`. The SDK needs no help beyond that: it carries its own version-compat layer.
+**What made it more than a version bump.** Our `overrides` block pinned `zod-to-json-schema` to `3.24.6`, added to fix a startup crash under zod 3 (#47). That pin needs zod `^3.24.1`, so npm satisfied the MCP SDK with a *nested* zod 3 while our own code used zod 4 — two copies in one tree, which is why a bare bump reports `Type 'ZodString' is not assignable to type 'AnySchema'` at every tool definition. Dropping the override lets `zod-to-json-schema` reach 3.25.2, which accepts zod 4, and the tree dedupes onto a single `zod@4.4.3`. The SDK needed nothing: it ships its own version-compat layer. Note the override only ever governed *our* install — npm honours overrides in the root project only, so anyone who installed `ssh-mcp` was already resolving `zod-to-json-schema` from the SDK's own range.
 
-**`defaults: defaultsSchema.default({})` became `.prefault({})`.** zod 4 requires `.default()` to supply the parsed output, and added `.prefault()` for the input-side behaviour zod 3 had.
+`defaults: defaultsSchema.default({})` became `.prefault({})`. zod 4 wants the parsed output from `.default()`, and `.prefault()` is the input-side behaviour zod 3 had — with `.default({})` the inner defaults are skipped and `commandMaxChars` arrives `undefined`.
 
-**And the reserved-key guard stopped working.** `[policy.roleBindings."__proto__"]` was rejected with "Reserved name" under zod 3. Under zod 4, `z.record` never hands `__proto__` to the key schema — it drops the key and returns an object without it, so the config parses *cleanly* and comes out empty. This is not prototype pollution; zod 4 declines to write the key at all, which is the safe half. What is lost is the refusal: an operator naming that role gets a clean startup and a role that silently does not exist, which is the exact failure the guard was written for. `constructor` and `prototype` still reach the key schema and are still rejected. The check now runs against the raw object before `z.record` sees it, and covers all three.
+**A config guard had to be rebuilt.** `[policy.roleBindings."__proto__"]` was rejected under zod 3 by the key schema. zod 4's `z.record` never hands `__proto__` to the key schema — it drops the key and returns an object without it, so the block parsed cleanly and vanished. Not prototype pollution: zod 4 declines to write the key, which is the safe half. What was lost is the refusal, and downstream only notices when a profile actually uses that role, so a binding block nothing referenced disappeared in silence. zod 4 also replaces key-schema messages with its own `Invalid key in record`, so the reserved-name text and the empty-name text both stopped reaching the operator. The check now runs against the raw object before `z.record` sees it and owns both rules; the unreachable `refine` came off the key schema at the same time. Reserved-name diagnostics also name the role a bad tier sits under rather than only the tier.
 
-Nothing changes for a valid config: parsing, every policy decision and the runtime validation of tool arguments are unchanged. Two client-visible differences, both measured by diffing the emitted `tools/list` schemas across the upgrade:
+Against the released 2.4.2 this changes no verdict — zod 3 refused all three reserved names too. It matters to anyone bisecting the two commits in this release, and it is what keeps the refusal working now.
 
-- **`additionalProperties: false` is no longer emitted** on tool input schemas. Runtime behaviour is identical — an extra argument is accepted and dropped before the handler sees it, on both versions — so what changed is what the schema *advertises*, and zod 3's version was the inaccurate one: it told clients extra properties were rejected while they were silently stripped. A client that validates locally against the schema will now allow a call it used to refuse, and the server will behave exactly as before.
-- **Key order inside the schemas differs**, and `$schema` moves. Not semantic.
+### Client- and operator-visible changes
 
-The one behaviour difference in config handling is that an invalid role or tier name is refused again instead of being dropped.
+- **`tools/list` no longer advertises `additionalProperties: false`** on the nine tools that take arguments. Runtime behaviour is unchanged: an extra argument is accepted and stripped before the handler sees it, on both versions. zod 3's advertisement was the inaccurate one — it told clients extra properties were rejected while they were silently dropped. A client that validated locally loses a guard that used to catch invented arguments early; the server behaves as it always did.
+- **`signal-process.pid` gained `maximum: 9007199254740991`**, advertised and enforced. zod 4's `.int()` carries a safe-integer bound where zod 3's only tested `Number.isInteger`. A pid above 2^53−1 is now refused; no operating system issues one — Linux caps `pid_max` at 2^22.
+- **Every config validation message is reworded.** `Unrecognized key(s) in object: 'x'` becomes `Unrecognized key: "x"`; `Array must contain at least 1 element(s)` becomes `Too small: expected array to have >=1 items`. Refusals and exit codes are unchanged; a wrapper matching on message text is not. Enum failures no longer echo the rejected value, which was the useful half for a typo like `priviledged`.
+- **Key order inside emitted schemas differs**, and `additionalProperties` no longer precedes `$schema`. Not semantic.
+
+Config parsing, every policy decision, and the runtime validation of every argument a client can realistically send are unchanged.

--- a/.changeset/zod-4.md
+++ b/.changeset/zod-4.md
@@ -1,0 +1,15 @@
+---
+"ssh-mcp": patch
+---
+
+Upgrade zod to 4.x, and restore a config guard that it silently disabled.
+
+The bump alone does not build. Three things had to move with it.
+
+**The `zod-to-json-schema` override had to go.** It was pinned to `3.24.6` to fix a startup crash under zod 3 (#47), and that pin requires zod `^3.24.1` — so npm satisfied the MCP SDK with a *nested* zod 3 while our own code used zod 4. Two copies in one tree means the SDK types our schemas against internals they do not have, which is why a bare version bump reports `Type 'ZodString' is not assignable to type 'AnySchema'` at every tool definition. Dropping the override lets `zod-to-json-schema` move to 3.25.2, which accepts zod 4, and the whole tree dedupes onto a single `zod@4.4.3`. The SDK needs no help beyond that: it carries its own version-compat layer.
+
+**`defaults: defaultsSchema.default({})` became `.prefault({})`.** zod 4 requires `.default()` to supply the parsed output, and added `.prefault()` for the input-side behaviour zod 3 had.
+
+**And the reserved-key guard stopped working.** `[policy.roleBindings."__proto__"]` was rejected with "Reserved name" under zod 3. Under zod 4, `z.record` never hands `__proto__` to the key schema — it drops the key and returns an object without it, so the config parses *cleanly* and comes out empty. This is not prototype pollution; zod 4 declines to write the key at all, which is the safe half. What is lost is the refusal: an operator naming that role gets a clean startup and a role that silently does not exist, which is the exact failure the guard was written for. `constructor` and `prototype` still reach the key schema and are still rejected. The check now runs against the raw object before `z.record` sees it, and covers all three.
+
+Nothing changes for a valid config. `tools/list` schemas, config parsing and every policy decision are unaffected — the one behaviour difference is that an invalid role or tier name is refused again instead of being dropped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-mcp",
-  "version": "2.3.2",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-mcp",
-      "version": "2.3.2",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -17,7 +17,7 @@
         "@opentelemetry/semantic-conventions": "^1.43.0",
         "smol-toml": "^1.7.0",
         "ssh2": "^1.17.0",
-        "zod": "^3.25.28"
+        "zod": "^4.4.3"
       },
       "bin": {
         "ssh-mcp": "build/index.js"
@@ -5569,21 +5569,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
     "@opentelemetry/semantic-conventions": "^1.43.0",
     "smol-toml": "^1.7.0",
     "ssh2": "^1.17.0",
-    "zod": "^3.25.28"
-  },
-  "overrides": {
-    "zod-to-json-schema": "3.24.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -16,10 +16,20 @@ const RESERVED_BINDING_KEYS = ['__proto__', 'constructor', 'prototype'];
 const RESERVED_KEY_MESSAGE =
   `Reserved name (${RESERVED_BINDING_KEYS.join(', ')}). Rename the role or tier.`;
 
-const bindingKeySchema = z.string().min(1).refine(
-  (key) => !RESERVED_BINDING_KEYS.includes(key),
-  { message: RESERVED_KEY_MESSAGE },
-);
+/** Only the length rule. The reserved-name rule lives in `checkReservedKeys` below. */
+const bindingKeySchema = z.string().min(1);
+
+/**
+ * How deep the walk goes: role -> tier -> classes.
+ *
+ * The schema descends exactly two levels whatever the input looks like, but this
+ * function follows the *data*, so without a bound it recurses as deep as the TOML
+ * nests. `smol-toml` parses ten thousand levels happily, and the resulting
+ * `RangeError` escapes `loadConfig` — `safeParse` throws rather than returning
+ * `{ success: false }`, and that call sits outside the loader's try/catch — so the
+ * operator got a stack trace where zod 3 printed a validation error.
+ */
+const MAX_BINDING_DEPTH = 2;
 
 /**
  * The reserved-key check, run against the raw object before `z.record` sees it.
@@ -30,31 +40,57 @@ const bindingKeySchema = z.string().min(1).refine(
  * came out empty. Measured: `Object.keys` on the parsed TOML shows `__proto__`,
  * `z.record` accepts, and the result has zero keys.
  *
- * That is not prototype pollution — zod 4 declines to write the key at all, which
- * is the safe half. What it loses is the loud refusal: the operator gets a clean
- * startup and a role that silently does not exist, which is the exact failure the
- * comment above was written for. `constructor` and `prototype` still reach the key
- * schema and are still rejected by it; only `__proto__` slips past, and this covers
- * all three rather than special-casing the one.
+ * zod 4 broke it in two separate ways, both measured. `z.record` never hands
+ * `__proto__` to the key schema — it drops the key and returns an object without it.
+ * And for the keys it does check, zod 4 replaces the key schema's message with its
+ * own `Invalid key in record`, so neither the reserved-name text nor `min(1)`'s
+ * reached the operator.
+ *
+ * The dropped key is not prototype pollution — zod 4 declines to write it at all,
+ * which is the safe half. What was lost is the refusal, and downstream catches it
+ * only when a profile uses the role: `resolvePolicyRules` throws for a role with no
+ * bindings, but a binding block no profile references was dropped in silence.
+ *
+ * So this owns both rules outright rather than layering over the key schema. The
+ * reserved-name `refine` came off `bindingKeySchema` at the same time — the pipe
+ * short-circuits, so it could never run, and calling it a second layer would have
+ * described something that was not there.
  *
  * `getOwnPropertyNames` and a property descriptor rather than `Object.keys` and a
- * property read. Measured, neither choice changes the outcome for the input this
- * actually receives — `smol-toml` leaves `__proto__` enumerable, and the reserved
- * branch returns before anything reads the value. Both are kept because neither
- * conclusion is ours to depend on: an enumerable key is the TOML parser's decision,
- * and `value['__proto__']` would follow the prototype rather than read the key.
+ * property read. Measured, neither changes the outcome for anything this can
+ * receive: `smol-toml` yields enumerable string keys, and an own `__proto__` data
+ * property shadows the prototype accessor, so even a direct read returns the key.
+ * They are kept because a descriptor cannot run a getter, and because whether a key
+ * is enumerable is the TOML parser's decision rather than ours.
  */
-function checkReservedKeys(value: unknown, ctx: z.core.$RefinementCtx): void {
+function checkReservedKeys(
+  value: unknown,
+  ctx: z.RefinementCtx,
+  prefix: (string | number)[] = [],
+): void {
   if (typeof value !== 'object' || value === null) return;
+  if (prefix.length >= MAX_BINDING_DEPTH) return;
 
   for (const key of Object.getOwnPropertyNames(value)) {
+    // The path carries the ancestry, so a reserved tier names the role it sits under.
+    // Reporting only the leaf pointed the operator at a top-level role that was not in
+    // their file, which is the opposite of a refusal they can act on.
+    const path = [...prefix, key];
+
     if (RESERVED_BINDING_KEYS.includes(key)) {
-      ctx.addIssue({ code: 'custom', message: RESERVED_KEY_MESSAGE, path: [key] });
+      ctx.addIssue({ code: 'custom', message: RESERVED_KEY_MESSAGE, path });
+      // `continue` rather than `return`: a config with several bad names should hear
+      // about all of them, the way the policy engine's coherence check does.
       continue;
     }
+    if (key.length === 0) {
+      ctx.addIssue({ code: 'custom', message: 'Role and tier names cannot be empty.', path });
+      continue;
+    }
+
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (descriptor && typeof descriptor.value === 'object' && descriptor.value !== null) {
-      checkReservedKeys(descriptor.value, ctx);
+      checkReservedKeys(descriptor.value, ctx, path);
     }
   }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,10 +13,51 @@ const commandClassSchema = z.enum(['read-only', 'safe', 'destructive', 'privileg
  * excluded alongside it rather than reasoned about case by case.
  */
 const RESERVED_BINDING_KEYS = ['__proto__', 'constructor', 'prototype'];
+const RESERVED_KEY_MESSAGE =
+  `Reserved name (${RESERVED_BINDING_KEYS.join(', ')}). Rename the role or tier.`;
+
 const bindingKeySchema = z.string().min(1).refine(
   (key) => !RESERVED_BINDING_KEYS.includes(key),
-  { message: `Reserved name (${RESERVED_BINDING_KEYS.join(', ')}). Rename the role or tier.` },
+  { message: RESERVED_KEY_MESSAGE },
 );
+
+/**
+ * The reserved-key check, run against the raw object before `z.record` sees it.
+ *
+ * `bindingKeySchema` alone stopped being enough at zod 4. Its record
+ * implementation never hands `__proto__` to the key schema — it drops the key and
+ * returns an object without it, so a config naming that role parsed *cleanly* and
+ * came out empty. Measured: `Object.keys` on the parsed TOML shows `__proto__`,
+ * `z.record` accepts, and the result has zero keys.
+ *
+ * That is not prototype pollution — zod 4 declines to write the key at all, which
+ * is the safe half. What it loses is the loud refusal: the operator gets a clean
+ * startup and a role that silently does not exist, which is the exact failure the
+ * comment above was written for. `constructor` and `prototype` still reach the key
+ * schema and are still rejected by it; only `__proto__` slips past, and this covers
+ * all three rather than special-casing the one.
+ *
+ * `getOwnPropertyNames` and a property descriptor rather than `Object.keys` and a
+ * property read. Measured, neither choice changes the outcome for the input this
+ * actually receives — `smol-toml` leaves `__proto__` enumerable, and the reserved
+ * branch returns before anything reads the value. Both are kept because neither
+ * conclusion is ours to depend on: an enumerable key is the TOML parser's decision,
+ * and `value['__proto__']` would follow the prototype rather than read the key.
+ */
+function checkReservedKeys(value: unknown, ctx: z.core.$RefinementCtx): void {
+  if (typeof value !== 'object' || value === null) return;
+
+  for (const key of Object.getOwnPropertyNames(value)) {
+    if (RESERVED_BINDING_KEYS.includes(key)) {
+      ctx.addIssue({ code: 'custom', message: RESERVED_KEY_MESSAGE, path: [key] });
+      continue;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor && typeof descriptor.value === 'object' && descriptor.value !== null) {
+      checkReservedKeys(descriptor.value, ctx);
+    }
+  }
+}
 
 export const defaultsSchema = z.object({
   defaultProfile: z.string().optional(),
@@ -86,10 +127,13 @@ export const profileSchema = z.object({
  * code reads it, so accepting it here would document a key that does nothing.
  */
 export const policySchema = z.object({
-  roleBindings: z.record(
-    bindingKeySchema,
-    z.record(bindingKeySchema, z.array(commandClassSchema)),
-  ).optional(),
+  roleBindings: z.unknown()
+    .superRefine(checkReservedKeys)
+    .pipe(z.record(
+      bindingKeySchema,
+      z.record(bindingKeySchema, z.array(commandClassSchema)),
+    ))
+    .optional(),
   denylist: z.array(z.string()).optional(),
 }).strict();
 
@@ -97,7 +141,7 @@ export const policySchema = z.object({
 // key from a newer version) parses cleanly and is dropped with no warning, so
 // the operator gets a clean startup and none of the behaviour they configured.
 export const configSchema = z.object({
-  defaults: defaultsSchema.default({}),
+  defaults: defaultsSchema.prefault({}),
   profiles: z.array(profileSchema).min(1),
   policy: policySchema.optional(),
 }).strict();

--- a/test/unit/policy/policy-config.test.ts
+++ b/test/unit/policy/policy-config.test.ts
@@ -280,6 +280,73 @@ ${ADMIN_PROD_PROFILE}
     await expect(loadConfig(tier)).rejects.toThrow(/Reserved name/);
   });
 
+  it('names the role a reserved tier sits under, not just the tier', async () => {
+    // The path is the actionable half of the refusal. Reporting only the leaf key
+    // pointed the operator at `policy.roleBindings.__proto__` — a top-level role that
+    // is not in their file — while the role they have to edit went unnamed. Asserting
+    // the message alone let that regress unnoticed.
+    const path = await writeConfig(`
+${ADMIN_PROD_PROFILE}
+
+[policy.roleBindings.admin]
+"__proto__" = ["privileged"]
+`);
+    await expect(loadConfig(path)).rejects.toThrow(/policy\.roleBindings\.admin\.__proto__/);
+  });
+
+  it('rejects a role named prototype', async () => {
+    // `prototype` was in the reserved list with nothing pinning it: removing it from
+    // the list failed no test. It is also the name a future narrowing would drop
+    // first, since unlike `__proto__` it reaches the key schema on its own.
+    const path = await writeConfig(`
+${ADMIN_PROD_PROFILE}
+
+[policy.roleBindings."prototype"]
+prod = ["privileged"]
+`);
+    await expect(loadConfig(path)).rejects.toThrow(/Reserved name/);
+  });
+
+  it('reports every reserved name rather than stopping at the first', async () => {
+    // The walk uses `continue`, not `return`, matching the engine's coherence check.
+    // With only a `/Reserved name/` assertion, swapping one for the other was
+    // invisible.
+    const path = await writeConfig(`
+${ADMIN_PROD_PROFILE}
+
+[policy.roleBindings."constructor"]
+prod = ["privileged"]
+
+[policy.roleBindings.admin]
+"prototype" = ["privileged"]
+`);
+    const error = await loadConfig(path).then(() => null, (e: Error) => e);
+    expect(error?.message).toMatch(/roleBindings\.constructor/);
+    expect(error?.message).toMatch(/roleBindings\.admin\.prototype/);
+  });
+
+  it('explains an empty role or tier name instead of saying only that the key is invalid', async () => {
+    // zod 4's record replaces the key schema's own message with `Invalid key in
+    // record`, so `min(1)`'s text stopped reaching the operator.
+    const path = await writeConfig(`
+${ADMIN_PROD_PROFILE}
+
+[policy.roleBindings.""]
+prod = ["privileged"]
+`);
+    await expect(loadConfig(path)).rejects.toThrow(/cannot be empty/);
+  });
+
+  it('refuses roleBindings that is not a table', async () => {
+    const path = await writeConfig(`
+${ADMIN_PROD_PROFILE}
+
+[policy]
+roleBindings = "nope"
+`);
+    await expect(loadConfig(path)).rejects.toThrow(/policy\.roleBindings/);
+  });
+
   it('names the root in a top-level validation error instead of an empty path', async () => {
     const path = await writeConfig(`
 ${ADMIN_PROD_PROFILE}

--- a/test/zod.compat.test.ts
+++ b/test/zod.compat.test.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createRequire } from 'module';
+import { realpathSync } from 'fs';
+import { resolve } from 'path';
 
 /**
  * Our zod and the SDK's have to be the same zod.
@@ -15,10 +18,14 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
  *
  * What actually matters is unchanged and is what this now checks: a schema built
  * with the zod *we* depend on has to be accepted by the SDK, reach the wire as a
- * JSON Schema with our field names on it, and validate arguments. When the tree
- * carries two zod copies — which is what an unconstrained `zod-to-json-schema`
- * override caused — this fails at registration with a type that has no `_parse`,
- * which is the same symptom under a different cause.
+ * JSON Schema with our field names on it, and validate arguments.
+ *
+ * Note what this first test does *not* catch, because the earlier draft of this file
+ * claimed it did: two zod copies in the tree. Planting a nested zod 3 under the SDK
+ * and running this leaves it green — the SDK's compat layer makes mixed copies work
+ * at run time, and the failure an unconstrained `zod-to-json-schema` override
+ * actually produced was a `tsc` error, which no vitest test can raise. The second
+ * test below is what covers that, by comparing resolution rather than behaviour.
  *
  * Deliberately built on a throwaway schema rather than the real eleven tools, so
  * adding a tool or editing a description never touches it.
@@ -26,6 +33,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 describe('zod compatibility with the MCP SDK', () => {
   it('registers a schema from our zod and serves it as JSON Schema', async () => {
     const server = new McpServer({ name: 'zod-compat', version: '0.0.0' }, { capabilities: { tools: {} } });
+    let seen: unknown;
 
     server.tool(
       'probe',
@@ -34,7 +42,10 @@ describe('zod compatibility with the MCP SDK', () => {
         required: z.string().describe('a required string'),
         optional: z.number().optional().describe('an optional number'),
       },
-      async ({ required }) => ({ content: [{ type: 'text' as const, text: `got ${required}` }] }),
+      async (args) => {
+        seen = args;
+        return { content: [{ type: 'text' as const, text: `got ${args.required}` }] };
+      },
     );
 
     const client = new Client({ name: 'zod-compat-client', version: '0.0.0' }, { capabilities: {} });
@@ -56,6 +67,18 @@ describe('zod compatibility with the MCP SDK', () => {
       const ok: any = await client.callTool({ name: 'probe', arguments: { required: 'hi' } });
       expect(ok.content[0].text).toBe('got hi');
 
+      // The two client-visible facts the changeset states about this upgrade, pinned
+      // here because nothing else covered them. zod 3 emitted
+      // `additionalProperties: false`; zod 4 emits nothing, while the runtime keeps
+      // stripping the extra argument either way — so the advertised contract loosened
+      // and the actual behaviour did not. If a future bump starts advertising `true`,
+      // or lets an undeclared argument reach a handler, that is a change clients see.
+      expect(probe!.inputSchema.additionalProperties).toBeUndefined();
+
+      const extra: any = await client.callTool({ name: 'probe', arguments: { required: 'hi', bogus: 1 } });
+      expect(extra.isError).toBeFalsy();
+      expect(seen, 'an undeclared argument reached the handler').toEqual({ required: 'hi' });
+
       // Returned as an error result rather than a rejection — the SDK converts the
       // validation failure into `isError` with the message attached.
       const bad: any = await client.callTool({ name: 'probe', arguments: { optional: 1 } });
@@ -67,18 +90,22 @@ describe('zod compatibility with the MCP SDK', () => {
     }
   });
 
-  it('resolves exactly one zod in the production tree', async () => {
-    // Two copies is the failure this file exists for. The SDK accepts `^3.25 || ^4.0`,
-    // so npm can satisfy it with a nested copy rather than deduping — which is what
-    // an override pinning `zod-to-json-schema` to a zod-3-only version caused.
-    const ours = await import('zod');
-    const sdkSide = await import('@modelcontextprotocol/sdk/server/mcp.js');
-    expect(typeof ours.z.string).toBe('function');
-    expect(typeof sdkSide.McpServer).toBe('function');
+  it('resolves exactly one zod in the production tree', () => {
+    // Resolution, not liveness. The previous version of this test imported both
+    // packages and asserted `typeof z.string === 'function'` — which is true of any
+    // zod, and true with two of them: planting zod 3 at
+    // `node_modules/@modelcontextprotocol/sdk/node_modules/zod` left it passing while
+    // naming the one property it was supposed to protect.
+    //
+    // `realpathSync` because a workspace or a linked install can reach the same
+    // package through two paths without it being two copies.
+    const projectRequire = createRequire(resolve(import.meta.dirname, '../package.json'));
+    const sdkRequire = createRequire(projectRequire.resolve('@modelcontextprotocol/sdk/server/mcp.js'));
 
-    // A schema from our zod must be the same brand the SDK checks against; if the
-    // tree had two copies the registration in the previous test would already have
-    // failed, so this asserts the cheap half — that importing both is coherent.
-    expect(ours.z.string().safeParse('x').success).toBe(true);
+    const ours = realpathSync(projectRequire.resolve('zod/package.json'));
+    const theirs = realpathSync(sdkRequire.resolve('zod/package.json'));
+
+    expect(theirs, `the SDK resolves a different zod than we do:\n  ours:   ${ours}\n  theirs: ${theirs}`)
+      .toBe(ours);
   });
 });

--- a/test/zod.compat.test.ts
+++ b/test/zod.compat.test.ts
@@ -1,16 +1,84 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
-describe('zod compatibility with MCP SDK', async () => {
-  it('app zod schemas expose _parse expected by SDK (regression for issue #10)', async () => {
-    const appZod = await import('zod');
+/**
+ * Our zod and the SDK's have to be the same zod.
+ *
+ * This file used to assert `typeof z.string()._parse === 'function'` — a zod 3
+ * internal the SDK reached into (issue #10), which made the test a tripwire
+ * against upgrading to zod 4 rather than a check on anything we promise. The SDK
+ * has a version-compat layer now, so that premise is gone, and asserting a private
+ * field would only forbid the upgrade it was written to survive.
+ *
+ * What actually matters is unchanged and is what this now checks: a schema built
+ * with the zod *we* depend on has to be accepted by the SDK, reach the wire as a
+ * JSON Schema with our field names on it, and validate arguments. When the tree
+ * carries two zod copies — which is what an unconstrained `zod-to-json-schema`
+ * override caused — this fails at registration with a type that has no `_parse`,
+ * which is the same symptom under a different cause.
+ *
+ * Deliberately built on a throwaway schema rather than the real eleven tools, so
+ * adding a tool or editing a description never touches it.
+ */
+describe('zod compatibility with the MCP SDK', () => {
+  it('registers a schema from our zod and serves it as JSON Schema', async () => {
+    const server = new McpServer({ name: 'zod-compat', version: '0.0.0' }, { capabilities: { tools: {} } });
 
-    // Create a schema using our app's zod
-    const schema: any = (appZod as any).string();
+    server.tool(
+      'probe',
+      'A throwaway tool that exists only to exercise schema conversion.',
+      {
+        required: z.string().describe('a required string'),
+        optional: z.number().optional().describe('an optional number'),
+      },
+      async ({ required }) => ({ content: [{ type: 'text' as const, text: `got ${required}` }] }),
+    );
 
-    // In zod v3, schemas have an internal _parse used by consumers like MCP SDK.
-    // In zod v4, this internal differs, leading to `..._parse is not a function` at runtime.
-    expect(typeof schema._parse).toBe('function');
+    const client = new Client({ name: 'zod-compat-client', version: '0.0.0' }, { capabilities: {} });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const { tools } = await client.listTools();
+      const probe = tools.find((t) => t.name === 'probe');
+      expect(probe, 'the SDK did not accept a schema built with our zod').toBeDefined();
+
+      // The shape the SDK derives from our schema, not the shape of our own tools:
+      // field names and requiredness are what a client needs to call it at all.
+      expect(probe!.inputSchema.type).toBe('object');
+      expect(Object.keys(probe!.inputSchema.properties ?? {}).sort()).toEqual(['optional', 'required']);
+      expect(probe!.inputSchema.required).toEqual(['required']);
+
+      // And validation is live, in both directions.
+      const ok: any = await client.callTool({ name: 'probe', arguments: { required: 'hi' } });
+      expect(ok.content[0].text).toBe('got hi');
+
+      // Returned as an error result rather than a rejection — the SDK converts the
+      // validation failure into `isError` with the message attached.
+      const bad: any = await client.callTool({ name: 'probe', arguments: { optional: 1 } });
+      expect(bad.isError).toBe(true);
+      expect(bad.content[0].text).toMatch(/Invalid arguments for tool probe/);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it('resolves exactly one zod in the production tree', async () => {
+    // Two copies is the failure this file exists for. The SDK accepts `^3.25 || ^4.0`,
+    // so npm can satisfy it with a nested copy rather than deduping — which is what
+    // an override pinning `zod-to-json-schema` to a zod-3-only version caused.
+    const ours = await import('zod');
+    const sdkSide = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    expect(typeof ours.z.string).toBe('function');
+    expect(typeof sdkSide.McpServer).toBe('function');
+
+    // A schema from our zod must be the same brand the SDK checks against; if the
+    // tree had two copies the registration in the previous test would already have
+    // failed, so this asserts the cheap half — that importing both is coherent.
+    expect(ours.z.string().safeParse('x').success).toBe(true);
   });
 });
-
-


### PR DESCRIPTION
Replaces #101. Dependabot's PR is red because a bare version bump does not build — it cannot know to drop our override or migrate our code.

## Why the bump alone fails

Our `package.json` pinned `zod-to-json-schema` to `3.24.6` via `overrides`, added to fix a startup crash under zod 3 (#47). That pin requires zod `^3.24.1`, so npm satisfied the MCP SDK with a **nested zod 3** while our code used zod 4:

```
+ node_modules/@modelcontextprotocol/sdk/node_modules/zod  3.25.76
```

Two copies in one tree, so the SDK types our schemas against internals they do not have:

```
src/tools/command-tools.ts(20,7): error TS2322:
  Type 'ZodString' is not assignable to type 'AnySchema'.
  Type 'ZodString' is missing the following properties: _type, _parse, _getType, ...
```

**The blocker was our override, not the SDK.** SDK 1.30.0 ships a version-compat layer (`server/zod-compat.js`, `server/zod-json-schema-compat.js`) and declares `^3.25 || ^4.0`. Dropping the override lets `zod-to-json-schema` move to 3.25.2, which accepts zod 4, and the tree dedupes onto a single `zod@4.4.3`.

## The part that mattered

`[policy.roleBindings."__proto__"]` was rejected with `Reserved name` under zod 3. Under zod 4 it is **accepted**, and the parsed result has zero keys — `z.record` never hands `__proto__` to the key schema, it drops the key.

Measured: `Object.keys` on the parsed TOML shows `__proto__`, `z.record` accepts, output keys are `[]`.

**This is not prototype pollution** — zod 4 declines to write the key, which is the safe half. What is lost is the refusal: an operator naming that role gets a clean startup and a role that silently does not exist, which is the exact failure the guard was written for. `constructor` and `prototype` still reach the key schema and are still rejected; only `__proto__` slipped.

The check now runs against the raw object before `z.record` sees it, and covers all three.

## Also

- `defaults: defaultsSchema.default({})` → `.prefault({})`. zod 4 wants the parsed output from `.default()`; `.prefault()` is the input-side behaviour zod 3 had.
- `test/zod.compat.test.ts` asserted `typeof z.string()._parse === 'function'` — a zod 3 internal, which made it a **tripwire against this upgrade** rather than a check on anything we promise. Rewritten against public behaviour: a throwaway schema registered through the real SDK, served as JSON Schema, validated in both directions. Throwaway rather than the real eleven tools, so adding a tool never touches it.

## Verification

- **777 tests pass**, including the SSH integration suite.
- Guard mutations: disabling the pre-check fails a test; dropping the recursion fails a test. Swapping `getOwnPropertyNames` for `Object.keys` **does not** — that comment was defending a distinction that changes nothing here, and now says so while keeping the broader call.
- Existing tests were the thing that caught the `__proto__` regression. A snapshot test on emitted schemas would have caught neither this nor the `_parse` obsolescence, which is why none was added.

## Notes

- Production dependency, so a changeset is included — and its content is more than "bump zod".
- Close #101 in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
