### PR TITLE
fix(sftp): report utf8 byte length from sftp-upload, not UTF-16 code units

### DIFF
--- a/.changeset/sftp-upload-byte-count.md
+++ b/.changeset/sftp-upload-byte-count.md
@@ -1,0 +1,20 @@
+---
+"ssh-mcp": patch
+---
+
+**Fix:** `sftp-upload` reports the number of bytes it wrote, not the string's UTF-16 length.
+
+`content` is a JS string, so `content.length` counts UTF-16 code units. Every character that
+takes more than one byte in UTF-8 was counted once instead of two or three, so the reported
+size was systematically low for any non-ASCII upload — measured as `Uploaded 26501 bytes` for
+a file that is 34138 bytes on disk, 22% under.
+
+The transfer itself was never affected. `SftpClient.upload` writes `Buffer.from(content)`,
+which is utf8, and the md5 of the uploaded file matched the source byte for byte. Only the
+number in the reply was wrong.
+
+That number is the only confirmation a caller gets that an upload succeeded, so a systematic
+mismatch means checking a transfer takes a second `md5sum` round-trip — the report is least
+trustworthy exactly where it is relied on. `Buffer.byteLength(content, 'utf8')` is by
+definition the length of the buffer `Buffer.from(content)` produces, so the count now
+describes what reached the remote side.

--- a/src/tools/file-tools.ts
+++ b/src/tools/file-tools.ts
@@ -30,7 +30,11 @@ export function registerFileTools(
           await new SftpClient(rt.conn).upload({ remotePath, content });
           return {
             audited: syntheticSuccess(rt.profileName),
-            output: textResult(`Uploaded ${content.length} bytes to ${remotePath}`),
+            // Byte count, not string length: `content` is a JS string, so
+            // `.length` counts UTF-16 code units and under-reports every
+            // multi-byte character. SftpClient.upload writes Buffer.from(content),
+            // which is utf8, so this is exactly what lands on the remote side.
+            output: textResult(`Uploaded ${Buffer.byteLength(content, 'utf8')} bytes to ${remotePath}`),
           };
         },
       );

--- a/test/integration/ssh-sftp.test.ts
+++ b/test/integration/ssh-sftp.test.ts
@@ -86,6 +86,22 @@ describe.skipIf(await SSH_AVAILABLE === false)('SFTP operations', () => {
     await conn.exec(`rm -f ${markerPath}`);
   });
 
+  // sftp-upload reports Buffer.byteLength(content, 'utf8'), which is only the
+  // right number because upload() writes Buffer.from(content) — utf8. Pin that
+  // with a string whose UTF-16 length differs from its utf8 byte length; the
+  // tool used to report content.length and under-reported every such upload.
+  it('writes utf8 bytes, not UTF-16 code units', async () => {
+    const remotePath = '/tmp/ssh-mcp-utf8-size.txt';
+    const content = 'привет мир';
+    expect(Buffer.byteLength(content, 'utf8')).not.toBe(content.length);
+
+    await sftp.upload({ remotePath, content });
+    const stats = await sftp.stat(remotePath);
+    expect(stats.size).toBe(Buffer.byteLength(content, 'utf8'));
+
+    await conn.exec(`rm -f ${remotePath}`);
+  });
+
   it('rejects nonexistent path for stat', async () => {
     await expect(sftp.stat('/tmp/nonexistent-ssh-mcp-test-12345')).rejects.toThrow();
   });


### PR DESCRIPTION
## What

`sftp-upload` reports `content.length`. `content` is a JS string, so that counts UTF-16 code units, not bytes.

```js
output: textResult(`Uploaded ${content.length} bytes to ${remotePath}`),
```

Every character that takes more than one byte in UTF-8 is counted once instead of two or three, so the reported size is systematically low for any non-ASCII upload.

## Measured

Uploading a UTF-8 file of mostly Cyrillic:

```
Uploaded 26501 bytes to /opt/myapp/static/js/strings-ru.js
```

On the host:

```
34138 static/js/strings-ru.js
<md5 elided>  static/js/strings-ru.js   # md5 matches the local source
```

22% under. The file itself arrived intact — the md5 matched the source byte for byte, so this is a reporting bug only.

## Why it is worth fixing

That number is the only confirmation the caller gets that an upload succeeded. When it disagrees with the file on disk, verifying integrity needs a separate `md5sum` round-trip, so the report is least trustworthy exactly where it is relied on.

## The fix

`SftpClient.upload` writes `Buffer.from(opts.content)`, which is utf8. `Buffer.byteLength(content, 'utf8')` is by definition the length of that buffer, so the reported count now describes what reached the remote side.

## Tests

Added an integration assertion in `test/integration/ssh-sftp.test.ts` pinning the contract the fix rests on — that `upload()` writes utf8 bytes — using a string whose UTF-16 length differs from its utf8 byte length.

I did not add a unit test asserting the reply text itself: `test/unit/tools/harness.ts` currently mocks `exec` only, and adding SFTP mocking for a one-line fix seemed like the wrong trade. #186 extends that harness, so if you would rather have the assertion at the tool layer, I am happy to add it on top of that once it lands, or now if you prefer.

## Relationship to #186

No overlap. #186 is `+104/-0` in `src/tools/file-tools.ts` — it adds new tools alongside the existing ones and does not touch this line. Its new `sftp-upload-file` already reports `local.size`, which is correct; this only brings the existing string-content tool in line with it.
