### PR TITLE
docs: use a security contact address that reaches someone

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ If you discover a security vulnerability in SSH MCP Server, please report it res
 1. **DO NOT** open a public GitHub issue.
 2. Report it privately, either way:
    - [Open a private security advisory](https://github.com/tufantunc/ssh-mcp/security/advisories/new) — preferred, since it keeps the report, the fix and the CVE in one thread; or
-   - email <security@tufantunc.com>.
+   - email <tufan.tunc.91@gmail.com>.
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce


### PR DESCRIPTION
`security@tufantunc.com` was the email fallback in SECURITY.md and is not an address the maintainer reads. That is worse than no address: a reporter who picks it over the advisory form gets silence and reasonably concludes the project does not answer.

It surfaced concretely — a researcher reached out over LinkedIn saying they could not find an email, having decided the findings were worth reporting but found no route for them.

The [private advisory form](https://github.com/tufantunc/ssh-mcp/security/advisories/new) stays the documented preference, since it keeps report, fix and CVE in one thread and credits the reporter. This just makes the fallback work when someone takes it.

One tradeoff, stated because it is real: a plain address in a public SECURITY.md gets scraped. That is the cost of being reachable, and the form remains the route that needs no address at all.

No changeset: docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)