### PR TITLE
fix(policy): the audit's remaining findings — fork-bomb spacing, --opaFailClosed, and what cannot be fixed

### DIFF
--- a/.changeset/plain-otters-remainder.md
+++ b/.changeset/plain-otters-remainder.md
@@ -35,7 +35,9 @@ warns there too now, where a permanently broken bundle used to log nothing at al
 request is bounded at two seconds: a sidecar that accepts the connection and never answers
 used to hold every tool call for undici's five-minute timeout. `--opaUrl` written with a
 space, and `--opaFailClosed` given without a URL, are refused at startup rather than
-silently dropping the flag. And the refusal text is a fixed string — it carried the sidecar
+silently dropping the flag — and so is a `--opaUrl` value `fetch` cannot use, which is the
+same hole one flag-value away: `--opaUrl=localhost:8181` without a scheme printed
+`OPA sidecar enabled` and was never consulted. And the refusal text is a fixed string — it carried the sidecar
 URL, and any credential embedded in it, out to the MCP client.
 
 **Interactive sessions are outside name-based classification, and that is now written

--- a/.changeset/plain-otters-remainder.md
+++ b/.changeset/plain-otters-remainder.md
@@ -32,8 +32,11 @@ OPA answers for an undefined document, so a misnamed package or an unactivated b
 the ordinary way an OPA gate is down while the process is still listening — and reading it
 as consent meant the flag missed exactly the case operators buy it for. The default mode
 warns there too now, where a permanently broken bundle used to log nothing at all. The
-request is bounded at two seconds: a sidecar that accepts the connection and never answers
-used to hold every tool call for undici's five-minute timeout. `--opaUrl` written with a
+request is bounded, where a sidecar that accepts the connection and never answers used to
+hold every tool call for undici's five-minute timeout. Ten seconds by default, and
+`--opaTimeoutMs` moves it — the budget is also the price of turning an explicit OPA *deny*
+into an allow, because a timeout falls back to the local decision, so too low is its own
+bypass and too high brings the hang back. `--opaUrl` written with a
 space, and `--opaFailClosed` given without a URL, are refused at startup rather than
 silently dropping the flag — and so is a `--opaUrl` value `fetch` cannot use, which is the
 same hole one flag-value away: `--opaUrl=localhost:8181` without a scheme printed

--- a/.changeset/plain-otters-remainder.md
+++ b/.changeset/plain-otters-remainder.md
@@ -6,13 +6,17 @@ The remaining findings from the source review behind GHSA-qvx5-rxrj-9vfh, none o
 exploitable on their own.
 
 **The fork-bomb rule tolerates the spacing bash tolerates.** The pattern allowed whitespace
-around the braces but not before the parentheses or around the pipe, so
-`: () { : | : & } ; :` ran and classified `safe` while `:(){ :|:& };:` was refused. Three
-spacing variants escaped, not the one the report named. Only the classic `:` spelling is
-covered: `f(){ f|f& };f` is the same bomb and is still not matched, because matching it
-needs a backreference over an unbounded body and this file has already shipped one ReDoS.
-The impact is a denial of service against the target host rather than against this server,
-which is why that trade is not worth making.
+around the braces but not at the five positions bash also allows it — before the parentheses,
+inside them, either side of the pipe, and before the ampersand — so `: () { : | : & } ; :`
+ran and classified `safe` while `:(){ :|:& };:` was refused.
+
+Three spellings still escape, named here rather than implied away: the same bomb under
+another name (`f(){ f|f& };f`), a body separating the two calls with `&` or `;` instead of
+`|` (`:(){ :&:& };:`), and a comment between the tokens. The first needs a backreference
+over an unbounded body and this file has already shipped one ReDoS; the others would widen
+a list no role, tier or approval mode can override. The impact is a denial of service
+against the target host rather than against this server, which is why neither trade is
+worth making — but this is a narrower hole, not a closed door.
 
 **`--opaFailClosed`.** When `--opaUrl` is set and the sidecar is unreachable, evaluation
 falls back to the local decision and logs one warning per minute. That stays the default —
@@ -22,6 +26,17 @@ authorization gate loses it during an outage, with the only signal on a stderr s
 clients usually discard. The new flag makes the gate being down mean no. The refusal
 carries `ruleId: "opa-unavailable"` rather than `"opa"`, so an audit record says the gate
 was down instead of implying a policy refused the command.
+
+A 200 that carries no boolean `result` counts as unavailable, in both modes. That is what
+OPA answers for an undefined document, so a misnamed package or an unactivated bundle is
+the ordinary way an OPA gate is down while the process is still listening — and reading it
+as consent meant the flag missed exactly the case operators buy it for. The default mode
+warns there too now, where a permanently broken bundle used to log nothing at all. The
+request is bounded at two seconds: a sidecar that accepts the connection and never answers
+used to hold every tool call for undici's five-minute timeout. `--opaUrl` written with a
+space, and `--opaFailClosed` given without a URL, are refused at startup rather than
+silently dropping the flag. And the refusal text is a fixed string — it carried the sidecar
+URL, and any credential embedded in it, out to the MCP client.
 
 **Interactive sessions are outside name-based classification, and that is now written
 down.** `run-command` classifies each input on its own, but an interactive session keeps

--- a/.changeset/plain-otters-remainder.md
+++ b/.changeset/plain-otters-remainder.md
@@ -1,0 +1,37 @@
+---
+"ssh-mcp": minor
+---
+
+The remaining findings from the source review behind GHSA-qvx5-rxrj-9vfh, none of them
+exploitable on their own.
+
+**The fork-bomb rule tolerates the spacing bash tolerates.** The pattern allowed whitespace
+around the braces but not before the parentheses or around the pipe, so
+`: () { : | : & } ; :` ran and classified `safe` while `:(){ :|:& };:` was refused. Three
+spacing variants escaped, not the one the report named. Only the classic `:` spelling is
+covered: `f(){ f|f& };f` is the same bomb and is still not matched, because matching it
+needs a backreference over an unbounded body and this file has already shipped one ReDoS.
+The impact is a denial of service against the target host rather than against this server,
+which is why that trade is not worth making.
+
+**`--opaFailClosed`.** When `--opaUrl` is set and the sidecar is unreachable, evaluation
+falls back to the local decision and logs one warning per minute. That stays the default —
+OPA is an additional deny layer, and an outage that stopped all work would be a worse
+failure than one that narrows the policy. But an operator who deployed OPA *as* the
+authorization gate loses it during an outage, with the only signal on a stderr stream MCP
+clients usually discard. The new flag makes the gate being down mean no. The refusal
+carries `ruleId: "opa-unavailable"` rather than `"opa"`, so an audit record says the gate
+was down instead of implying a policy refused the command.
+
+**Interactive sessions are outside name-based classification, and that is now written
+down.** `run-command` classifies each input on its own, but an interactive session keeps
+the remote shell's state, so `alias ls='sudo id'` classifies `safe` and the following `ls`
+classifies `read-only` and runs it. The same holds for a shell function and for a prepended
+`PATH` entry. The classifier already refuses a command word containing `$` — `S=sudo` then
+`$S id` — but an alias is an ordinary name and nothing about it looks wrong.
+
+No fix is offered for that last one, because classifying harder cannot reach it: the state
+is in the remote shell, not in this server. What changed instead is its reachability —
+opening an interactive session became `destructive` in 2.6.0, so under the default rules
+`operator` cannot open one on `prod` at all where before it was `safe`. SECURITY.md now says
+so, and says that `ask-all` is the control that covers the second call as well as the first.

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ The request shape follows the AuthZEN Access Evaluation contract:
 }
 ```
 
-OPA responds with `{ "result": true/false }`. If OPA denies (`result: false`), the command is blocked even if the built-in engine allows it. If OPA is unreachable, the built-in engine's decision stands (fail-open to avoid locking out access).
+OPA responds with `{ "result": true/false }`. If OPA denies (`result: false`), the command is blocked even if the built-in engine allows it. If OPA is unreachable, the built-in engine's decision stands by default (fail-open, to avoid locking out access); `--opaFailClosed` refuses instead. A 200 that carries no boolean `result` counts as unreachable — that is what OPA answers for an undefined document, so a misnamed package or an unactivated bundle is an outage rather than consent.
 
 Example Rego policy (`ssh-mcp.rego`):
 ```rego

--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ Secrets are **never** passed as CLI arguments.
 | `--disableApproval` | false | Skip the approval gate (quick start profile only) |
 | `--opaUrl` | — | OPA sidecar URL for external policy |
 | `--opaFailClosed` | false | Refuse every command while OPA is unreachable, instead of falling back to local policy |
+| `--opaTimeoutMs` | 10000 | How long to wait for the OPA sidecar. Lower makes the fail-open cheaper to reach; higher makes an outage slower to notice |
 | `--commandQuota` | 0 (off) | Max commands per rolling 24h per profile |
 | `--approvalGrantTtl` | 0 (off) | Auto-approve an identical command for this many ms after approval |
 | `--auditEntropyScan` | false | Enable entropy-based secret scanning in audit |

--- a/README.md
+++ b/README.md
@@ -487,7 +487,17 @@ When `--opaUrl` is set, commands the built-in engine allows are additionally
 evaluated by OPA. **OPA can only narrow.** A command the built-in engine has
 already denied returns that denial without OPA being consulted at all, so a
 sidecar answering `allow` cannot grant a class the role bindings withhold. To
-widen, edit `[policy]`. The request shape follows the AuthZEN Access Evaluation contract:
+widen, edit `[policy]`.
+
+An outage falls back to the local decision and logs one warning per minute. That is the
+default because OPA is an *additional* deny layer and stopping all work would be the worse
+failure — but an operator who deployed OPA *as* the authorization gate loses that gate
+during the outage, and the only signal is a stderr line MCP clients usually discard.
+`--opaFailClosed` makes the gate being down mean no; the refusal carries `ruleId:
+"opa-unavailable"` so the audit record says the gate was down rather than implying a policy
+refused the command.
+
+The request shape follows the AuthZEN Access Evaluation contract:
 
 ```json
 {
@@ -710,6 +720,7 @@ Secrets are **never** passed as CLI arguments.
 | `--strictConfigAcl` | false | Windows: refuse on every ACL finding, including a read-only over-grant |
 | `--disableApproval` | false | Skip the approval gate (quick start profile only) |
 | `--opaUrl` | — | OPA sidecar URL for external policy |
+| `--opaFailClosed` | false | Refuse every command while OPA is unreachable, instead of falling back to local policy |
 | `--commandQuota` | 0 (off) | Max commands per rolling 24h per profile |
 | `--approvalGrantTtl` | 0 (off) | Auto-approve an identical command for this many ms after approval |
 | `--auditEntropyScan` | false | Enable entropy-based secret scanning in audit |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -159,10 +159,13 @@ cat /etc/hosts                  read-only   allowed — runs /tmp/mine/cat
 ls() { sudo id; }               safe        allowed
 ```
 
-The classifier already answers this for variables — `S=sudo` then `$S id` is refused,
-because a command word containing `$` cannot be resolved statically. That answer does not
-extend to an alias, a shell function or a `PATH` entry, because there the command word is
-an ordinary name and nothing about it looks wrong.
+The classifier already answers this for variables, but less strongly than "refused": `S=sudo`
+then `$S id` classifies `destructive`, because a command word containing `$` cannot be
+resolved statically. So it reaches the approval gate — prompted under `ask-destructive`,
+refused only where `destructive` is not bound, and allowed outright under `auto`. The alias,
+shell function and `PATH` cases do not even reach that: they classify `safe` or `read-only`,
+below the class that prompts, because the command word is an ordinary name and nothing about
+it looks wrong. That difference is the gap, and it is one class wide.
 
 **This is not fixable by classifying harder.** The state lives in the remote shell, not in
 this server, and a name-based classifier cannot know what a name means on the other end.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -161,8 +161,9 @@ ls() { sudo id; }               safe        allowed
 
 The classifier already answers this for variables, but less strongly than "refused": `S=sudo`
 then `$S id` classifies `destructive`, because a command word containing `$` cannot be
-resolved statically. So it reaches the approval gate — prompted under `ask-destructive`,
-refused only where `destructive` is not bound, and allowed outright under `auto`. The alias,
+resolved statically. So it reaches the approval gate — prompted under
+`ask-destructive` or `ask-all`, refused outright under `deny` or where `destructive` is not
+bound for the role and tier, and allowed under `auto`. The alias,
 shell function and `PATH` cases do not even reach that: they classify `safe` or `read-only`,
 below the class that prompts, because the command word is an ordinary name and nothing about
 it looks wrong. That difference is the gap, and it is one class wide.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -143,6 +143,38 @@ span. `close-session` reports its own outcome in the tool result and in the audi
 exit code rather than on a span: it distinguishes a confirmed close from a signal that was
 dispatched but never took, and from one that could not be dispatched at all.
 
+### An interactive session is outside name-based classification
+
+`run-command` classifies each input on its own, but an interactive session is a persistent
+PTY shell that keeps whatever the previous input left behind. So a command word can be
+redefined by one call and used by the next, and both calls classify low:
+
+```
+alias ls='sudo id'              safe        allowed
+ls                              read-only   allowed — runs sudo id
+
+export PATH=/tmp/mine:$PATH     safe        allowed
+cat /etc/hosts                  read-only   allowed — runs /tmp/mine/cat
+
+ls() { sudo id; }               safe        allowed
+```
+
+The classifier already answers this for variables — `S=sudo` then `$S id` is refused,
+because a command word containing `$` cannot be resolved statically. That answer does not
+extend to an alias, a shell function or a `PATH` entry, because there the command word is
+an ordinary name and nothing about it looks wrong.
+
+**This is not fixable by classifying harder.** The state lives in the remote shell, not in
+this server, and a name-based classifier cannot know what a name means on the other end.
+Treat the ability to open an interactive session as the privilege it is:
+
+- Opening one classifies `destructive` as of 2.6.0, so under the default rules `operator`
+  cannot open one on `prod` at all, and `admin` is prompted. Before 2.6.0 it was `safe`.
+- On a profile that grants `destructive`, `approvalPolicy = "ask-all"` is the control that
+  covers the second call as well as the first.
+- A `readOnly` profile is unaffected: it holds `read-only` only, so it cannot set the alias
+  in the first place.
+
 ## Safe Deployment Guidelines
 
 1. **Never run as root.** Create a dedicated low-privilege service account.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,6 +140,41 @@ export function parseMaxChars(raw: string | null | undefined): number {
 }
 
 /**
+ * `--opaUrl`, refused at startup rather than at every request.
+ *
+ * Only emptiness was checked, so anything `fetch` cannot use reached the engine and failed
+ * on every call — with `OPA sidecar enabled` printed at startup and one stderr line per
+ * minute as the only signal. `--opaUrl=localhost:8181` is a realistic slip, since OPA's own
+ * `--addr` is written `:8181`, and in the default mode it leaves a gate that looks
+ * configured and is never consulted. Credentials in the URL are refused too: `fetch`
+ * rejects such a URL outright, so it would be a gate that cannot work at all.
+ */
+export function parseOpaUrl(raw: string | null | undefined): string {
+  if (!raw) {
+    throw new OperatorError('--opaUrl needs a URL, as --opaUrl=http://localhost:8181.');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new OperatorError(
+      `--opaUrl=${raw} is not a URL. Include the scheme, as --opaUrl=http://localhost:8181.`,
+    );
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new OperatorError(`--opaUrl must be http or https, got ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new OperatorError(
+      '--opaUrl must not embed credentials — fetch() refuses such a URL, so the gate would ' +
+      'never be consulted. Put the sidecar behind a network boundary instead.',
+    );
+  }
+  // A trailing slash would make the request path `//v1/data/...`.
+  return (parsed.origin + parsed.pathname).replace(/\/$/, '');
+}
+
+/**
  * `strict` was previously unreachable: nothing but test code could select it,
  * yet host-key.ts pointed users at a `--acceptNewHostKey` flag that never
  * existed. `--insecureHostKey` is kept as an alias for the documented flag.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,6 +140,24 @@ export function parseMaxChars(raw: string | null | undefined): number {
 }
 
 /**
+ * `--opaTimeoutMs`, bounded on both sides.
+ *
+ * Too low turns an explicit OPA deny into an allow whenever the sidecar is slow, which is
+ * the fail-open this budget exists inside; too high brings back the hang it replaced. One
+ * second is the floor and two minutes the ceiling.
+ */
+export function parseOpaTimeout(raw: string | null | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const value = raw === null ? NaN : Number(raw.trim());
+  if (!Number.isSafeInteger(value) || value < 1_000 || value > 120_000) {
+    throw new OperatorError(
+      `--opaTimeoutMs must be a whole number of milliseconds between 1000 and 120000, got ${JSON.stringify(raw)}.`,
+    );
+  }
+  return value;
+}
+
+/**
  * `--opaUrl`, refused at startup rather than at every request.
  *
  * Only emptiness was checked, so anything `fetch` cannot use reached the engine and failed

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ async function main() {
   const audit = new AuditStore(undefined, entropyScan, tamperEvident);
 
   if (argv.opaUrl) {
-    policy.setOpaUrl(argv.opaUrl);
+    policy.setOpaUrl(argv.opaUrl, flagEnabled(argv, 'opaFailClosed'));
     console.error(`OPA sidecar enabled: ${argv.opaUrl}`);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   flagEnabled,
   parseFailureLimit,
   parseOpaUrl,
+  parseOpaTimeout,
   resolveHostKeyMode,
 } from './cli.js';
 
@@ -48,7 +49,11 @@ async function main() {
     // Presence, not truthiness — the trap `flagEnabled` was written for. A
     // space-separated `--opaUrl http://…` stores null, so the old guard dropped it
     // silently, and dropped any `--opaFailClosed` the operator asked for with it.
-    policy.setOpaUrl(parseOpaUrl(argv.opaUrl), flagEnabled(argv, 'opaFailClosed'));
+    policy.setOpaUrl(
+      parseOpaUrl(argv.opaUrl),
+      flagEnabled(argv, 'opaFailClosed'),
+      parseOpaTimeout(argv.opaTimeoutMs),
+    );
     console.error(`OPA sidecar enabled: ${argv.opaUrl}`);
   } else if (flagEnabled(argv, 'opaFailClosed')) {
     throw new OperatorError('--opaFailClosed does nothing without --opaUrl.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   checkRemovedFlags,
   flagEnabled,
   parseFailureLimit,
+  parseOpaUrl,
   resolveHostKeyMode,
 } from './cli.js';
 
@@ -47,10 +48,7 @@ async function main() {
     // Presence, not truthiness — the trap `flagEnabled` was written for. A
     // space-separated `--opaUrl http://…` stores null, so the old guard dropped it
     // silently, and dropped any `--opaFailClosed` the operator asked for with it.
-    if (!argv.opaUrl) {
-      throw new OperatorError('--opaUrl needs a URL, as --opaUrl=<url>.');
-    }
-    policy.setOpaUrl(argv.opaUrl, flagEnabled(argv, 'opaFailClosed'));
+    policy.setOpaUrl(parseOpaUrl(argv.opaUrl), flagEnabled(argv, 'opaFailClosed'));
     console.error(`OPA sidecar enabled: ${argv.opaUrl}`);
   } else if (flagEnabled(argv, 'opaFailClosed')) {
     throw new OperatorError('--opaFailClosed does nothing without --opaUrl.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { reportFatal } from './errors.js';
+import { reportFatal, OperatorError } from './errors.js';
 import { ConnectionRegistry } from './ssh/connection-registry.js';
 import { PolicyEngine, resolvePolicyRules } from './policy/engine.js';
 import { AuditStore } from './audit/store.js';
@@ -43,9 +43,17 @@ async function main() {
   const policy = new PolicyEngine(resolvePolicyRules(config.profiles, config.policy));
   const audit = new AuditStore(undefined, entropyScan, tamperEvident);
 
-  if (argv.opaUrl) {
+  if ('opaUrl' in argv) {
+    // Presence, not truthiness — the trap `flagEnabled` was written for. A
+    // space-separated `--opaUrl http://…` stores null, so the old guard dropped it
+    // silently, and dropped any `--opaFailClosed` the operator asked for with it.
+    if (!argv.opaUrl) {
+      throw new OperatorError('--opaUrl needs a URL, as --opaUrl=<url>.');
+    }
     policy.setOpaUrl(argv.opaUrl, flagEnabled(argv, 'opaFailClosed'));
     console.error(`OPA sidecar enabled: ${argv.opaUrl}`);
+  } else if (flagEnabled(argv, 'opaFailClosed')) {
+    throw new OperatorError('--opaFailClosed does nothing without --opaUrl.');
   }
 
   // An McpServer binds to a single transport, so HTTP needs one per session.

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -86,7 +86,15 @@ const FORBIDDEN_PATTERNS: RegExp[] = [
   /rm\s+-rf?\s+\/(\s|$)/,          // rm -rf / — the filesystem root itself
   /mkfs\./,
   />\s*\/dev\/sd/,
-  /:\(\)\s*\{\s*:\|:\&\s*\}\s*;\s*:/,   // fork bomb
+  // Fork bomb. Whitespace is allowed at every position bash allows it, which the first
+  // version of this got wrong in three places at once: `: () { : | : & } ; :` and
+  // `:()  {  : | : &  }  ;  :` both ran and both classified `safe`, because the pattern
+  // permitted spaces around the braces but not before the parentheses or around the pipe.
+  // Only the classic `:` spelling is covered — `f(){ f|f& };f` is the same bomb and is
+  // not matched. Detecting that needs a backreference over an unbounded body, and this
+  // file has already shipped one ReDoS; the impact here is a denial of service against
+  // the target host rather than against this server, which is not worth that trade.
+  /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/,
   />\s*\/etc\/cron/,
   />\s*\/etc\/systemd/,
   />\s*~\/.ssh\/authorized_keys/,

--- a/src/policy/classifier.ts
+++ b/src/policy/classifier.ts
@@ -86,14 +86,18 @@ const FORBIDDEN_PATTERNS: RegExp[] = [
   /rm\s+-rf?\s+\/(\s|$)/,          // rm -rf / — the filesystem root itself
   /mkfs\./,
   />\s*\/dev\/sd/,
-  // Fork bomb. Whitespace is allowed at every position bash allows it, which the first
-  // version of this got wrong in three places at once: `: () { : | : & } ; :` and
-  // `:()  {  : | : &  }  ;  :` both ran and both classified `safe`, because the pattern
-  // permitted spaces around the braces but not before the parentheses or around the pipe.
-  // Only the classic `:` spelling is covered — `f(){ f|f& };f` is the same bomb and is
-  // not matched. Detecting that needs a backreference over an unbounded body, and this
-  // file has already shipped one ReDoS; the impact here is a denial of service against
-  // the target host rather than against this server, which is not worth that trade.
+  // Fork bomb, with whitespace allowed at the five positions bash allows it and the old
+  // pattern did not: before the parentheses, inside them, either side of the pipe, and
+  // before the ampersand. `: () { : | : & } ; :` ran and classified `safe`.
+  //
+  // What this still does not catch, so that nobody reads it as "fork bombs are handled":
+  // the same bomb under another name (`f(){ f|f& };f`), a body that separates the two
+  // calls with `&` or `;` rather than `|` (`:(){ :&:& };:`), and a comment between the
+  // tokens (`:() # x\n{ :|:& };:`). Matching the first needs a backreference over an
+  // unbounded body and this file has already shipped one ReDoS; the others would widen a
+  // list no role, tier or approval mode can override. The impact is a denial of service
+  // against the target host rather than against this server, which is not worth either
+  // trade — but it is a hole, not a closed door.
   /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/,
   />\s*\/etc\/cron/,
   />\s*\/etc\/systemd/,

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -18,8 +18,18 @@ export interface PolicyRules {
   denylist?: string[];
 }
 
-/** How long to wait for the OPA sidecar before treating it as unavailable. */
-const OPA_TIMEOUT_MS = 2_000;
+/**
+ * How long to wait for the OPA sidecar before treating it as unavailable.
+ *
+ * Bounded because an unbounded wait held every tool call for undici's five-minute header
+ * timeout. Ten seconds and not two: in the default mode a timeout falls back to the local
+ * decision, so the budget is also the price of turning an explicit OPA *deny* into an
+ * allow — at two seconds a sidecar under load crosses it by accident, and anyone who can
+ * add latency crosses it on purpose. Ten is above a loaded sidecar's p99 and still thirty
+ * times cheaper than the hang it replaced. `--opaTimeoutMs` moves it: lower makes the
+ * fail-open cheaper to reach, higher makes an outage slower to notice.
+ */
+const DEFAULT_OPA_TIMEOUT_MS = 10_000;
 
 /** Tiers, most restrictive first. Unknown/unset tiers resolve to the first. */
 export const HOST_GROUPS = ['prod', 'staging', 'dev'] as const;
@@ -233,6 +243,7 @@ export function resolvePolicyRules(
 export class PolicyEngine {
   private opaUrl: string | null = null;
   private opaFailClosed = false;
+  private opaTimeoutMs = DEFAULT_OPA_TIMEOUT_MS;
   /** Rate-limits the fail-open warning so one outage can't flood stderr. */
   private lastOpaWarning = 0;
   /** The operator's patterns, compiled once. The built-ins live in classifier.ts. */
@@ -253,7 +264,8 @@ export class PolicyEngine {
     });
   }
 
-  setOpaUrl(url: string | null, failClosed = false): void {
+  setOpaUrl(url: string | null, failClosed = false, timeoutMs = DEFAULT_OPA_TIMEOUT_MS): void {
+    this.opaTimeoutMs = timeoutMs;
     // Reset the warning throttle when the mode changes, or the one warning per minute can
     // be the *previous* mode's sentence — "commands OPA would deny may now be allowed"
     // printed while the engine refuses everything.
@@ -358,7 +370,7 @@ export class PolicyEngine {
         // OPA is "unreachable", and without this the call ran to undici's five-minute
         // header timeout while every tool call waited on it. The abort lands in the catch
         // below, so both modes reach their own answer inside the budget.
-        signal: AbortSignal.timeout(OPA_TIMEOUT_MS),
+        signal: AbortSignal.timeout(this.opaTimeoutMs),
       });
 
       if (!resp.ok) {

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -18,6 +18,9 @@ export interface PolicyRules {
   denylist?: string[];
 }
 
+/** How long to wait for the OPA sidecar before treating it as unavailable. */
+const OPA_TIMEOUT_MS = 2_000;
+
 /** Tiers, most restrictive first. Unknown/unset tiers resolve to the first. */
 export const HOST_GROUPS = ['prod', 'staging', 'dev'] as const;
 
@@ -251,6 +254,10 @@ export class PolicyEngine {
   }
 
   setOpaUrl(url: string | null, failClosed = false): void {
+    // Reset the warning throttle when the mode changes, or the one warning per minute can
+    // be the *previous* mode's sentence — "commands OPA would deny may now be allowed"
+    // printed while the engine refuses everything.
+    if (failClosed !== this.opaFailClosed) this.lastOpaWarning = 0;
     this.opaUrl = url;
     this.opaFailClosed = failClosed;
   }
@@ -347,13 +354,26 @@ export class PolicyEngine {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ input }),
+        // A sidecar that accepts the connection and never answers is the canonical way
+        // OPA is "unreachable", and without this the call ran to undici's five-minute
+        // header timeout while every tool call waited on it. The abort lands in the catch
+        // below, so both modes reach their own answer inside the budget.
+        signal: AbortSignal.timeout(OPA_TIMEOUT_MS),
       });
 
       if (!resp.ok) {
-        return this.onOpaUnavailable(`HTTP ${resp.status} from ${this.opaUrl}`, local);
+        return this.onOpaUnavailable(`HTTP ${resp.status}`, local);
       }
 
-      const data = await resp.json() as { result?: boolean };
+      const data = await resp.json() as { result?: unknown };
+      if (typeof data.result !== 'boolean') {
+        // A 200 carrying no decision is how OPA answers for an undefined document, which
+        // is what a wrong package path, an unactivated bundle, or an `allow` rule written
+        // without `default allow := false` all produce. Reading that as consent meant
+        // `--opaFailClosed` did not cover the way an OPA gate actually goes down: six of
+        // seven response shapes allowed, with no warning at all.
+        return this.onOpaUnavailable('no boolean `result` in the response', local);
+      }
       if (data.result === false) {
         return {
           decision: 'deny',
@@ -388,7 +408,11 @@ export class PolicyEngine {
       commandClass: local.commandClass,
       binary: local.binary,
       ruleId: 'opa-unavailable',
-      reason: `OPA evaluation unavailable and --opaFailClosed is set (${cause})`,
+      // Fixed string. `cause` goes to stderr, where the operator is; this `reason` is
+      // rethrown as the tool's error text and written to the audit record, and it carried
+      // `this.opaUrl` — an internal hostname, and any credential embedded in it — out to
+      // the MCP client on every refusal.
+      reason: 'OPA evaluation unavailable and --opaFailClosed is set',
     };
   }
 

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -257,7 +257,7 @@ export class PolicyEngine {
     // Reset the warning throttle when the mode changes, or the one warning per minute can
     // be the *previous* mode's sentence — "commands OPA would deny may now be allowed"
     // printed while the engine refuses everything.
-    if (failClosed !== this.opaFailClosed) this.lastOpaWarning = 0;
+    if (failClosed !== this.opaFailClosed || url !== this.opaUrl) this.lastOpaWarning = 0;
     this.opaUrl = url;
     this.opaFailClosed = failClosed;
   }
@@ -365,8 +365,14 @@ export class PolicyEngine {
         return this.onOpaUnavailable(`HTTP ${resp.status}`, local);
       }
 
-      const data = await resp.json() as { result?: unknown };
-      if (typeof data.result !== 'boolean') {
+      const payload: unknown = await resp.json();
+      // Guarded, not cast. `as { result?: unknown }` is a lie for a `null` body — reading
+      // `.result` off it threw, so the cause on stderr read as a defect in this server
+      // rather than as the "no decision" condition it names below.
+      const result = typeof payload === 'object' && payload !== null
+        ? (payload as { result?: unknown }).result
+        : undefined;
+      if (typeof result !== 'boolean') {
         // A 200 carrying no decision is how OPA answers for an undefined document, which
         // is what a wrong package path, an unactivated bundle, or an `allow` rule written
         // without `default allow := false` all produce. Reading that as consent meant
@@ -374,7 +380,7 @@ export class PolicyEngine {
         // seven response shapes allowed, with no warning at all.
         return this.onOpaUnavailable('no boolean `result` in the response', local);
       }
-      if (data.result === false) {
+      if (result === false) {
         return {
           decision: 'deny',
           commandClass: parsed.class,

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -229,6 +229,7 @@ export function resolvePolicyRules(
 
 export class PolicyEngine {
   private opaUrl: string | null = null;
+  private opaFailClosed = false;
   /** Rate-limits the fail-open warning so one outage can't flood stderr. */
   private lastOpaWarning = 0;
   /** The operator's patterns, compiled once. The built-ins live in classifier.ts. */
@@ -249,8 +250,9 @@ export class PolicyEngine {
     });
   }
 
-  setOpaUrl(url: string | null): void {
+  setOpaUrl(url: string | null, failClosed = false): void {
     this.opaUrl = url;
+    this.opaFailClosed = failClosed;
   }
 
   evaluate(
@@ -348,8 +350,7 @@ export class PolicyEngine {
       });
 
       if (!resp.ok) {
-        this.warnOpaUnavailable(`HTTP ${resp.status} from ${this.opaUrl}`);
-        return local;
+        return this.onOpaUnavailable(`HTTP ${resp.status} from ${this.opaUrl}`, local);
       }
 
       const data = await resp.json() as { result?: boolean };
@@ -363,10 +364,32 @@ export class PolicyEngine {
         };
       }
     } catch (err) {
-      this.warnOpaUnavailable(err instanceof Error ? err.message : String(err));
+      return this.onOpaUnavailable(err instanceof Error ? err.message : String(err), local);
     }
 
     return local;
+  }
+
+  /**
+   * What an OPA outage means, which is the operator's choice rather than ours.
+   *
+   * Falling back to the local decision is the default and stays the default: OPA is an
+   * additional deny layer, and an outage that stopped all work would be a worse failure
+   * than one that narrows the policy. But an operator who deployed OPA *as* the
+   * authorization gate has a control that disappears during an outage, and the only signal
+   * is a stderr line that MCP clients usually discard. `--opaFailClosed` lets them say
+   * that the gate being down means no.
+   */
+  private onOpaUnavailable(cause: string, local: PolicyEvaluation): PolicyEvaluation {
+    this.warnOpaUnavailable(cause);
+    if (!this.opaFailClosed) return local;
+    return {
+      decision: 'deny',
+      commandClass: local.commandClass,
+      binary: local.binary,
+      ruleId: 'opa-unavailable',
+      reason: `OPA evaluation unavailable and --opaFailClosed is set (${cause})`,
+    };
   }
 
   /**
@@ -382,7 +405,9 @@ export class PolicyEngine {
     this.lastOpaWarning = now;
     console.error(
       `POLICY WARNING: OPA evaluation unavailable (${cause}). ` +
-      'Falling back to local policy — commands OPA would deny may now be allowed.',
+      (this.opaFailClosed
+        ? 'Refusing every command while it is down, because --opaFailClosed is set.'
+        : 'Falling back to local policy — commands OPA would deny may now be allowed.'),
     );
   }
 

--- a/test/unit/cli-boolean-flags.test.ts
+++ b/test/unit/cli-boolean-flags.test.ts
@@ -90,3 +90,35 @@ describe('parseFailureLimit', () => {
     },
   );
 });
+
+/**
+ * `--opaUrl` was checked only for emptiness, so anything `fetch` cannot use reached the
+ * engine and failed on every request — with `OPA sidecar enabled` on stdout and one stderr
+ * line a minute as the only signal that the gate was never consulted.
+ */
+describe('parseOpaUrl', () => {
+  it.each([
+    ['http://localhost:8181', 'http://localhost:8181'],
+    ['https://opa:8181/base', 'https://opa:8181/base'],
+    // A trailing slash would make the request path `//v1/data/...`.
+    ['http://opa:8181/', 'http://opa:8181'],
+  ])('accepts %s', async (raw, expected) => {
+    const { parseOpaUrl } = await import('../../src/cli.js');
+    expect(parseOpaUrl(raw)).toBe(expected);
+  });
+
+  it.each(['opa.internal:8181', 'localhost:8181', 'not a url', '/v1/data', 'ftp://x', '', null])(
+    'refuses %j at startup rather than at every request',
+    async (raw) => {
+      // `--opaUrl=localhost:8181` is a realistic slip: OPA's own `--addr` is `:8181`.
+      const { parseOpaUrl } = await import('../../src/cli.js');
+      expect(() => parseOpaUrl(raw as any)).toThrow(/opaUrl/);
+    },
+  );
+
+  it('refuses credentials in the URL, which fetch cannot use at all', async () => {
+    const { parseOpaUrl } = await import('../../src/cli.js');
+    expect(() => parseOpaUrl('http://opa-admin:s3cr3t@opa.internal:8181'))
+      .toThrow(/must not embed credentials/);
+  });
+});

--- a/test/unit/policy/classifier.test.ts
+++ b/test/unit/policy/classifier.test.ts
@@ -313,6 +313,40 @@ describe('forbidden pattern matching cost', () => {
   }, 30_000);
 });
 
+describe('the fork-bomb rule tolerates the spacing bash tolerates', () => {
+  it.each([
+    ':(){ :|:& };:',
+    ': () { : | : & } ; :',
+    ': (){ :|:& };:',
+    ':()  {  : | : &  }  ;  :',
+    ':()\t{\t:|:&\t}\t;\t:',
+  ])('%j is refused', (command) => {
+    // The pattern permitted spaces around the braces but not before the parentheses or
+    // around the pipe, so three of these ran and classified `safe`.
+    expect(isForbidden(command)).toBe(true);
+  });
+
+  it.each([
+    'docker run -v /a:/b img',
+    'PATH=/x:/y ls',
+    'echo a:b:c',
+    'git log --format=%h:%s',
+    'ssh user@host:/path',
+    "awk -F: '{print $1}' /etc/passwd",
+    'curl http://x:8080/',
+    'true; :',
+  ])('%j is not', (command) => {
+    expect(isForbidden(command)).toBe(false);
+  });
+
+  it('does not claim to catch a fork bomb under another name', () => {
+    // `f(){ f|f& };f` is the same bomb. Matching it needs a backreference over an
+    // unbounded body, and this file has already shipped one ReDoS; the impact is a
+    // denial of service against the target host, not against this server.
+    expect(isForbidden('f(){ f|f& };f')).toBe(false);
+  });
+});
+
 describe('forbidden patterns still match after the rewrite', () => {
   const forbids = (command: string) => isForbidden(command);
 

--- a/test/unit/policy/classifier.test.ts
+++ b/test/unit/policy/classifier.test.ts
@@ -339,6 +339,16 @@ describe('the fork-bomb rule tolerates the spacing bash tolerates', () => {
     expect(isForbidden(command)).toBe(false);
   });
 
+  it.each([':(){ :&:& };:', ':(){ : ;: & };:'])(
+    '%j escapes too, and the comment says so',
+    (command) => {
+      // A body that separates the two calls with `&` or `;` rather than `|`. Widening the
+      // pattern to cover these would widen a list no role, tier or approval mode can
+      // override, so the trade is left where it is — but written down, not implied away.
+      expect(isForbidden(command)).toBe(false);
+    },
+  );
+
   it('does not claim to catch a fork bomb under another name', () => {
     // `f(){ f|f& };f` is the same bomb. Matching it needs a backreference over an
     // unbounded body, and this file has already shipped one ReDoS; the impact is a

--- a/test/unit/policy/opa.test.ts
+++ b/test/unit/policy/opa.test.ts
@@ -169,6 +169,53 @@ describe('OPA evaluation', () => {
     });
   });
 
+  describe('when the operator chooses fail-closed', () => {
+    it('refuses instead of falling back, on an HTTP error', async () => {
+      await startOpa(() => ({ status: 500, body: { error: 'boom' } }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(url, true);
+
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).toBe('deny');
+      // A distinct ruleId, so the audit record says the gate was down rather than
+      // implying a policy actually refused this command.
+      expect(result.ruleId).toBe('opa-unavailable');
+      expect(result.reason).toMatch(/--opaFailClosed/);
+    });
+
+    it('refuses when nothing is listening', async () => {
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl('http://127.0.0.1:1', true);
+
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).toBe('deny');
+      expect(result.ruleId).toBe('opa-unavailable');
+    });
+
+    it('says what it is doing, not what the default does', async () => {
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl('http://127.0.0.1:1', true);
+
+      await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      const warning = warnings();
+      expect(warning).toContain('POLICY WARNING');
+      expect(warning).toMatch(/Refusing every command/);
+      // The fail-open sentence would be a lie in this mode.
+      expect(warning).not.toMatch(/may now be allowed/);
+    });
+
+    it('leaves a healthy OPA alone', async () => {
+      await startOpa(() => ({ body: { result: true } }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(url, true);
+
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).not.toBe('deny');
+      expect(errSpy).not.toHaveBeenCalled();
+    });
+  });
+
+
   it('skips OPA entirely when no URL is configured', async () => {
     const engine = new PolicyEngine(DEFAULT_RULES);
     const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');

--- a/test/unit/policy/opa.test.ts
+++ b/test/unit/policy/opa.test.ts
@@ -213,6 +213,68 @@ describe('OPA evaluation', () => {
       expect(result.decision).not.toBe('deny');
       expect(errSpy).not.toHaveBeenCalled();
     });
+
+    it('treats a 200 that carries no decision as unavailable', async () => {
+      // `{}` is what OPA answers for an undefined document — a misnamed package, an
+      // unactivated bundle, or an `allow` rule written without `default allow := false`.
+      // Reading that as consent meant the flag did not cover the way an OPA gate
+      // actually goes down: six of seven response shapes allowed, with no warning.
+      for (const body of [{}, { result: null }, { result: 'false' }, { result: { allow: false } }]) {
+        await startOpa(() => ({ body }));
+        const engine = new PolicyEngine(DEFAULT_RULES);
+        engine.setOpaUrl(url, true);
+        const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+        expect(result.decision, JSON.stringify(body)).toBe('deny');
+        expect(result.ruleId).toBe('opa-unavailable');
+      }
+    });
+
+    it('keeps the sidecar URL out of what the client is told', async () => {
+      await startOpa(() => ({ status: 500, body: { error: 'boom' } }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl('http://opa-admin:s3cr3t@opa.internal:8181', true);
+    
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      // `reason` is rethrown as the tool's error text and written to the audit record.
+      expect(result.reason).not.toMatch(/s3cr3t|internal|8181/);
+    });
+
+    it('gives up on a sidecar that never answers, rather than waiting on it', async () => {
+      // A process that accepts the connection and never replies is the canonical
+      // "unreachable". Without a bound on the request this ran to undici's five-minute
+      // header timeout while every tool call waited behind it.
+      const hung = createServer(() => { /* deliberately no response */ });
+      await new Promise<void>((r) => hung.listen(0, '127.0.0.1', () => r()));
+      const port = (hung.address() as AddressInfo).port;
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(`http://127.0.0.1:${port}`, true);
+
+      const started = Date.now();
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      const elapsed = Date.now() - started;
+      hung.close();
+
+      expect(result.decision).toBe('deny');
+      expect(result.ruleId).toBe('opa-unavailable');
+      expect(elapsed).toBeLessThan(10_000);
+    }, 20_000);
+
+    it('does not print the other mode\'s sentence after the mode changes', async () => {
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl('http://127.0.0.1:1');
+      await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(warnings()).toMatch(/may now be allowed/);
+
+      // The throttle is one warning per minute, so without a reset the next warning is
+      // suppressed and the fail-open sentence stands on the record while the engine
+      // refuses everything.
+      engine.setOpaUrl('http://127.0.0.1:1', true);
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).toBe('deny');
+      expect(warnings()).toMatch(/Refusing every command/);
+    });
+
+
   });
 
 

--- a/test/unit/policy/opa.test.ts
+++ b/test/unit/policy/opa.test.ts
@@ -232,11 +232,32 @@ describe('OPA evaluation', () => {
     it('keeps the sidecar URL out of what the client is told', async () => {
       await startOpa(() => ({ status: 500, body: { error: 'boom' } }));
       const engine = new PolicyEngine(DEFAULT_RULES);
-      engine.setOpaUrl('http://opa-admin:s3cr3t@opa.internal:8181', true);
-    
+      // Pointed at the server that was actually started. An earlier version handed the
+      // engine a different, hardcoded URL with credentials in it — which `fetch` refuses
+      // before opening a socket, so the request never reached the 500 and the non-2xx
+      // route this test exists to cover was never taken.
+      engine.setOpaUrl(url, true);
+
       const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(requests).toHaveLength(1);
       // `reason` is rethrown as the tool's error text and written to the audit record.
-      expect(result.reason).not.toMatch(/s3cr3t|internal|8181/);
+      expect(result.reason).toBe('OPA evaluation unavailable and --opaFailClosed is set');
+      // The operator still gets the diagnostic, on stderr, where it is useful.
+      expect(warnings()).toMatch(/HTTP 500/);
+      expect(warnings()).not.toContain(url);
+    });
+
+    it('reports a body with no decision as that, not as an internal error', async () => {
+      // `null` is valid JSON, and reading `.result` off it threw — so the cause on stderr
+      // read as a defect in this server rather than the condition it names.
+      await startOpa(() => ({ body: null }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(url, true);
+
+      const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
+      expect(result.decision).toBe('deny');
+      expect(warnings()).toMatch(/no boolean/);
+      expect(warnings()).not.toMatch(/Cannot read properties/);
     });
 
     it('gives up on a sidecar that never answers, rather than waiting on it', async () => {

--- a/test/unit/policy/opa.test.ts
+++ b/test/unit/policy/opa.test.ts
@@ -35,7 +35,9 @@ describe('OPA evaluation', () => {
   let requests: any[] = [];
   let errSpy: ReturnType<typeof vi.spyOn>;
 
-  async function startOpa(handler: (req: any) => { status?: number; body?: unknown }) {
+  async function startOpa(
+    handler: (req: any) => { status?: number; body?: unknown; delayMs?: number },
+  ) {
     requests = [];
     server = createServer((req, res) => {
       let raw = '';
@@ -43,9 +45,14 @@ describe('OPA evaluation', () => {
       req.on('end', () => {
         const parsed = raw ? JSON.parse(raw) : {};
         requests.push(parsed);
-        const { status = 200, body = {} } = handler(parsed);
-        res.writeHead(status, { 'content-type': 'application/json' });
-        res.end(JSON.stringify(body));
+        const { status = 200, body = {}, delayMs = 0 } = handler(parsed);
+        // `delayMs` stands in for a loaded sidecar: healthy, answering, just slow.
+        const respond = () => {
+          res.writeHead(status, { 'content-type': 'application/json' });
+          res.end(JSON.stringify(body));
+        };
+        if (delayMs > 0) setTimeout(respond, delayMs).unref();
+        else respond();
       });
     });
     await new Promise<void>((r) => server!.listen(0, '127.0.0.1', r));
@@ -260,6 +267,31 @@ describe('OPA evaluation', () => {
       expect(warnings()).not.toMatch(/Cannot read properties/);
     });
 
+    it('keeps an explicit deny from a slow but healthy sidecar', async () => {
+      // The budget is also the price of turning an OPA *deny* into an allow, because a
+      // timeout falls back to the local decision. At two seconds a loaded sidecar crossed
+      // it by accident and anyone who could add latency crossed it on purpose.
+      await startOpa(() => ({ body: { result: false }, delayMs: 2_500 }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(url);
+
+      const result = await engine.evaluateWithOpa('rm -rf /data', makeProfile(), 'run-command');
+      expect(result.decision).toBe('deny');
+      expect(result.ruleId).toBe('opa');
+    }, 20_000);
+
+    it('honours a budget the operator set lower', async () => {
+      await startOpa(() => ({ body: { result: false }, delayMs: 2_000 }));
+      const engine = new PolicyEngine(DEFAULT_RULES);
+      engine.setOpaUrl(url, false, 1_000);
+
+      const result = await engine.evaluateWithOpa('rm -rf /data', makeProfile(), 'run-command');
+      // Their choice, and the warning says the gate was skipped.
+      expect(result.decision).not.toBe('deny');
+      expect(warnings()).toContain('POLICY WARNING');
+    }, 20_000);
+
+
     it('gives up on a sidecar that never answers, rather than waiting on it', async () => {
       // A process that accepts the connection and never replies is the canonical
       // "unreachable". Without a bound on the request this ran to undici's five-minute
@@ -268,7 +300,9 @@ describe('OPA evaluation', () => {
       await new Promise<void>((r) => hung.listen(0, '127.0.0.1', () => r()));
       const port = (hung.address() as AddressInfo).port;
       const engine = new PolicyEngine(DEFAULT_RULES);
-      engine.setOpaUrl(`http://127.0.0.1:${port}`, true);
+      // An explicit budget rather than the default, so this test pins "it gives up" and
+      // not whatever the default happens to be.
+      engine.setOpaUrl(`http://127.0.0.1:${port}`, true, 1_000);
 
       const started = Date.now();
       const result = await engine.evaluateWithOpa('ls -la', makeProfile(), 'read-command');
@@ -277,7 +311,8 @@ describe('OPA evaluation', () => {
 
       expect(result.decision).toBe('deny');
       expect(result.ruleId).toBe('opa-unavailable');
-      expect(elapsed).toBeLessThan(10_000);
+      expect(elapsed).toBeGreaterThanOrEqual(900);
+      expect(elapsed).toBeLessThan(5_000);
     }, 20_000);
 
     it('does not print the other mode\'s sentence after the mode changes', async () => {


### PR DESCRIPTION
The last three findings from the source review behind GHSA-qvx5-rxrj-9vfh — the part that was not exploitable and so did not go into the advisory. Three review rounds; the later ones found defects in the earlier fixes, listed below.

## F12 — the fork-bomb rule is defeated by spacing

The pattern allowed whitespace around the braces but not at the five positions bash also allows it, so `: () { : | : & } ; :` ran and classified `safe` while `:(){ :|:& };:` was refused. The report named one variant; measuring found five.

**Three spellings still escape, and are named rather than implied away**: the same bomb under another name (`f(){ f|f& };f`), a body separating the two calls with `&` or `;` instead of `|`, and a comment between the tokens. The first needs a backreference over an unbounded body and this file has already shipped one ReDoS; the others would widen a list no role, tier or approval mode can override. The impact is a denial of service against the target host rather than against this server, which is why neither trade is worth making — but this is a narrower hole, not a closed door. The comment, the changeset and a test all say so.

Checked for the false positives that widening brings: 26 ordinary commands with colons, parens, braces, pipes and ampersands in ordinary positions (`awk -F:`, `jq` filters, `find -exec … \;`, `git log --format`, inline JSON, `PATH=` assignments) — zero new refusals.

## F13 — `--opaFailClosed`

An OPA outage falls back to the local decision. That stays the default: OPA is an additional deny layer, and an outage that stopped all work would be the worse failure. But an operator who deployed OPA *as* the gate loses it during an outage with only a throttled stderr line as the signal, so the flag lets them say the gate being down means no. The refusal carries `ruleId: "opa-unavailable"` rather than `"opa"`, so an audit record says the gate was down instead of implying a policy refused the command.

What the review rounds changed:

- **A 200 carrying no boolean `result` was read as consent.** Six of seven response shapes allowed with the flag set, none of them warning. `{}` is what OPA answers for an undefined document — a misnamed package, an unactivated bundle, or an `allow` rule without `default allow := false` — which is the ordinary way an OPA gate is down while the process is still listening. So the flag missed exactly what it is bought for. Anything that is not a boolean is unavailable now, in both modes, and the default mode gains a warning it never had.
- **The refusal text carried the sidecar URL to the client**, including any credential in it. `reason` is rethrown as the tool error and written to the audit record; it is a fixed string now, and the cause stays on stderr.
- **A wedged sidecar held every tool call for five minutes.** Bounded now — but the first bound, two seconds, made the fail-open a hundred and fifty times cheaper: a healthy sidecar answering `{"result":false}` at 2100ms had its **deny turned into an allow**. Ten seconds by default with `--opaTimeoutMs` to move it, and both directions of that trade are documented, because lower makes the bypass cheaper and higher makes an outage slower to notice.
- **`--opaFailClosed` was dropped for three of four `--opaUrl` spellings**, because the guard was `if (argv.opaUrl)` and `parseArgv` stores `null` for a flag written without `=`. And a value `fetch` cannot use — `--opaUrl=localhost:8181` without a scheme, which OPA's own `--addr` spelling makes a realistic slip — printed `OPA sidecar enabled` and was never consulted. Both refused at startup now, along with credentials in the URL, which `fetch` rejects outright.
- **A `null` JSON body threw before the check that names the condition**, so stderr read "Cannot read properties of null" where it should have said "no boolean `result`".

## F7 — interactive sessions, documented rather than fixed

`run-command` classifies each input on its own, but an interactive session keeps the remote shell's state, so `alias ls='sudo id'` classifies `safe` and the following `ls` classifies `read-only` and runs it. A shell function and a prepended `PATH` do the same.

**No fix, deliberately.** Classifying harder cannot reach this: the state is in the remote shell, not in this server. What changed instead is its reachability — opening an interactive session became `destructive` in 2.6.0, so under the default rules `operator` cannot open one on `prod` at all where before it was `safe`. `SECURITY.md` now says all of that, and says that `ask-all` is the control that covers the second call as well as the first.

Pretending to have closed something that cannot be closed is the failure mode the awk arm of the advisory taught us to avoid.

## Measurements

- Suite: 762 unit tests pass. `npm run typecheck` clean.
- A 3332-command differential against `main` — 3204 fork-bomb spacing permutations plus 128 ordinary and destructive commands — shows every difference in one direction and one shape: fork-bomb spellings moving from `safe` to the never-allowed list. Nothing loosened.
- The new pattern is linear: 0.5ms on a 200k-character adversarial input, against a rule that runs twice per evaluation.
- Mutation: every fix is pinned by a test that fails when it is reverted, including the ones this round added.