### PR TITLE
fix(http): throttle failed bearer authentication

### DIFF
--- a/.changeset/quick-hounds-throttle.md
+++ b/.changeset/quick-hounds-throttle.md
@@ -36,7 +36,14 @@ Two things worth knowing before upgrading:
   request, or name a victim's address and spend theirs. This assumes one trusted proxy hop.
 - **The budget is tracked for at most 1024 addresses**, and a fresh address evicts the
   emptiest tracked one rather than the oldest, so cycling addresses cannot refund a spent
-  budget.
+  budget. While all 1024 are spent — which needs 1024 addresses that have each burned a
+  full budget — an arriving client has one attempt rather than the full ten. That is the
+  price of not refunding, and it is the one place this control is worse than no control.
+- **`X-Forwarded-For` is read only when the peer is the proxy.** Bare `--trustProxy` means
+  a loopback peer, which is the deployment the README describes; `--trustedProxies` names
+  one elsewhere. Trusting whoever connected would have left the header forgeable by anyone
+  reaching the listener directly, which is the hole the rightmost-entry rule was meant to
+  close.
 - **A malformed `--authFailureLimit` is now refused at startup** rather than silently
   disabling the check. Only `0` turns it off.
 

--- a/.changeset/quick-hounds-throttle.md
+++ b/.changeset/quick-hounds-throttle.md
@@ -1,0 +1,32 @@
+---
+"ssh-mcp": minor
+---
+
+**Security:** throttle failed bearer authentication on the HTTP transport ([#187](https://github.com/tufantunc/ssh-mcp/issues/187)).
+
+`--rateLimit` never saw a wrong token. The auth check answers before the limiter is
+reached, so a failed attempt consumed nothing — measured as twelve 401s and zero 429s
+against `--rateLimit=3`, with the bucket still full afterwards. A bearer token is the only
+thing in front of a tool that runs commands over SSH, and guessing it ran at network speed
+with no backoff.
+
+`--authFailureLimit` (default 10 per client per minute, 0 disables) is a separate budget,
+spent only on a 401. A correct token never consumes from it, so a working client never
+throttles itself, which is why the default is on. Moving the request limiter above the auth
+check instead would have closed this and opened something worse: that bucket is global, so
+unauthenticated traffic could then starve every legitimate client.
+
+Two things worth knowing before upgrading:
+
+- **Once an address has spent its budget, every request from it waits — including one with
+  the right token.** That is deliberate. Gating only the 401 path would still evaluate the
+  guess and still serve a correct token, so the status code would tell an attacker which
+  token was right and the limit would slow nothing down. A client with a correct token in
+  its config never reaches this; a client with a *wrong* token now waits between attempts
+  rather than retrying freely.
+- **Clients are told apart by socket address.** `--trustProxy` reads `X-Forwarded-For`
+  instead, and is off by default because a client that can set that header could otherwise
+  pick its own budget. Set it only when a proxy you control is in front.
+
+The request limiter itself is unchanged, and is still one global bucket rather than one per
+client — a separate question, tracked in #187.

--- a/.changeset/quick-hounds-throttle.md
+++ b/.changeset/quick-hounds-throttle.md
@@ -22,11 +22,23 @@ Two things worth knowing before upgrading:
   the right token.** That is deliberate. Gating only the 401 path would still evaluate the
   guess and still serve a correct token, so the status code would tell an attacker which
   token was right and the limit would slow nothing down. A client with a correct token in
-  its config never reaches this; a client with a *wrong* token now waits between attempts
-  rather than retrying freely.
+  its config never spends any of the budget, so it never throttles *itself* — but it does
+  wait if it shares a source address with something that is failing. Behind a reverse
+  proxy that is every client at once, so **set `--trustProxy` when the proxy is yours**;
+  without it the server keys on the proxy's address and one failing client can lock out the
+  rest. The server says so on stderr the first time it sees `X-Forwarded-For` without
+  `--trustProxy`.
 - **Clients are told apart by socket address.** `--trustProxy` reads `X-Forwarded-For`
   instead, and is off by default because a client that can set that header could otherwise
-  pick its own budget. Set it only when a proxy you control is in front.
+  pick its own budget. When it is on, the **rightmost** entry is used — a proxy appends the
+  address it saw, so everything left of the last entry came from the client. Reading the
+  leftmost would be worse than having no limit: a client could mint a fresh budget per
+  request, or name a victim's address and spend theirs. This assumes one trusted proxy hop.
+- **The budget is tracked for at most 1024 addresses**, and a fresh address evicts the
+  emptiest tracked one rather than the oldest, so cycling addresses cannot refund a spent
+  budget.
+- **A malformed `--authFailureLimit` is now refused at startup** rather than silently
+  disabling the check. Only `0` turns it off.
 
 The request limiter itself is unchanged, and is still one global bucket rather than one per
 client — a separate question, tracked in #187.

--- a/README.md
+++ b/README.md
@@ -619,7 +619,8 @@ ssh-mcp --transport=http --httpPort=3000 --bearerToken=secret --rateLimit=60
 | `--httpHost` | 127.0.0.1 | Bind address |
 | `--rateLimit` | 0 (off) | Max requests per minute (0 = unlimited) |
 | `--authFailureLimit` | 10 | Failed bearer-auth attempts allowed per client per minute (0 = off) |
-| `--trustProxy` | false | Read the client address from `X-Forwarded-For`. Only behind a proxy you control |
+| `--trustProxy` | false | Read the client address from `X-Forwarded-For`, but only when the peer is the proxy — bare means a loopback peer |
+| `--trustedProxies` | — | Comma-separated peer addresses allowed to send `X-Forwarded-For`. Empty means loopback only |
 
 Endpoints: `POST /` (MCP Streamable HTTP), `GET /status`, `GET /health`
 
@@ -642,8 +643,12 @@ reverse proxy that means every client shares one budget**, so set `--trustProxy`
 proxy is yours — the server prints a warning the first time it sees `X-Forwarded-For`
 without it. `--trustProxy` takes the *rightmost* `X-Forwarded-For` entry, which is the hop
 the proxy itself appended; everything to its left came from the client, so reading the
-leftmost would let a client choose its own budget or spend a victim's. One trusted hop is
-assumed. A malformed `--authFailureLimit` is refused at startup rather than silently
+leftmost would let a client choose its own budget or spend a victim's. That only holds if a
+proxy actually appended the entry, so the header is read **only when the peer is the
+proxy** — bare `--trustProxy` means a loopback peer, which is the deployment above; name a
+proxy elsewhere with `--trustedProxies`. When the header cannot be read as an address, or
+the peer is not trusted, the server falls back to the socket address and says so once, so
+a flag that is not taking effect is not silent. One trusted hop is assumed. A malformed `--authFailureLimit` is refused at startup rather than silently
 disabling the check; only `0` turns it off.
 
 **Always terminate TLS at a reverse proxy** (Caddy/nginx). The server listens on `127.0.0.1` only.
@@ -696,7 +701,8 @@ Secrets are **never** passed as CLI arguments.
 | `--bearerToken` | — | Bearer token for HTTP transport auth (required for `--transport=http`) |
 | `--rateLimit` | 0 | HTTP requests per minute on the MCP route (0 = unlimited) |
 | `--authFailureLimit` | 10 | Failed bearer-auth attempts allowed per client per minute (0 = off) |
-| `--trustProxy` | false | Read the client address from `X-Forwarded-For`. Only behind a proxy you control |
+| `--trustProxy` | false | Read the client address from `X-Forwarded-For`, but only when the peer is the proxy — bare means a loopback peer |
+| `--trustedProxies` | — | Comma-separated peer addresses allowed to send `X-Forwarded-For`. Empty means loopback only |
 | `--allowedHosts` | bind address + localhost | Comma-separated Host headers accepted by the DNS-rebinding guard |
 | `--hostKeyMode` | `tofu` | `tofu \| strict \| insecure`. See [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) — `strict` currently refuses every host |
 | `--insecureHostKey` | false | Disable host key verification (test only!) |

--- a/README.md
+++ b/README.md
@@ -637,10 +637,14 @@ guessing ran at network speed. `--authFailureLimit` gives each client its own sm
 spent only on a 401; a correct token never consumes from it, so a working client never
 throttles itself. Once an address has spent its budget every request from it waits,
 including one with the right token — that is deliberate, since answering the guess would
-otherwise tell the caller which token was right. Clients are told apart by socket address;
-`--trustProxy` reads `X-Forwarded-For` instead, and should be set only when a proxy you
-control is in front, because a client that can set that header can otherwise choose its own
-budget.
+otherwise tell the caller which token was right. Clients are told apart by socket address. **Behind a
+reverse proxy that means every client shares one budget**, so set `--trustProxy` when the
+proxy is yours — the server prints a warning the first time it sees `X-Forwarded-For`
+without it. `--trustProxy` takes the *rightmost* `X-Forwarded-For` entry, which is the hop
+the proxy itself appended; everything to its left came from the client, so reading the
+leftmost would let a client choose its own budget or spend a victim's. One trusted hop is
+assumed. A malformed `--authFailureLimit` is refused at startup rather than silently
+disabling the check; only `0` turns it off.
 
 **Always terminate TLS at a reverse proxy** (Caddy/nginx). The server listens on `127.0.0.1` only.
 

--- a/README.md
+++ b/README.md
@@ -618,6 +618,8 @@ ssh-mcp --transport=http --httpPort=3000 --bearerToken=secret --rateLimit=60
 | `--httpPort` | 3000 | HTTP listen port |
 | `--httpHost` | 127.0.0.1 | Bind address |
 | `--rateLimit` | 0 (off) | Max requests per minute (0 = unlimited) |
+| `--authFailureLimit` | 10 | Failed bearer-auth attempts allowed per client per minute (0 = off) |
+| `--trustProxy` | false | Read the client address from `X-Forwarded-For`. Only behind a proxy you control |
 
 Endpoints: `POST /` (MCP Streamable HTTP), `GET /status`, `GET /health`
 
@@ -628,6 +630,17 @@ refuses every tool call. `GET /status` carries the profile list itself and stays
 bearer token.
 
 When rate limit is exceeded, the server returns HTTP 429 with `Retry-After` header and a JSON-RPC error body so MCP clients can handle it gracefully.
+
+Failed authentication is throttled separately, and on by default. `--rateLimit` never saw a
+wrong bearer token, because the auth check answers before the limiter is reached — so
+guessing ran at network speed. `--authFailureLimit` gives each client its own small budget,
+spent only on a 401; a correct token never consumes from it, so a working client never
+throttles itself. Once an address has spent its budget every request from it waits,
+including one with the right token — that is deliberate, since answering the guess would
+otherwise tell the caller which token was right. Clients are told apart by socket address;
+`--trustProxy` reads `X-Forwarded-For` instead, and should be set only when a proxy you
+control is in front, because a client that can set that header can otherwise choose its own
+budget.
 
 **Always terminate TLS at a reverse proxy** (Caddy/nginx). The server listens on `127.0.0.1` only.
 
@@ -678,6 +691,8 @@ Secrets are **never** passed as CLI arguments.
 | `--httpHost` | 127.0.0.1 | HTTP bind address |
 | `--bearerToken` | — | Bearer token for HTTP transport auth (required for `--transport=http`) |
 | `--rateLimit` | 0 | HTTP requests per minute on the MCP route (0 = unlimited) |
+| `--authFailureLimit` | 10 | Failed bearer-auth attempts allowed per client per minute (0 = off) |
+| `--trustProxy` | false | Read the client address from `X-Forwarded-For`. Only behind a proxy you control |
 | `--allowedHosts` | bind address + localhost | Comma-separated Host headers accepted by the DNS-rebinding guard |
 | `--hostKeyMode` | `tofu` | `tofu \| strict \| insecure`. See [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) — `strict` currently refuses every host |
 | `--insecureHostKey` | false | Disable host key verification (test only!) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,7 @@ SSH MCP Server gives LLM agents the ability to execute shell commands on remote 
 | Weak SSH algorithms | Frozen algorithm allow-list per RFC 9142 (no SHA-1, no CBC, no ssh-rsa) |
 | PTY session leaks (MaxSessions) | Interactive sessions are bounded, not absent: `sessionMaxPerConnection` (default 5), `sessionIdleTimeoutMs` (10 min), `sessionBackgroundMaxMs` (1 h), and a reaper that sweeps expired sessions every 60s. One-shot commands use `exec()` and hold no channel. No persistent `su` shells |
 | Unbounded agent actions | Per-profile RBAC, rate limits, denylist, approval modes |
+| Bearer token guessing | `--authFailureLimit` — a per-client budget spent only on failed auth, on by default |
 
 ## Stopping a Command
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,8 +84,20 @@ export function parseFailureLimit(raw: string | null | undefined): number | unde
       'Use --authFailureLimit=0 to turn the check off deliberately.',
     );
   }
-  return Number(raw.trim());
+  const value = Number(raw.trim());
+  // Bounded, because an unbounded one is the same fail-open this guard exists to stop:
+  // `--authFailureLimit=99999999999999999999` parsed to 1e20, a bucket that never empties
+  // and a `Retry-After` of 1 — configured on, functionally absent.
+  if (!Number.isSafeInteger(value) || value > MAX_AUTH_FAILURE_LIMIT) {
+    throw new OperatorError(
+      `--authFailureLimit must be between 0 and ${MAX_AUTH_FAILURE_LIMIT}, got ${JSON.stringify(raw)}.`,
+    );
+  }
+  return value;
 }
+
+/** Far above any real budget; the point is that there is one. */
+const MAX_AUTH_FAILURE_LIMIT = 10_000;
 
 export function flagEnabled(argv: Record<string, string | null>, name: string): boolean {
   if (!(name in argv)) return false;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,28 @@ export function parseArgv(args: string[] = process.argv.slice(2)): Record<string
  * `--flag=false` and `--flag=0` turn it off, because a flag that cannot be
  * turned off once written into a wrapper script is its own annoyance.
  */
+/**
+ * `--authFailureLimit`, refusing rather than guessing.
+ *
+ * `parseArgv` stores `null` for a flag written without a value, and `null !== undefined`,
+ * so a bare `--authFailureLimit` reached `parseInt` and produced NaN. NaN fails the `> 0`
+ * test the transport uses to decide whether to build the limiter at all, so a typo — or
+ * `--authFailureLimit=off`, which `0 = off` makes a plausible spelling — silently turned
+ * off a control that is on by default, with no line in the startup banner to say so. The
+ * same shape on `--rateLimit` is harmless because that one defaults to off; this one does
+ * not, which is what makes failing open new.
+ */
+export function parseFailureLimit(raw: string | null | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null || !/^\d+$/.test(raw.trim())) {
+    throw new OperatorError(
+      `--authFailureLimit needs a non-negative whole number, got ${JSON.stringify(raw)}. ` +
+      'Use --authFailureLimit=0 to turn the check off deliberately.',
+    );
+  }
+  return Number(raw.trim());
+}
+
 export function flagEnabled(argv: Record<string, string | null>, name: string): boolean {
   if (!(name in argv)) return false;
   const value = argv[name];

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,10 @@ async function main() {
       host: (argv.httpHost as string) || '127.0.0.1',
       bearerToken: argv.bearerToken as string | undefined,
       rateLimit: parseInt(argv.rateLimit as string) || 0,
+      authFailureLimit: argv.authFailureLimit === undefined
+        ? undefined
+        : parseInt(argv.authFailureLimit as string),
+      trustProxy: flagEnabled(argv, 'trustProxy'),
       allowedHosts: (argv.allowedHosts as string)?.split(',').map((h) => h.trim()).filter(Boolean),
       registry,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   buildAppConfig,
   checkRemovedFlags,
   flagEnabled,
+  parseFailureLimit,
   resolveHostKeyMode,
 } from './cli.js';
 
@@ -70,9 +71,7 @@ async function main() {
       host: (argv.httpHost as string) || '127.0.0.1',
       bearerToken: argv.bearerToken as string | undefined,
       rateLimit: parseInt(argv.rateLimit as string) || 0,
-      authFailureLimit: argv.authFailureLimit === undefined
-        ? undefined
-        : parseInt(argv.authFailureLimit as string),
+      authFailureLimit: parseFailureLimit(argv.authFailureLimit),
       trustProxy: flagEnabled(argv, 'trustProxy'),
       allowedHosts: (argv.allowedHosts as string)?.split(',').map((h) => h.trim()).filter(Boolean),
       registry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ async function main() {
       rateLimit: parseInt(argv.rateLimit as string) || 0,
       authFailureLimit: parseFailureLimit(argv.authFailureLimit),
       trustProxy: flagEnabled(argv, 'trustProxy'),
+      trustedProxies: (argv.trustedProxies as string)?.split(',').map((h) => h.trim()).filter(Boolean),
       allowedHosts: (argv.allowedHosts as string)?.split(',').map((h) => h.trim()).filter(Boolean),
       registry,
     });

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'http';
 import { randomUUID, timingSafeEqual } from 'crypto';
+import { isIP } from 'net';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -12,10 +13,10 @@ const MAX_BODY_SIZE = 1_048_576; // 1MB
 const MAX_SESSIONS = 64;
 
 /** How many failed auth attempts one client may make per minute. 0 disables the check. */
-const DEFAULT_AUTH_FAILURE_LIMIT = 10;
+export const DEFAULT_AUTH_FAILURE_LIMIT = 10;
 
 /** Cap on tracked clients, for the reason `MAX_SESSIONS` exists: churn must not grow a map. */
-const MAX_TRACKED_CLIENTS = 1024;
+export const MAX_TRACKED_CLIENTS = 1024;
 
 const REFILL_INTERVAL_MS = 60_000;
 
@@ -75,7 +76,7 @@ class RateLimiter {
  * point. Charging only after the comparison would leave the guess itself evaluated and the
  * status code would still tell the attacker which token was right.
  */
-class AuthFailureLimiter {
+export class AuthFailureLimiter {
   private buckets = new Map<string, Bucket>();
 
   constructor(private maxTokens: number) {}
@@ -95,17 +96,23 @@ class AuthFailureLimiter {
   recordFailure(key: string): void {
     let bucket = this.buckets.get(key);
     if (bucket === undefined) {
-      // Evict the least recently refilled entry rather than growing without bound. A
-      // client that has stopped failing is the one worth forgetting.
-      if (this.buckets.size >= MAX_TRACKED_CLIENTS) {
-        let oldestKey: string | null = null;
-        let oldest = Infinity;
-        for (const [k, b] of this.buckets) {
-          if (b.lastRefill < oldest) { oldest = b.lastRefill; oldestKey = k; }
-        }
-        if (oldestKey !== null) this.buckets.delete(oldestKey);
-      }
       bucket = { tokens: this.maxTokens, lastRefill: Date.now() };
+      if (this.buckets.size >= MAX_TRACKED_CLIENTS) {
+        // Evict the *fullest* entry, not the oldest. An exhausted bucket has the oldest
+        // `lastRefill` by construction, so evicting by age evicted the locked-out client
+        // first and then handed its key a fresh budget: minting enough keys cleared a
+        // lockout, which was measured end to end. A full bucket is the one with nothing
+        // worth remembering.
+        let fullestKey: string | null = null;
+        let fullest = -1;
+        for (const [k, b] of this.buckets) {
+          if (b.tokens > fullest) { fullest = b.tokens; fullestKey = k; }
+        }
+        if (fullestKey !== null) this.buckets.delete(fullestKey);
+        // Every tracked client is spent, so the table itself is the signal. The new key
+        // inherits that rather than being rewarded for arriving late.
+        if (fullest <= 0) bucket = { tokens: 0, lastRefill: Date.now() };
+      }
       this.buckets.set(key, bucket);
     }
     consume(bucket, this.maxTokens);
@@ -119,15 +126,33 @@ class AuthFailureLimiter {
  * server is normally run. `X-Forwarded-For` is read only when a proxy is explicitly
  * trusted: honouring it unconditionally would let any client forge its own key and so opt
  * out of the limit entirely.
+ *
+ * When it is read, the **rightmost** entry is the one taken, not the leftmost. A proxy
+ * appends the address it saw, so the rightmost entry is what the nearest trusted proxy
+ * observed while every entry to its left came from the client. Reading the leftmost was
+ * worse than having no limit: a client sending `X-Forwarded-For: 10.0.0.1` minted a fresh
+ * budget per request — measured as nine wrong tokens and zero 429s — and sending a
+ * victim's address burned *their* budget instead, locking out a correct token.
+ *
+ * This assumes exactly one trusted proxy in front, which is what `--trustProxy` means. A
+ * chain of two would need the second-from-right, and this does not try to guess the depth.
+ * Anything that is not an IP address is discarded rather than used as a map key.
  */
 export function clientKey(req: IncomingMessage, trustProxy: boolean): string {
   if (trustProxy) {
     const forwarded = req.headers['x-forwarded-for'];
-    const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(',')[0]?.trim();
-    if (first) return first;
+    const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
+    const entries = (raw ?? '').split(',').map((e) => e.trim()).filter(Boolean);
+    const nearest = entries[entries.length - 1];
+    if (nearest !== undefined && isIP(canonicalAddress(nearest)) !== 0) {
+      return canonicalAddress(nearest);
+    }
   }
-  const address = req.socket.remoteAddress ?? 'unknown';
-  // `::ffff:127.0.0.1` and `127.0.0.1` are the same client; key them the same way.
+  return canonicalAddress(req.socket.remoteAddress ?? 'unknown');
+}
+
+/** `::ffff:127.0.0.1` and `127.0.0.1` are the same client; key them the same way. */
+function canonicalAddress(address: string): string {
   return address.startsWith('::ffff:') ? address.slice(7) : address;
 }
 
@@ -184,6 +209,22 @@ export async function startHttpServer(
   const authFailureLimiter = authFailureLimit > 0
     ? new AuthFailureLimiter(authFailureLimit)
     : null;
+
+  // Said once, when it turns out to matter. Behind a proxy with `--trustProxy` off, every
+  // client is keyed on the proxy's socket address and so shares one budget — which means
+  // ten failures from anyone locks out everyone. The README tells operators to terminate
+  // TLS at a proxy, so this is the configuration it recommends, and the collapse is
+  // invisible until a legitimate client is refused.
+  let warnedSharedBudget = false;
+  const warnSharedBudget = () => {
+    if (warnedSharedBudget) return;
+    warnedSharedBudget = true;
+    console.error(
+      'POLICY WARNING: requests carry X-Forwarded-For but --trustProxy is off, so every ' +
+      'client shares one failed-auth budget keyed on the proxy address — one failing ' +
+      'client can lock out the rest. Set --trustProxy if that proxy is yours.',
+    );
+  };
 
   const rateLimiter = opts.rateLimit && opts.rateLimit > 0
     ? new RateLimiter(opts.rateLimit)
@@ -256,6 +297,9 @@ export async function startHttpServer(
       // nothing: the comparison would still happen and a correct token would still be
       // served, so the status code would still tell an attacker which guess was right.
       const key = authFailureLimiter ? clientKey(req, opts.trustProxy === true) : '';
+      if (authFailureLimiter && opts.trustProxy !== true && req.headers['x-forwarded-for']) {
+        warnSharedBudget();
+      }
       if (authFailureLimiter) {
         const { allowed, retryAfterMs } = authFailureLimiter.peek(key);
         if (!allowed) {

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -11,36 +11,124 @@ const MAX_BODY_SIZE = 1_048_576; // 1MB
 /** Cap on concurrent MCP sessions, so unauthenticated-adjacent churn can't grow the map without bound. */
 const MAX_SESSIONS = 64;
 
-class RateLimiter {
-  private tokens: number;
-  private lastRefill: number;
-  private maxTokens: number;
-  private refillIntervalMs: number;
+/** How many failed auth attempts one client may make per minute. 0 disables the check. */
+const DEFAULT_AUTH_FAILURE_LIMIT = 10;
 
-  constructor(maxRequestsPerMinute: number) {
-    this.maxTokens = maxRequestsPerMinute;
-    this.tokens = maxRequestsPerMinute;
-    this.lastRefill = Date.now();
-    this.refillIntervalMs = 60_000;
+/** Cap on tracked clients, for the reason `MAX_SESSIONS` exists: churn must not grow a map. */
+const MAX_TRACKED_CLIENTS = 1024;
+
+const REFILL_INTERVAL_MS = 60_000;
+
+interface Bucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+/**
+ * One token-bucket step, shared by the two limiters so the refill arithmetic exists once.
+ *
+ * Mutates the bucket. Refills proportionally to elapsed time rather than on a timer, so an
+ * idle server costs nothing and there is no interval to clean up.
+ */
+function consume(bucket: Bucket, maxTokens: number): { allowed: boolean; retryAfterMs: number } {
+  const elapsed = Date.now() - bucket.lastRefill;
+  const refilled = Math.floor((elapsed / REFILL_INTERVAL_MS) * maxTokens);
+  if (refilled > 0) {
+    bucket.tokens = Math.min(maxTokens, bucket.tokens + refilled);
+    bucket.lastRefill += Math.round((refilled / maxTokens) * REFILL_INTERVAL_MS);
+  }
+
+  if (bucket.tokens > 0) {
+    bucket.tokens--;
+    return { allowed: true, retryAfterMs: 0 };
+  }
+
+  return { allowed: false, retryAfterMs: Math.ceil(REFILL_INTERVAL_MS / maxTokens) };
+}
+
+class RateLimiter {
+  private bucket: Bucket;
+
+  constructor(private maxTokens: number) {
+    this.bucket = { tokens: maxTokens, lastRefill: Date.now() };
   }
 
   tryConsume(): { allowed: boolean; retryAfterMs: number } {
-    const now = Date.now();
-    const elapsed = now - this.lastRefill;
-    const refilled = Math.floor((elapsed / this.refillIntervalMs) * this.maxTokens);
-    if (refilled > 0) {
-      this.tokens = Math.min(this.maxTokens, this.tokens + refilled);
-      this.lastRefill += Math.round((refilled / this.maxTokens) * this.refillIntervalMs);
-    }
-
-    if (this.tokens > 0) {
-      this.tokens--;
-      return { allowed: true, retryAfterMs: 0 };
-    }
-
-    const retryAfterMs = Math.ceil(this.refillIntervalMs / this.maxTokens);
-    return { allowed: false, retryAfterMs };
+    return consume(this.bucket, this.maxTokens);
   }
+}
+
+/**
+ * A bucket per client, for throttling failed authentication.
+ *
+ * Separate from the request limiter on purpose. The auth check returned before the request
+ * limiter was reached, so a wrong bearer token consumed nothing and guessing ran at network
+ * speed with no backoff — measured as twelve 401s and zero 429s against `--rateLimit=3`.
+ * Moving the request limiter above the auth check would have closed that and opened
+ * something worse: the request bucket is global, so unauthenticated traffic could then
+ * starve every legitimate client.
+ *
+ * Only failures consume a token, so a working client never builds a budget up and is never
+ * throttled by its own traffic — which is what makes this safe to have on by default. It
+ * is not a promise that a correct token always passes: once an address has spent its
+ * budget, everything from that address waits, correct tokens included. That is the whole
+ * point. Charging only after the comparison would leave the guess itself evaluated and the
+ * status code would still tell the attacker which token was right.
+ */
+class AuthFailureLimiter {
+  private buckets = new Map<string, Bucket>();
+
+  constructor(private maxTokens: number) {}
+
+  /** Whether this client may make another attempt. Does not consume. */
+  peek(key: string): { allowed: boolean; retryAfterMs: number } {
+    const bucket = this.buckets.get(key);
+    if (bucket === undefined) return { allowed: true, retryAfterMs: 0 };
+    const elapsed = Date.now() - bucket.lastRefill;
+    const refilled = Math.floor((elapsed / REFILL_INTERVAL_MS) * this.maxTokens);
+    const available = Math.min(this.maxTokens, bucket.tokens + Math.max(refilled, 0));
+    if (available > 0) return { allowed: true, retryAfterMs: 0 };
+    return { allowed: false, retryAfterMs: Math.ceil(REFILL_INTERVAL_MS / this.maxTokens) };
+  }
+
+  /** Charge this client for a failed attempt. */
+  recordFailure(key: string): void {
+    let bucket = this.buckets.get(key);
+    if (bucket === undefined) {
+      // Evict the least recently refilled entry rather than growing without bound. A
+      // client that has stopped failing is the one worth forgetting.
+      if (this.buckets.size >= MAX_TRACKED_CLIENTS) {
+        let oldestKey: string | null = null;
+        let oldest = Infinity;
+        for (const [k, b] of this.buckets) {
+          if (b.lastRefill < oldest) { oldest = b.lastRefill; oldestKey = k; }
+        }
+        if (oldestKey !== null) this.buckets.delete(oldestKey);
+      }
+      bucket = { tokens: this.maxTokens, lastRefill: Date.now() };
+      this.buckets.set(key, bucket);
+    }
+    consume(bucket, this.maxTokens);
+  }
+}
+
+/**
+ * Which client an attempt is charged to.
+ *
+ * The socket's remote address, which is the real client on a direct connection — how this
+ * server is normally run. `X-Forwarded-For` is read only when a proxy is explicitly
+ * trusted: honouring it unconditionally would let any client forge its own key and so opt
+ * out of the limit entirely.
+ */
+export function clientKey(req: IncomingMessage, trustProxy: boolean): string {
+  if (trustProxy) {
+    const forwarded = req.headers['x-forwarded-for'];
+    const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  const address = req.socket.remoteAddress ?? 'unknown';
+  // `::ffff:127.0.0.1` and `127.0.0.1` are the same client; key them the same way.
+  return address.startsWith('::ffff:') ? address.slice(7) : address;
 }
 
 export interface HttpTransportOpts {
@@ -49,6 +137,18 @@ export interface HttpTransportOpts {
   bearerToken?: string;
   registry: ConnectionRegistry;
   rateLimit?: number;
+  /**
+   * Failed bearer-auth attempts allowed per client per minute. Defaults to
+   * `DEFAULT_AUTH_FAILURE_LIMIT`; 0 disables the check. A correct token never consumes from
+   * this budget, so a working client never throttles itself; a client sharing an address
+   * with a failing one does wait, which is what the limit is for.
+   */
+  authFailureLimit?: number;
+  /**
+   * Whether to read the client address from `X-Forwarded-For`. Off by default, because a
+   * client that can set that header can otherwise choose its own rate-limit key.
+   */
+  trustProxy?: boolean;
   /**
    * Host headers accepted by the DNS-rebinding guard. Defaults to the bind
    * address and localhost; set this when running behind a reverse proxy that
@@ -79,6 +179,11 @@ export async function startHttpServer(
       'Without authentication, any network client can execute SSH commands on your hosts.',
     );
   }
+
+  const authFailureLimit = opts.authFailureLimit ?? DEFAULT_AUTH_FAILURE_LIMIT;
+  const authFailureLimiter = authFailureLimit > 0
+    ? new AuthFailureLimiter(authFailureLimit)
+    : null;
 
   const rateLimiter = opts.rateLimit && opts.rateLimit > 0
     ? new RateLimiter(opts.rateLimit)
@@ -146,6 +251,31 @@ export async function startHttpServer(
     const isHealthProbe = req.method === 'GET' && url.pathname === '/health';
 
     if (!isHealthProbe) {
+      // Checked before the token is compared, not after — so an exhausted budget answers
+      // 429 without evaluating the guess. Gating only the 401 path instead would throttle
+      // nothing: the comparison would still happen and a correct token would still be
+      // served, so the status code would still tell an attacker which guess was right.
+      const key = authFailureLimiter ? clientKey(req, opts.trustProxy === true) : '';
+      if (authFailureLimiter) {
+        const { allowed, retryAfterMs } = authFailureLimiter.peek(key);
+        if (!allowed) {
+          const retryAfterSec = Math.ceil(retryAfterMs / 1000);
+          res.writeHead(429, {
+            'Content-Type': 'application/json',
+            'Retry-After': String(retryAfterSec),
+          });
+          res.end(JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+              code: -32604,
+              message: `Too many failed authentication attempts. Retry after ${retryAfterSec}s.`,
+            },
+            id: null,
+          }));
+          return;
+        }
+      }
+
       const auth = req.headers.authorization || '';
       const expected = `Bearer ${bearerToken}`;
       const authBuf = Buffer.from(auth);
@@ -153,6 +283,7 @@ export async function startHttpServer(
       const match = authBuf.length === expectedBuf.length &&
         timingSafeEqual(authBuf, expectedBuf);
       if (!match) {
+        authFailureLimiter?.recordFailure(key);
         // RFC 7235: a 401 must say how to authenticate. MCP clients also parse
         // JSON-RPC envelopes on this route, so 401 speaks the same dialect as
         // the 429 and 413 responses rather than a bare {error}.
@@ -299,6 +430,9 @@ export async function startHttpServer(
       console.error('Endpoints: POST / (MCP), GET /status, GET /health');
       if (rateLimiter) {
         console.error(`Rate limit: ${opts.rateLimit} req/min`);
+      }
+      if (authFailureLimiter) {
+        console.error(`Auth failure limit: ${authFailureLimit}/min per client`);
       }
       resolve();
     });

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -109,8 +109,17 @@ export class AuthFailureLimiter {
           if (b.tokens > fullest) { fullest = b.tokens; fullestKey = k; }
         }
         if (fullestKey !== null) this.buckets.delete(fullestKey);
-        // Every tracked client is spent, so the table itself is the signal. The new key
-        // inherits that rather than being rewarded for arriving late.
+        // Every tracked client is spent, so the table itself is the signal and a new key
+        // does not get a full budget.
+        //
+        // The cost, stated because it is real and cannot be softened here: while the table
+        // is saturated an arriving client has one attempt rather than the full budget, so
+        // a first typo leaves its correct token waiting. Seeding one token instead of zero
+        // looks like it would help and does not — `consume` spends it immediately, and
+        // `peek` already allows a key it has never seen, so the first attempt is free
+        // either way and the second is refused either way. Measured both, identical.
+        // Giving an arriving key a real budget is the refund this rule exists to stop.
+        // Saturation needs 1024 addresses that have each spent a full budget.
         if (fullest <= 0) bucket = { tokens: 0, lastRefill: Date.now() };
       }
       this.buckets.set(key, bucket);
@@ -138,17 +147,65 @@ export class AuthFailureLimiter {
  * chain of two would need the second-from-right, and this does not try to guess the depth.
  * Anything that is not an IP address is discarded rather than used as a map key.
  */
-export function clientKey(req: IncomingMessage, trustProxy: boolean): string {
-  if (trustProxy) {
-    const forwarded = req.headers['x-forwarded-for'];
-    const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
-    const entries = (raw ?? '').split(',').map((e) => e.trim()).filter(Boolean);
-    const nearest = entries[entries.length - 1];
-    if (nearest !== undefined && isIP(canonicalAddress(nearest)) !== 0) {
-      return canonicalAddress(nearest);
-    }
+export function clientKey(
+  req: IncomingMessage,
+  trustProxy: boolean,
+  trustedProxies?: string[],
+): { key: string; forwardedIgnored: boolean } {
+  const peer = canonicalAddress(req.socket.remoteAddress ?? 'unknown');
+  const forwarded = req.headers['x-forwarded-for'];
+  if (!trustProxy || forwarded === undefined) return { key: peer, forwardedIgnored: false };
+
+  // The rightmost entry is proxy-authored only if a proxy actually appended one. Nothing
+  // about the header says whether it did, so the *peer* has to be the proxy — otherwise a
+  // client reaching the listener directly sends one forged entry, that entry is the
+  // rightmost, and it picks its own key. Both attacks this keying was fixed to stop came
+  // back alive in exactly that configuration.
+  if (!isTrustedPeer(peer, trustedProxies)) {
+    return { key: peer, forwardedIgnored: true };
   }
-  return canonicalAddress(req.socket.remoteAddress ?? 'unknown');
+
+  const raw = Array.isArray(forwarded) ? forwarded.join(',') : forwarded;
+  const entries = raw.split(',').map((e) => e.trim()).filter(Boolean);
+  const nearest = entries[entries.length - 1];
+  const address = nearest === undefined ? undefined : forwardedAddress(nearest);
+  if (address === undefined) return { key: peer, forwardedIgnored: true };
+  return { key: address, forwardedIgnored: false };
+}
+
+/**
+ * Whether the peer may speak for other clients.
+ *
+ * Bare `--trustProxy` means a loopback peer, which is the deployment the README asks for:
+ * the server binds to 127.0.0.1 and a proxy on the same host terminates TLS. A proxy
+ * somewhere else has to be named, because "trust whoever connected" is the assumption that
+ * made the header forgeable again.
+ */
+function isTrustedPeer(peer: string, trustedProxies?: string[]): boolean {
+  if (trustedProxies !== undefined && trustedProxies.length > 0) {
+    return trustedProxies.includes(peer);
+  }
+  return peer === '127.0.0.1' || peer === '::1' || peer.startsWith('127.');
+}
+
+/**
+ * One `X-Forwarded-For` entry as an address, or undefined if it is not one.
+ *
+ * `net.isIP` rejects the bracketed and port-suffixed spellings, which is how IPv6 usually
+ * appears in this header — and rejecting silently collapsed every client onto the proxy's
+ * key, which is worse than not keying at all.
+ */
+function forwardedAddress(entry: string): string | undefined {
+  let candidate = entry;
+  const bracketed = /^\[([^\]]+)\](?::\d+)?$/.exec(candidate);
+  if (bracketed) candidate = bracketed[1];
+  // A trailing `:port` only when what is left is not itself an IPv6 literal: `::1` has
+  // colons of its own and must not be truncated.
+  else if (isIP(candidate) === 0 && /^[^:]+:\d+$/.test(candidate)) {
+    candidate = candidate.slice(0, candidate.lastIndexOf(':'));
+  }
+  candidate = canonicalAddress(candidate);
+  return isIP(candidate) === 0 ? undefined : candidate;
 }
 
 /** `::ffff:127.0.0.1` and `127.0.0.1` are the same client; key them the same way. */
@@ -174,6 +231,11 @@ export interface HttpTransportOpts {
    * client that can set that header can otherwise choose its own rate-limit key.
    */
   trustProxy?: boolean;
+  /**
+   * Peer addresses allowed to speak for other clients via `X-Forwarded-For`. Empty means
+   * a loopback peer only, which is the deployment the README describes.
+   */
+  trustedProxies?: string[];
   /**
    * Host headers accepted by the DNS-rebinding guard. Defaults to the bind
    * address and localhost; set this when running behind a reverse proxy that
@@ -220,9 +282,11 @@ export async function startHttpServer(
     if (warnedSharedBudget) return;
     warnedSharedBudget = true;
     console.error(
-      'POLICY WARNING: requests carry X-Forwarded-For but --trustProxy is off, so every ' +
-      'client shares one failed-auth budget keyed on the proxy address — one failing ' +
-      'client can lock out the rest. Set --trustProxy if that proxy is yours.',
+      'POLICY WARNING: X-Forwarded-For is present but not being used to tell clients ' +
+      'apart, so every client shares one failed-auth budget and one failing client can ' +
+      'lock out the rest. Either --trustProxy is off, or the peer is not a trusted proxy ' +
+      '(bare --trustProxy trusts a loopback peer; name others with --trustedProxies), or ' +
+      'the rightmost entry is not an address this server can read.',
     );
   };
 
@@ -296,9 +360,17 @@ export async function startHttpServer(
       // 429 without evaluating the guess. Gating only the 401 path instead would throttle
       // nothing: the comparison would still happen and a correct token would still be
       // served, so the status code would still tell an attacker which guess was right.
-      const key = authFailureLimiter ? clientKey(req, opts.trustProxy === true) : '';
-      if (authFailureLimiter && opts.trustProxy !== true && req.headers['x-forwarded-for']) {
-        warnSharedBudget();
+      let key = '';
+      if (authFailureLimiter) {
+        const resolved = clientKey(req, opts.trustProxy === true, opts.trustedProxies);
+        key = resolved.key;
+        // Warned in both directions. Without `--trustProxy` a proxied deployment shares
+        // one budget; *with* it, an entry that could not be read leaves the same collapse
+        // in place, and that case used to be the silent one — the operator had set the
+        // flag and had no way to know it was not taking effect.
+        if (resolved.forwardedIgnored || (opts.trustProxy !== true && req.headers['x-forwarded-for'])) {
+          warnSharedBudget();
+        }
       }
       if (authFailureLimiter) {
         const { allowed, retryAfterMs } = authFailureLimiter.peek(key);

--- a/test/unit/cli-boolean-flags.test.ts
+++ b/test/unit/cli-boolean-flags.test.ts
@@ -53,3 +53,40 @@ describe('boolean flags reach their call sites', () => {
     expect(resolveHostKeyMode({ insecureHostKey: 'false' })).toBe('tofu');
   });
 });
+
+/**
+ * `--authFailureLimit` guards a control that is on by default, so a value it cannot read
+ * has to be refused rather than quietly turning the control off — the trap `flagEnabled`
+ * exists for, on a numeric flag.
+ */
+describe('parseFailureLimit', () => {
+  it('accepts a non-negative whole number, and 0 as "off"', async () => {
+    const { parseFailureLimit } = await import('../../src/cli.js');
+    expect(parseFailureLimit('10')).toBe(10);
+    expect(parseFailureLimit('0')).toBe(0);
+    expect(parseFailureLimit(' 5 ')).toBe(5);
+    expect(parseFailureLimit('007')).toBe(7);
+    // Absent means "use the default", and nothing else may.
+    expect(parseFailureLimit(undefined)).toBeUndefined();
+  });
+
+  it.each([null, '', 'abc', '-1', '+5', '1e3', '10.5', 'off', 'NaN'])(
+    'refuses %j rather than disabling the check',
+    async (raw) => {
+      const { parseFailureLimit } = await import('../../src/cli.js');
+      // `parseArgv` stores null for a flag written without `=`, and NaN survives `??`,
+      // so the old code turned the throttle off for every one of these.
+      expect(() => parseFailureLimit(raw as any)).toThrow(/authFailureLimit/);
+    },
+  );
+
+  it.each(['10001', '99999999999999999999', '9007199254740993'])(
+    'refuses %s, because an unbounded limit is the same fail-open',
+    async (raw) => {
+      // 1e20 is a bucket that never empties and a Retry-After of 1: configured on,
+      // functionally absent.
+      const { parseFailureLimit } = await import('../../src/cli.js');
+      expect(() => parseFailureLimit(raw)).toThrow(/between 0 and/);
+    },
+  );
+});

--- a/test/unit/transport/http.test.ts
+++ b/test/unit/transport/http.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import * as httpModule from 'http';
+import { clientKey } from '../../../src/transport/http.js';
 import type { Server } from 'net';
 
 const HTTP_PORT = 18399;
@@ -207,13 +208,20 @@ function bareRequest(
   port: number,
   path: string,
   headers: Record<string, string> = {},
-): Promise<{ status: number; headers: Record<string, string | string[] | undefined> }> {
+): Promise<{
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}> {
   return new Promise((resolve, reject) => {
     const req = httpModule.request(
       { hostname: HTTP_HOST, port, path, method: 'GET', headers, agent: false as const },
       (res) => {
-        res.resume();
-        res.on('end', () => resolve({ status: res.statusCode || 0, headers: res.headers }));
+        // Accumulated rather than discarded: both limiters answer 429 with the same
+        // JSON-RPC code, so a status-only assertion cannot tell them apart.
+        let body = '';
+        res.on('data', (c) => (body += c));
+        res.on('end', () => resolve({ status: res.statusCode || 0, headers: res.headers, body }));
       },
     );
     req.on('error', reject);
@@ -445,39 +453,318 @@ describe('HTTP transport — the budget is keyed by client', () => {
  * platform, so that test would prove less than it costs.
  */
 describe('clientKey', () => {
+  const clientKeyOf = (req: any, trustProxy: boolean) => clientKey(req, trustProxy);
   const fake = (remoteAddress: string | undefined, forwarded?: string | string[]) => ({
     socket: { remoteAddress },
     headers: forwarded === undefined ? {} : { 'x-forwarded-for': forwarded },
   }) as any;
 
   it('uses the socket address, which is the real client on a direct connection', async () => {
-    const { clientKey } = await import('../../../src/transport/http.js');
-    expect(clientKey(fake('203.0.113.7'), false)).toBe('203.0.113.7');
+    expect(clientKeyOf(fake('203.0.113.7'), false)).toBe('203.0.113.7');
   });
 
   it('treats the IPv6-mapped form as the same client', async () => {
-    const { clientKey } = await import('../../../src/transport/http.js');
-    expect(clientKey(fake('::ffff:127.0.0.1'), false)).toBe('127.0.0.1');
-    expect(clientKey(fake('127.0.0.1'), false)).toBe('127.0.0.1');
+    expect(clientKeyOf(fake('::ffff:127.0.0.1'), false)).toBe('127.0.0.1');
+    expect(clientKeyOf(fake('127.0.0.1'), false)).toBe('127.0.0.1');
   });
 
   it('ignores X-Forwarded-For unless a proxy is trusted', async () => {
-    const { clientKey } = await import('../../../src/transport/http.js');
     // Otherwise a client picks its own key and opts out of the limit.
-    expect(clientKey(fake('203.0.113.7', '9.9.9.9'), false)).toBe('203.0.113.7');
-    expect(clientKey(fake('203.0.113.7', '9.9.9.9'), true)).toBe('9.9.9.9');
+    expect(clientKeyOf(fake('203.0.113.7', '9.9.9.9'), false)).toBe('203.0.113.7');
+    expect(clientKeyOf(fake('203.0.113.7', '9.9.9.9'), true)).toBe('9.9.9.9');
   });
 
-  it('reads the leftmost forwarded entry, which is the original client', async () => {
-    const { clientKey } = await import('../../../src/transport/http.js');
-    expect(clientKey(fake('10.0.0.1', '9.9.9.9, 10.0.0.5, 10.0.0.9'), true)).toBe('9.9.9.9');
-    expect(clientKey(fake('10.0.0.1', ['8.8.8.8', '7.7.7.7']), true)).toBe('8.8.8.8');
+  it('reads the rightmost forwarded entry, which is the hop the proxy itself added', async () => {
+    // Not the leftmost. A proxy appends the address it saw, so everything to the left of
+    // the last entry came from the client — reading the leftmost let a client mint a fresh
+    // budget per request, and let it burn a victim's budget by naming their address.
+    expect(clientKeyOf(fake('10.0.0.1', '9.9.9.9, 10.0.0.5, 10.0.0.9'), true)).toBe('10.0.0.9');
+    expect(clientKeyOf(fake('10.0.0.1', ['8.8.8.8', '7.7.7.7']), true)).toBe('7.7.7.7');
+  });
+
+  it('discards a forwarded value that is not an address', async () => {
+    // Otherwise arbitrary client text becomes a map key.
+    expect(clientKeyOf(fake('10.0.0.1', 'not-an-ip'), true)).toBe('10.0.0.1');
+    expect(clientKeyOf(fake('10.0.0.1', '9.9.9.9, garbage'), true)).toBe('10.0.0.1');
+  });
+
+  it('normalises the forwarded value the same way as the socket address', async () => {
+    expect(clientKeyOf(fake('10.0.0.1', '::ffff:203.0.113.9'), true)).toBe('203.0.113.9');
   });
 
   it('falls back rather than throwing when there is no address', async () => {
-    const { clientKey } = await import('../../../src/transport/http.js');
-    expect(clientKey(fake(undefined), false)).toBe('unknown');
+    expect(clientKeyOf(fake(undefined), false)).toBe('unknown');
     // A trusted proxy that sent nothing useful must not produce an empty key.
-    expect(clientKey(fake('10.0.0.1', '   '), true)).toBe('10.0.0.1');
+    expect(clientKeyOf(fake('10.0.0.1', '   '), true)).toBe('10.0.0.1');
+  });
+});
+
+/**
+ * The properties the default rests on, each pinned because a mutation of it survived the
+ * first version of these tests.
+ */
+describe('HTTP transport — the throttle only charges failures', () => {
+  const PORT = 18407;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [], listAllProfiles: () => [], get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: PORT, host: HTTP_HOST, bearerToken: BEARER,
+      authFailureLimit: 3, registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('a working client never spends its own budget', async () => {
+    // The whole justification for shipping this on by default. Charging the success path
+    // too would lock every legitimate client out after N requests a minute, and the
+    // previous version of this file could not tell.
+    for (let i = 0; i < 8; i++) {
+      expect((await bareRequest(PORT, '/status', { authorization: `Bearer ${BEARER}` })).status)
+        .toBe(200);
+    }
+    // The budget is untouched, so a wrong token still gets its first 401 rather than a 429.
+    expect((await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' })).status)
+      .toBe(401);
+  });
+});
+
+describe('HTTP transport — a spent budget comes back', () => {
+  const PORT = 18408;
+  const LIMIT = 3;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [], listAllProfiles: () => [], get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: PORT, host: HTTP_HOST, bearerToken: BEARER,
+      authFailureLimit: LIMIT, registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('recovers after the interval Retry-After advertises', async () => {
+    for (let i = 0; i < LIMIT; i++) {
+      await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' });
+    }
+    const throttled = await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' });
+    expect(throttled.status).toBe(429);
+    const retryAfterSec = Number(throttled.headers['retry-after']);
+
+    // Only Date is faked, so the server's own socket I/O keeps running. Without this the
+    // refill could be broken outright — a bucket that never comes back — and the header
+    // would still advertise a wait that never ends.
+    vi.useFakeTimers({ toFake: ['Date'], now: Date.now() + retryAfterSec * 1000 + 50 });
+    try {
+      expect((await bareRequest(PORT, '/status', { authorization: `Bearer ${BEARER}` })).status)
+        .toBe(200);
+
+      // And the limit still bites afterwards. Recovery alone is not enough to prove the
+      // refill works on both sides: `peek` has its own refill, so a broken refill inside
+      // `consume` lets every request through while the bucket sits at zero — the throttle
+      // stops re-arming and nothing else notices.
+      const again: number[] = [];
+      for (let i = 0; i < LIMIT + 1; i++) {
+        again.push((await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' })).status);
+      }
+      expect(again[again.length - 1]).toBe(429);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('HTTP transport — the default limit is the documented one', () => {
+  const PORT = 18409;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [], listAllProfiles: () => [], get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: PORT, host: HTTP_HOST, bearerToken: BEARER, registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('allows exactly ten failures, the number the README documents', async () => {
+    // The literal, not the imported constant. Asserting against
+    // `DEFAULT_AUTH_FAILURE_LIMIT` is tautological — moving the constant moves the
+    // expectation with it, so 2 and 13 both passed. This is the value README.md states
+    // and the one operators size their clients against, so it is written out here and
+    // the two have to be changed together.
+    const expected = 10;
+    const statuses: number[] = [];
+    for (let i = 0; i < expected + 2; i++) {
+      statuses.push((await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' })).status);
+    }
+    expect(statuses.slice(0, expected)).toEqual(Array(expected).fill(401));
+    expect(statuses[expected]).toBe(429);
+  });
+
+  it('and the constant agrees with it', async () => {
+    const { DEFAULT_AUTH_FAILURE_LIMIT } = await import('../../../src/transport/http.js');
+    expect(DEFAULT_AUTH_FAILURE_LIMIT).toBe(10);
+  });
+});
+
+describe('AuthFailureLimiter', () => {
+  it('keeps the tracked-client map bounded', async () => {
+    const { AuthFailureLimiter, MAX_TRACKED_CLIENTS } = await import('../../../src/transport/http.js');
+    const limiter = new AuthFailureLimiter(5) as any;
+    for (let i = 0; i < MAX_TRACKED_CLIENTS + 50; i++) limiter.recordFailure(`10.0.${i >> 8}.${i & 255}`);
+    // The only bound on this map, and the key is attacker-chosen under --trustProxy.
+    expect(limiter.buckets.size).toBeLessThanOrEqual(MAX_TRACKED_CLIENTS);
+  });
+
+  it('does not refund a spent budget when the map is recycled', async () => {
+    const { AuthFailureLimiter, MAX_TRACKED_CLIENTS } = await import('../../../src/transport/http.js');
+    const limiter = new AuthFailureLimiter(2);
+    for (let i = 0; i < 2; i++) limiter.recordFailure('victim');
+    expect(limiter.peek('victim').allowed).toBe(false);
+
+    // Evicting by age discarded the *blocked* bucket first — its lastRefill is frozen,
+    // because peek does not mutate — and then handed the key a fresh full budget, so
+    // cycling keys cleared a lockout.
+    for (let i = 0; i < MAX_TRACKED_CLIENTS + 10; i++) limiter.recordFailure(`filler-${i}`);
+    expect(limiter.peek('victim').allowed).toBe(false);
+  });
+});
+
+describe('HTTP transport — the two 429s are distinguishable', () => {
+  const PORT = 18410;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [], listAllProfiles: () => [], get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: PORT, host: HTTP_HOST, bearerToken: BEARER,
+      authFailureLimit: 2, rateLimit: 3, registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('the auth throttle says which throttle it is', async () => {
+    for (let i = 0; i < 2; i++) await bareRequest(PORT, '/status', { authorization: 'Bearer x' });
+    const res = await bareRequest(PORT, '/status', { authorization: 'Bearer x' });
+    expect(res.status).toBe(429);
+    // MCP clients parse this route, so the envelope is part of the contract.
+    const parsed = JSON.parse(res.body);
+    expect(parsed.jsonrpc).toBe('2.0');
+    expect(parsed.error.code).toBe(-32604);
+    expect(parsed.error.message).toMatch(/failed authentication/i);
+  });
+
+  it('a failed attempt never touches the global request budget', async () => {
+    // The reason the request limiter was left above the auth check: that bucket is
+    // global, so letting unauthenticated traffic drain it would starve every legitimate
+    // client. Checked on its own server, with the failure budget deliberately left
+    // unspent — once it is spent the auth throttle answers first, which is what the
+    // sibling test above measures.
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [], listAllProfiles: () => [], get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    const port = 18412;
+    await startHttpServer(() => mcpServer, {
+      port, host: HTTP_HOST, bearerToken: BEARER,
+      authFailureLimit: 5, rateLimit: 3, registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Two failures — under the budget of 5, so nothing is throttled yet.
+    for (let i = 0; i < 2; i++) {
+      expect((await bareRequest(port, '/status', { authorization: 'Bearer x' })).status).toBe(401);
+    }
+    // The request budget of 3 is still whole.
+    const statuses: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      statuses.push((await bareRequest(port, '/status', { authorization: `Bearer ${BEARER}` })).status);
+    }
+    expect(statuses).toEqual([200, 200, 200]);
+  });
+});
+
+describe('HTTP transport — the request limiter admits exactly its limit', () => {
+  const PORT = 18411;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [], listAllProfiles: () => [], get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: PORT, host: HTTP_HOST, bearerToken: BEARER,
+      rateLimit: 3, authFailureLimit: 0, registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('three through, then throttled — a fresh bucket, so the boundary is exact', async () => {
+    // The pre-existing test shares a bucket with the rest of the file and so can only
+    // assert a shape. That was fine until this arithmetic became shared by both limiters:
+    // an off-by-one in `consume` admits one extra request and nothing noticed.
+    const statuses: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const res = await new Promise<number>((resolve, reject) => {
+        const req = httpModule.request(
+          {
+            hostname: HTTP_HOST, port: PORT, path: '/', method: 'POST',
+            headers: { authorization: `Bearer ${BEARER}`, 'content-type': 'application/json' },
+            agent: false as const,
+          },
+          (r) => { r.resume(); r.on('end', () => resolve(r.statusCode || 0)); },
+        );
+        req.on('error', reject);
+        req.end(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }));
+      });
+      statuses.push(res);
+    }
+    expect(statuses.filter((x) => x !== 429)).toHaveLength(3);
+    expect(statuses.slice(3)).toEqual([429, 429]);
   });
 });

--- a/test/unit/transport/http.test.ts
+++ b/test/unit/transport/http.test.ts
@@ -453,7 +453,11 @@ describe('HTTP transport — the budget is keyed by client', () => {
  * platform, so that test would prove less than it costs.
  */
 describe('clientKey', () => {
-  const clientKeyOf = (req: any, trustProxy: boolean) => clientKey(req, trustProxy);
+  // `clientKey` also reports whether a forwarded entry was ignored, which the handler
+  // uses to warn. These cases are about the key.
+  const clientKeyOf = (req: any, trustProxy: boolean, trusted?: string[]) =>
+    clientKey(req, trustProxy, trusted).key;
+  const ignoredFor = (req: any, trustProxy: boolean) => clientKey(req, trustProxy).forwardedIgnored;
   const fake = (remoteAddress: string | undefined, forwarded?: string | string[]) => ({
     socket: { remoteAddress },
     headers: forwarded === undefined ? {} : { 'x-forwarded-for': forwarded },
@@ -471,31 +475,61 @@ describe('clientKey', () => {
   it('ignores X-Forwarded-For unless a proxy is trusted', async () => {
     // Otherwise a client picks its own key and opts out of the limit.
     expect(clientKeyOf(fake('203.0.113.7', '9.9.9.9'), false)).toBe('203.0.113.7');
-    expect(clientKeyOf(fake('203.0.113.7', '9.9.9.9'), true)).toBe('9.9.9.9');
+    // A loopback peer is the proxy in the deployment the README describes.
+    expect(clientKeyOf(fake('127.0.0.1', '9.9.9.9'), true)).toBe('9.9.9.9');
   });
 
   it('reads the rightmost forwarded entry, which is the hop the proxy itself added', async () => {
     // Not the leftmost. A proxy appends the address it saw, so everything to the left of
     // the last entry came from the client — reading the leftmost let a client mint a fresh
     // budget per request, and let it burn a victim's budget by naming their address.
-    expect(clientKeyOf(fake('10.0.0.1', '9.9.9.9, 10.0.0.5, 10.0.0.9'), true)).toBe('10.0.0.9');
-    expect(clientKeyOf(fake('10.0.0.1', ['8.8.8.8', '7.7.7.7']), true)).toBe('7.7.7.7');
+    expect(clientKeyOf(fake('127.0.0.1', '9.9.9.9, 10.0.0.5, 10.0.0.9'), true)).toBe('10.0.0.9');
+    expect(clientKeyOf(fake('127.0.0.1', ['8.8.8.8', '7.7.7.7']), true)).toBe('7.7.7.7');
   });
 
   it('discards a forwarded value that is not an address', async () => {
     // Otherwise arbitrary client text becomes a map key.
-    expect(clientKeyOf(fake('10.0.0.1', 'not-an-ip'), true)).toBe('10.0.0.1');
-    expect(clientKeyOf(fake('10.0.0.1', '9.9.9.9, garbage'), true)).toBe('10.0.0.1');
+    expect(clientKeyOf(fake('127.0.0.1', 'not-an-ip'), true)).toBe('127.0.0.1');
+    expect(clientKeyOf(fake('127.0.0.1', '9.9.9.9, garbage'), true)).toBe('127.0.0.1');
   });
 
   it('normalises the forwarded value the same way as the socket address', async () => {
-    expect(clientKeyOf(fake('10.0.0.1', '::ffff:203.0.113.9'), true)).toBe('203.0.113.9');
+    expect(clientKeyOf(fake('127.0.0.1', '::ffff:203.0.113.9'), true)).toBe('203.0.113.9');
+  });
+
+  it('will not let a client that is not the proxy speak for others', () => {
+    // The rightmost entry is proxy-authored only if a proxy appended one. On a direct
+    // connection the client's single forged entry *is* the rightmost, so both attacks
+    // this keying was written to stop came back alive until the peer was checked.
+    expect(clientKeyOf(fake('203.0.113.50', '10.0.0.1'), true)).toBe('203.0.113.50');
+    expect(ignoredFor(fake('203.0.113.50', '10.0.0.1'), true)).toBe(true);
+    // Naming the proxy makes it trusted again.
+    expect(clientKeyOf(fake('10.9.9.9', '198.51.100.42'), true, ['10.9.9.9']))
+      .toBe('198.51.100.42');
+  });
+
+  it.each([
+    ['[2001:db8::1]:443', '2001:db8::1'],
+    ['[2001:db8::1]', '2001:db8::1'],
+    ['198.51.100.5:51234', '198.51.100.5'],
+    ['::1', '::1'],
+  ])('reads %s as %s', (forwarded, expected) => {
+    // `net.isIP` rejects the bracketed and port-suffixed spellings, which is how IPv6
+    // usually appears here — and rejecting silently collapsed every client onto the
+    // proxy's key, which is worse than not keying at all.
+    expect(clientKeyOf(fake('127.0.0.1', forwarded), true)).toBe(expected);
+  });
+
+  it('says when a forwarded entry was ignored, so the handler can warn', () => {
+    expect(ignoredFor(fake('127.0.0.1', 'garbage'), true)).toBe(true);
+    expect(ignoredFor(fake('127.0.0.1', '9.9.9.9'), true)).toBe(false);
+    expect(ignoredFor(fake('127.0.0.1'), true)).toBe(false);
   });
 
   it('falls back rather than throwing when there is no address', async () => {
     expect(clientKeyOf(fake(undefined), false)).toBe('unknown');
     // A trusted proxy that sent nothing useful must not produce an empty key.
-    expect(clientKeyOf(fake('10.0.0.1', '   '), true)).toBe('10.0.0.1');
+    expect(clientKeyOf(fake('127.0.0.1', '   '), true)).toBe('127.0.0.1');
   });
 });
 
@@ -639,6 +673,26 @@ describe('AuthFailureLimiter', () => {
     for (let i = 0; i < MAX_TRACKED_CLIENTS + 50; i++) limiter.recordFailure(`10.0.${i >> 8}.${i & 255}`);
     // The only bound on this map, and the key is attacker-chosen under --trustProxy.
     expect(limiter.buckets.size).toBeLessThanOrEqual(MAX_TRACKED_CLIENTS);
+  });
+
+  it('gives an arriving client one attempt while every bucket is spent', async () => {
+    const { AuthFailureLimiter, MAX_TRACKED_CLIENTS } = await import('../../../src/transport/http.js');
+    const limiter = new AuthFailureLimiter(10);
+    // Saturate the table with exhausted buckets, which is remotely reachable.
+    for (let i = 0; i < MAX_TRACKED_CLIENTS; i++) {
+      for (let n = 0; n < 10; n++) limiter.recordFailure(`atk-${i}`);
+    }
+    // `peek` allows a key it has never seen, so the first attempt is free; the bucket is
+    // created by the failure and starts spent, so the second is refused. On an unsaturated
+    // table the same client would have the full budget — that collapse is the cost of not
+    // refunding, and it is asserted here so it cannot change unnoticed.
+    expect(limiter.peek('arriving').allowed).toBe(true);
+    limiter.recordFailure('arriving');
+    expect(limiter.peek('arriving').allowed).toBe(false);
+
+    const unsaturated = new AuthFailureLimiter(10);
+    unsaturated.recordFailure('arriving');
+    expect(unsaturated.peek('arriving').allowed).toBe(true);
   });
 
   it('does not refund a spent budget when the map is recycled', async () => {

--- a/test/unit/transport/http.test.ts
+++ b/test/unit/transport/http.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as httpModule from 'http';
 import type { Server } from 'net';
 
 const HTTP_PORT = 18399;
@@ -38,6 +39,12 @@ function startTestServer(): Promise<Server> {
         host: HTTP_HOST,
         bearerToken: BEARER,
         rateLimit: 3,
+        // Off on this server. The auth block below makes three failed attempts, and every
+        // request in this file comes from 127.0.0.1, so one shared failure budget would
+        // couple them: add a fourth 401 case and "accepts request with correct token"
+        // starts answering 429 for a reason nobody reading it would guess. The limiter has
+        // its own server at the bottom of the file.
+        authFailureLimit: 0,
         registry: mockRegistry,
       });
 
@@ -193,5 +200,284 @@ describe('HTTP transport — rate limiting', () => {
     expect(firstThrottled).toBeGreaterThanOrEqual(0);
     expect(results.slice(firstThrottled).every((s) => s === 429)).toBe(true);
     expect(results.filter((s) => s === 429).length).toBeGreaterThanOrEqual(7);
+  });
+});
+
+function bareRequest(
+  port: number,
+  path: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const req = httpModule.request(
+      { hostname: HTTP_HOST, port, path, method: 'GET', headers, agent: false as const },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve({ status: res.statusCode || 0, headers: res.headers }));
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/**
+ * F9: the auth check returned before the rate limiter was reached, so a wrong bearer token
+ * consumed nothing and guessing ran at network speed — twelve 401s and zero 429s against
+ * `--rateLimit=3`, measured. Its own server, because the budget is keyed by client address
+ * and every request in this file shares one.
+ */
+describe('HTTP transport — failed authentication is throttled', () => {
+  const PORT = 18402;
+  const LIMIT = 3;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [],
+      listAllProfiles: () => [],
+      get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: 18402,
+      host: HTTP_HOST,
+      bearerToken: BEARER,
+      authFailureLimit: 3,
+      registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  const attempt = (token: string) =>
+    bareRequest(PORT, '/status', { authorization: `Bearer ${token}` });
+
+  it('spends the budget on failures and then answers 429', async () => {
+    const statuses: number[] = [];
+    for (let i = 0; i < LIMIT + 3; i++) statuses.push((await attempt('wrong-guess')).status);
+
+    expect(statuses.slice(0, LIMIT)).toEqual(Array(LIMIT).fill(401));
+    expect(statuses.slice(LIMIT).every((s) => s === 429)).toBe(true);
+  });
+
+  it('says how long to wait', async () => {
+    const res = await attempt('still-wrong');
+    expect(res.status).toBe(429);
+    // 60s / LIMIT — the interval one token takes to come back.
+    expect(Number(res.headers['retry-after'])).toBe(Math.ceil(60 / LIMIT));
+  });
+
+  it('makes a correct token wait too, once the budget is spent', async () => {
+    // Deliberate, and the reason the budget is checked before the token is compared:
+    // gating only the 401 path would still evaluate the guess and still serve a correct
+    // token, so the status code would tell an attacker which guess was right.
+    expect((await attempt(BEARER)).status).toBe(429);
+  });
+
+  it('leaves the unauthenticated liveness probe alone', async () => {
+    expect((await bareRequest(PORT, '/health')).status).toBe(200);
+  });
+});
+
+/** The escape hatch, for a deployment that wants the previous behaviour back. */
+describe('HTTP transport — the failure limit can be turned off', () => {
+  const PORT = 18403;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [],
+      listAllProfiles: () => [],
+      get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: 18403,
+      host: HTTP_HOST,
+      bearerToken: BEARER,
+      authFailureLimit: 0,
+      registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('answers 401 for every attempt when the limit is 0', async () => {
+    const statuses: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      statuses.push((await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' })).status);
+    }
+    expect(statuses.every((s) => s === 401)).toBe(true);
+  });
+});
+
+/** The default is the security property, so it is asserted rather than assumed. */
+describe('HTTP transport — the failure limit is on without being asked for', () => {
+  const PORT = 18404;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [],
+      listAllProfiles: () => [],
+      get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: 18404,
+      host: HTTP_HOST,
+      bearerToken: BEARER,
+      // No authFailureLimit: the default is what is under test.
+      registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it('throttles after the default number of failures', async () => {
+    const statuses: number[] = [];
+    for (let i = 0; i < 14; i++) {
+      statuses.push((await bareRequest(PORT, '/status', { authorization: 'Bearer wrong' })).status);
+    }
+    const firstThrottled = statuses.indexOf(429);
+    expect(firstThrottled).toBeGreaterThan(0);
+    expect(statuses.slice(0, firstThrottled).every((x) => x === 401)).toBe(true);
+    expect(statuses.slice(firstThrottled).every((x) => x === 429)).toBe(true);
+  });
+});
+
+/**
+ * The budget is per client, and which client is a decision rather than a lookup:
+ * `X-Forwarded-For` is read only when a proxy is trusted, because a client that can set
+ * that header could otherwise pick its own key and opt out of the limit.
+ */
+describe('HTTP transport — the budget is keyed by client', () => {
+  const TRUSTING = 18405;
+  const PLAIN = 18406;
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [],
+      listAllProfiles: () => [],
+      get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: 18405,
+      host: HTTP_HOST,
+      bearerToken: BEARER,
+      authFailureLimit: 2,
+      trustProxy: true,
+      registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  beforeAll(async () => {
+    const { startHttpServer } = await import('../../../src/transport/http.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const mockRegistry = {
+      listConnections: () => [],
+      listAllProfiles: () => [],
+      get: () => undefined,
+      getOrCreate: async () => { throw new Error('not in test'); },
+    } as any;
+    const mcpServer = new McpServer(
+      { name: 'test', version: '0.0.0' },
+      { capabilities: { tools: {}, resources: {} } },
+    );
+    await startHttpServer(() => mcpServer, {
+      port: 18406,
+      host: HTTP_HOST,
+      bearerToken: BEARER,
+      authFailureLimit: 2,
+      registry: mockRegistry,
+    });
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  const fail = (port: number, forwardedFor?: string) =>
+    bareRequest(port, '/status', {
+      authorization: 'Bearer wrong',
+      ...(forwardedFor ? { 'x-forwarded-for': forwardedFor } : {}),
+    });
+
+  it('gives each forwarded client its own budget when a proxy is trusted', async () => {
+    expect((await fail(TRUSTING, '1.2.3.4')).status).toBe(401);
+    expect((await fail(TRUSTING, '1.2.3.4')).status).toBe(401);
+    expect((await fail(TRUSTING, '1.2.3.4')).status).toBe(429);
+
+    // A different client behind the same proxy has not spent anything.
+    expect((await fail(TRUSTING, '5.6.7.8')).status).toBe(401);
+  });
+
+  it('ignores the header when no proxy is trusted, so it cannot be used to reset', async () => {
+    expect((await fail(PLAIN, '1.1.1.1')).status).toBe(401);
+    expect((await fail(PLAIN, '2.2.2.2')).status).toBe(401);
+    // Both attempts were charged to the socket address, so the third is throttled
+    // whatever the header claims.
+    expect((await fail(PLAIN, '3.3.3.3')).status).toBe(429);
+  });
+});
+
+/**
+ * Keying is tested as a unit rather than over two sockets: distinguishing two client
+ * addresses end-to-end needs two source IPs, and which loopback aliases exist differs by
+ * platform, so that test would prove less than it costs.
+ */
+describe('clientKey', () => {
+  const fake = (remoteAddress: string | undefined, forwarded?: string | string[]) => ({
+    socket: { remoteAddress },
+    headers: forwarded === undefined ? {} : { 'x-forwarded-for': forwarded },
+  }) as any;
+
+  it('uses the socket address, which is the real client on a direct connection', async () => {
+    const { clientKey } = await import('../../../src/transport/http.js');
+    expect(clientKey(fake('203.0.113.7'), false)).toBe('203.0.113.7');
+  });
+
+  it('treats the IPv6-mapped form as the same client', async () => {
+    const { clientKey } = await import('../../../src/transport/http.js');
+    expect(clientKey(fake('::ffff:127.0.0.1'), false)).toBe('127.0.0.1');
+    expect(clientKey(fake('127.0.0.1'), false)).toBe('127.0.0.1');
+  });
+
+  it('ignores X-Forwarded-For unless a proxy is trusted', async () => {
+    const { clientKey } = await import('../../../src/transport/http.js');
+    // Otherwise a client picks its own key and opts out of the limit.
+    expect(clientKey(fake('203.0.113.7', '9.9.9.9'), false)).toBe('203.0.113.7');
+    expect(clientKey(fake('203.0.113.7', '9.9.9.9'), true)).toBe('9.9.9.9');
+  });
+
+  it('reads the leftmost forwarded entry, which is the original client', async () => {
+    const { clientKey } = await import('../../../src/transport/http.js');
+    expect(clientKey(fake('10.0.0.1', '9.9.9.9, 10.0.0.5, 10.0.0.9'), true)).toBe('9.9.9.9');
+    expect(clientKey(fake('10.0.0.1', ['8.8.8.8', '7.7.7.7']), true)).toBe('8.8.8.8');
+  });
+
+  it('falls back rather than throwing when there is no address', async () => {
+    const { clientKey } = await import('../../../src/transport/http.js');
+    expect(clientKey(fake(undefined), false)).toBe('unknown');
+    // A trusted proxy that sent nothing useful must not produce an empty key.
+    expect(clientKey(fake('10.0.0.1', '   '), true)).toBe('10.0.0.1');
   });
 });


### PR DESCRIPTION
Closes the F9 half of #187. Three review rounds; the second and third each found real defects in the previous round's fix, and all of them are listed below rather than folded away.

## The problem

The HTTP transport's auth check answers *before* the rate limiter is reached, so a wrong bearer token consumed nothing. Measured on `main` with `--rateLimit=3`:

```
12 × POST / with a wrong token  →  401 ×12, zero 429s
then a correct token            →  3 served, 4th 429   (the bucket was still full)
```

Guessing ran at network speed with no backoff, in front of a tool that executes commands over SSH.

## What ships

`--authFailureLimit` (default 10 per client per minute, `0` disables) is a separate token bucket, spent only on a 401. Moving the *request* limiter above the auth check instead would have closed this and opened something worse: that bucket is global, so unauthenticated traffic could then starve every legitimate client.

The budget is checked **before** the token is compared. Gating only the 401 path would throttle nothing — the comparison would still happen and a correct token would still be served, so the status code would still tell an attacker which guess was right. The cost is that an address which has spent its budget waits even with the right token; a client whose token is correct never spends any.

## What the review rounds changed

- **`X-Forwarded-For` direction.** The first version took the leftmost entry, reasoning it was the original client. It is — but proxies *append*, so the leftmost is exactly what the client controls: nine forged headers gave nine 401s and zero 429s, and naming a victim's address burned *their* budget. The rightmost entry is the hop the proxy added, so that is what is used.
- **The peer has to be the proxy.** Taking the rightmost entry is only safe if a proxy appended one, and nothing checked that — so a client reaching the listener directly with `--trustProxy` on picked its own key again. Bare `--trustProxy` now means a loopback peer, which is the deployment the README describes; `--trustedProxies` names one elsewhere.
- **`net.isIP` rejected bracketed and port-suffixed forms**, which is how IPv6 usually appears in that header. Rejecting fell back to the socket address and collapsed every client onto one budget — and the warning added for that collapse was gated on `--trustProxy` being *off*, so in the only configuration where the path is reachable it could not fire.
- **Eviction refunded a spent budget.** An exhausted bucket never advances `lastRefill`, so evicting by age discarded the locked-out client first and handed its key a full budget. The emptiest bucket is evicted now.
- **A malformed `--authFailureLimit` disabled the throttle silently** — `parseInt(null)` is NaN, `??` does not catch NaN, and `NaN > 0` is false, so `--authFailureLimit 20` turned off the control it was raising. Validated and refused now, bounded at 10000, because an unbounded limit is the same fail-open.

One change was reverted after measuring it: seeding an arriving key with one token instead of zero looks like it would soften the saturated-table case and does nothing, because `consume` spends it immediately and `peek` already allows an unseen key. The real cost — one attempt instead of ten while all 1024 tracked addresses are spent — is asserted in a test and stated in the changeset instead.

## Behaviour change

Behind a reverse proxy without `--trustProxy`, every client shares one budget keyed on the proxy address, so one failing client can make the rest wait. Not fixable by keying differently — there is nothing else to key on — so the server says so on stderr the first time it sees `X-Forwarded-For` it is not using, and the README and changeset say to set the flag.

## Measurements

- Suite: 768 unit tests pass. `npm run typecheck` clean.
- Mutation: the round-two pass found five survivors on the properties the default rests on — success never spending a token, the refill coming back and the throttle re-arming, the default being ten rather than "some number under fourteen", the 429 envelope being distinguishable from the request limiter's, the eviction bound, and the shared `consume()` boundary. All pinned. The default test asserts the literal `10`; importing the constant made it tautological and both 2 and 13 passed.
- The pre-existing HTTP surface (401 shape, request-limiter 429, `/health`, `/status`, 404, body-size limit) is byte-identical to `main`.

The global request limiter is unchanged and still one bucket rather than one per client — a separate question, tracked in #187.