### PR TITLE
fix: index roleBindings on a null-prototype object (#172)

### DIFF
--- a/.changeset/rolebindings-null-prototype.md
+++ b/.changeset/rolebindings-null-prototype.md
@@ -1,0 +1,13 @@
+---
+"ssh-mcp": patch
+---
+
+Index `roleBindings` on a null-prototype object ([#172](https://github.com/tufantunc/ssh-mcp/issues/172)).
+
+A role name is a free string, and `mergePolicyRules` assigns `roleBindings[role]`. On a plain object that assignment is not always a key: for `__proto__` it invokes the prototype setter instead. Measured, the effect was not global — `Object.prototype` stayed clean — but the object's own prototype became the operator's tier map, after which `roleBindings.prod` resolved through the chain as though `prod` were a role.
+
+Not reachable: the config schema rejects `__proto__`, `constructor` and `prototype` as role or tier names before the engine sees a config, and the policy engine's own coherence check refuses a role no profile uses. What makes it worth closing anyway is that the first of those guards is the one zod 4 silently disabled, rebuilt in 2.5.0 — the authorization engine should not depend on a check that has already regressed once.
+
+`DEFAULT_RULES.roleBindings` gets the same treatment, because `mergePolicyRules` returns it unchanged when there is no `[policy]` section, which is the commonest path. That also removes a second case needing no config at all: on a plain object `roleBindings['toString']` returned a function, so a profile whose role was named after an `Object.prototype` member found a truthy binding. It failed closed — the coherence check still refused it and evaluation floored at read-only — but by a different route than an unknown role, for no reason a reader could see.
+
+No behaviour change for any valid configuration. Reported by [@allenwu-blip](https://github.com/allenwu-blip) using [mcpaudit](https://github.com/allenwu-blip/mcpaudit).

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -22,7 +22,11 @@ export interface PolicyRules {
 export const HOST_GROUPS = ['prod', 'staging', 'dev'] as const;
 
 export const DEFAULT_RULES: PolicyRules = {
-  roleBindings: {
+  // Null-prototype for the reason spelled out at `mergePolicyRules`: a role name is
+  // a free string, and this object is indexed by it. `mergePolicyRules` returns this
+  // one unchanged when there is no override, so fixing only the merged copy would
+  // leave the commonest path — no `[policy]` section at all — on a plain object.
+  roleBindings: Object.assign(Object.create(null), {
     viewer: {
       prod: ['read-only'],
       staging: ['read-only'],
@@ -38,7 +42,7 @@ export const DEFAULT_RULES: PolicyRules = {
       staging: ['read-only', 'safe', 'destructive', 'privileged'],
       dev: ['read-only', 'safe', 'destructive', 'privileged'],
     },
-  },
+  }),
 };
 
 /**
@@ -69,7 +73,26 @@ export function mergePolicyRules(
 
   // Copy every tier map: assigning base's objects straight through would let a
   // later merge mutate DEFAULT_RULES, which is a module-level singleton.
-  const roleBindings: Record<string, Record<string, CommandClass[]>> = {};
+  //
+  // `Object.create(null)`, not `{}`, because the loop below assigns a key the
+  // operator chose: `roleBindings[role] = ...` with `role === '__proto__'` invokes
+  // the prototype setter on a plain object rather than creating a key. Measured, the
+  // effect is not global — `Object.prototype` is untouched — but this object's own
+  // prototype is replaced by the operator's tier map, after which `roleBindings.prod`
+  // resolves through the chain as though `prod` were a role. Reported as
+  // https://github.com/tufantunc/ssh-mcp/issues/172.
+  //
+  // Reaching it needs the schema guard in config/schema.ts to be bypassed first, and
+  // that guard is exactly what zod 4 silently disabled once already (2.5.0 rebuilt
+  // it). Insurance in the authorization engine is worth one function call.
+  //
+  // It also removes a second case with no config involved: on a plain object,
+  // `roleBindings['toString']` returns a function, so a profile whose role is named
+  // after an `Object.prototype` member found a truthy "binding". That failed closed —
+  // `findPolicyProblems` still refused it and evaluation floored at read-only — but it
+  // took a different branch than an unknown role, for no reason a reader could see.
+  const roleBindings: Record<string, Record<string, CommandClass[]>> =
+    Object.create(null);
   for (const [role, groups] of Object.entries(base.roleBindings)) {
     roleBindings[role] = { ...groups };
   }

--- a/test/unit/policy/rolebindings-prototype.test.ts
+++ b/test/unit/policy/rolebindings-prototype.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { mergePolicyRules, resolvePolicyRules, DEFAULT_RULES } from '../../../src/policy/engine.js';
+
+/**
+ * `roleBindings` is indexed by a name the operator chose (issue #172).
+ *
+ * `role` is a free string — `role: z.string().default('operator')` — and
+ * `mergePolicyRules` assigns `roleBindings[role]`. On a plain object that assignment
+ * is not always a key: for `__proto__` it invokes the prototype setter instead.
+ *
+ * Measured before the fix, the effect was not global — `Object.prototype` stayed
+ * clean — but this object's own prototype became the operator's tier map, after which
+ * `roleBindings.prod` resolved through the chain as though `prod` were a role. The
+ * config schema rejects that name before the engine sees it, and that guard is what
+ * zod 4 silently disabled once already, which is why the engine does not rely on it.
+ */
+describe('roleBindings cannot be reached through the prototype chain', () => {
+  const evilRole = () => JSON.parse('{"__proto__":{"prod":["privileged"]}}');
+
+  it('treats __proto__ as a key rather than a prototype assignment', () => {
+    const merged = mergePolicyRules(DEFAULT_RULES, { roleBindings: evilRole() });
+
+    expect(Object.getPrototypeOf(merged.roleBindings)).toBeNull();
+    expect(Object.keys(merged.roleBindings)).toContain('__proto__');
+    // The load-bearing assertion: before the fix this was ['privileged'], inherited
+    // from the tier map the setter installed as the prototype.
+    expect(merged.roleBindings.prod).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty('prod');
+  });
+
+  it('does not answer for Object.prototype members, with no config involved', () => {
+    // `mergePolicyRules` returns DEFAULT_RULES unchanged when there is no override,
+    // which is the commonest path, so fixing only the merged copy would have left it.
+    for (const rules of [DEFAULT_RULES, mergePolicyRules(DEFAULT_RULES, undefined)]) {
+      for (const inherited of ['toString', 'constructor', 'valueOf', 'hasOwnProperty']) {
+        expect(rules.roleBindings[inherited]).toBeUndefined();
+      }
+    }
+  });
+
+  it('still merges an ordinary override, and still copies rather than aliasing', () => {
+    const merged = mergePolicyRules(DEFAULT_RULES, {
+      roleBindings: { operator: { prod: ['read-only', 'safe', 'destructive'] } },
+    });
+
+    expect(merged.roleBindings.operator.prod).toEqual(['read-only', 'safe', 'destructive']);
+    expect(merged.roleBindings.admin).toEqual(DEFAULT_RULES.roleBindings.admin);
+    // The reason the copying loop exists: DEFAULT_RULES is a module-level singleton.
+    // Checked on a role the override does *not* touch — `operator` gets a fresh object
+    // from the override loop's spread either way, so asserting identity there passed
+    // even with the copying loop's spread removed. `admin` is the one that would alias.
+    expect(merged.roleBindings.admin).not.toBe(DEFAULT_RULES.roleBindings.admin);
+    expect(DEFAULT_RULES.roleBindings.operator.prod).toEqual(['read-only', 'safe']);
+  });
+
+  it('leaves every real policy decision where it was', () => {
+    const profile = (role: string) => ({
+      name: 'p', group: 'prod', host: 'h', port: 22, user: 'u', auth: 'key' as const, role,
+      readOnly: false, approvalPolicy: 'ask-destructive' as const, tty: false, timeout: 5000,
+      maxChars: 5000, maxOutputBytes: 1_048_576, cert: false, sessionMaxPerConnection: 5,
+      sessionIdleTimeoutMs: 60_000, sessionBackgroundMaxMs: 3_600_000, commandQuotaPerDay: 0,
+    });
+    const rules = resolvePolicyRules([profile('admin'), profile('operator'), profile('viewer')]);
+    expect(rules.roleBindings.admin.prod).toEqual(['read-only', 'safe', 'destructive']);
+    expect(rules.roleBindings.operator.prod).toEqual(['read-only', 'safe']);
+    expect(rules.roleBindings.viewer.prod).toEqual(['read-only']);
+  });
+});


### PR DESCRIPTION
Closes #172, reported by @allenwu-blip using [mcpaudit](https://github.com/allenwu-blip/mcpaudit).

## The finding

`src/policy/engine.ts:77` assigns `roleBindings[role]` where `role` is a free string from the operator's config (`role: z.string().default('operator')`). On a plain object that assignment is not always a key — for `__proto__` it invokes the prototype setter.

The report's wording was precise and this follows it: **not** `Object.prototype` pollution. Measured before the fix, with the schema guard bypassed:

```
Object.keys(rb)           ["viewer","operator","admin"]     ← __proto__ is not an own key
Object.getPrototypeOf(rb) {"prod":["privileged"]}           ← the tier map became the prototype
rb.prod                   ["privileged"]                    ← a tier name resolves as a role
Object.prototype.prod     undefined                         ← global prototype untouched
```

## Why fix something unreachable

Three layers stand in front of it: the config schema rejects `__proto__`/`constructor`/`prototype` as role or tier names, `findPolicyProblems` refuses a role no profile uses, and evaluation floors at read-only.

The reason to close it anyway is *which* layer is load-bearing. The schema guard is the one **zod 4 silently disabled** — `z.record` stopped handing `__proto__` to the key schema, which 2.5.0 had to rebuild. An authorization engine should not rest on a check that has already regressed once.

## Beyond the report

`DEFAULT_RULES.roleBindings` gets the same treatment. `mergePolicyRules` returns it **unchanged** when there is no `[policy]` section — the commonest path — so fixing only the merged copy would have left it, and the suggested fix read literally would have too.

That also closes a second case needing no config at all:

```
DEFAULT_RULES.roleBindings['toString']  →  [Function]   (before)
                                        →  undefined    (after)
```

A profile whose role was named after an `Object.prototype` member found a truthy binding. It failed closed — the coherence check still refused it and evaluation floored at read-only — but by a different route than an unknown role, for no reason a reader could see.

## Verification

- **786 tests pass** (782 before, 4 added).
- Three mutations, all dying: plain object for the merge container, plain object for `DEFAULT_RULES`, and dropping the copying loop's spread.
- That third mutation **caught a defect in my own test**: it asserted non-aliasing on `operator`, which the override loop re-creates anyway, so it passed with the copy removed. It checks `admin` now — the role that would actually alias.
- Real decisions unchanged, measured: `admin`+`sudo id` → `privileged/deny`, `operator`+`ls -la` → `read-only/allow`, `viewer`+`rm -rf /tmp/x` → `destructive/deny`.

## Not changed

The `opaUrl` item (`engine.ts:321`) is left alone. The report calls it non-exploitable and suggests optional scheme/host validation; that is a separate decision about a startup-time config value and does not belong in this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
