### PR TITLE
fix(ssh): make --hostKeyMode=strict work, and let a pin satisfy it

### DIFF
--- a/.changeset/lucky-keys-pinned.md
+++ b/.changeset/lucky-keys-pinned.md
@@ -50,6 +50,21 @@ accept.
   trust-on-first-use memory. If you were relying on the old refusal, you were
   relying on two profiles disagreeing about one host.
 
+- **A blank `trustedHostKey` is now a startup error.** `z.string().optional()`
+  accepted `trustedHostKey = ""`, and the gate that read it tested truthiness — so
+  the line was inert and the operator who wrote it believed the profile was
+  pinned. That is the worst outcome this field has, and it is now refused at load
+  time with `trustedHostKey cannot be empty`. Surrounding whitespace is trimmed
+  rather than refused, for the mirror-image reason: the comparison against the
+  presented fingerprint is exact, so a trailing newline from a heredoc refused
+  every key with nothing in the message pointing at the stray character. A config
+  carrying a blank pin previously started and now does not.
+
+  This one exists because the first draft of this change used `!== undefined`
+  where the old gate used truthiness, which would have turned `trustedHostKey = ""`
+  from inert into "refuse every host on every connection". Measured both ways.
+  The runtime predicate is truthiness again, and the schema is the primary guard.
+
 Unchanged: `strict` without a pin still refuses with `HOST_KEY_UNKNOWN`; `tofu`
 learns and compares exactly as before; `insecure` without a pin still accepts
 anything; and the store still does not persist across a restart, which

--- a/.changeset/lucky-keys-pinned.md
+++ b/.changeset/lucky-keys-pinned.md
@@ -30,16 +30,33 @@ means two profiles pinning different keys for the same `host:port` collide with 
 false `HOST_KEY_MISMATCH` — once the host presents each of them its own key, which
 is the only way that state arises.
 
-It does still *write*, under `tofu` only. Dropping the write was a draft of this
-fix and it cost a real refusal, found in review after the draft had been written
-down as finished: on 2.7.0 a matching pin fell through into the trust-on-first-use
-accept, so a pinned profile seeded the shared store and an unpinned profile on the
-same `host:port` was compared against a pin-verified fingerprint. Without the write
-that profile trust-on-first-uses whatever it is served, and the store then holds the
-attacker's key — so the next connection served the genuine one is refused, with the
-diagnostic naming the real server as the impostor. Not written under `strict`,
-because there the store is the only thing that can admit an *unpinned* profile, and
-seeding it would mean pinning one profile silently admitted every other.
+It does still *write*, under `tofu`, and only into an empty slot. Both halves of
+that were found by measurement rather than reasoning, in two passes.
+
+Dropping the write entirely was a draft of this fix and it cost a real refusal: on
+2.7.0 a matching pin fell through into the trust-on-first-use accept, so a pinned
+profile seeded the shared store and an unpinned profile on the same `host:port` was
+compared against a pin-verified fingerprint. Without the write that profile
+trust-on-first-uses whatever it is served, and the store then holds the attacker's
+key — so the next connection served the genuine one is refused, with the diagnostic
+naming the real server as the impostor.
+
+Restoring it as an unconditional `set` then broke a different profile. 2.7.0's write
+lived in the else-branch of `if (stored)`, so it only ever filled; overwriting made
+the entry order-dependent, and with two profiles pinning different keys for one
+`host:port` whichever connected last decided what an *unpinned* profile was compared
+against — giving that profile a false `HOST_KEY_MISMATCH` for a key the other pin had
+authorised. Only a three-connection sequence shows it; the single-call matrix does
+not. It is `!knownHosts.has(key)` now, matching what it replaced.
+
+Not written under `strict` at all, because there the store is the only thing that can
+admit an *unpinned* profile and seeding it would mean pinning one profile silently
+admitted every other; nor under `insecure`, where 2.7.0 returned before reaching the
+write.
+
+The net effect is worth stating plainly, because it is simpler than the reasoning
+behind it: **nothing an unpinned profile experiences differs from 2.7.0.** Every
+behaviour change below is about a profile that carries a pin.
 
 `strict` therefore means "every host must be pinned". That is the honest
 description of what it can do while the store lives only for the process, and it is

--- a/.changeset/lucky-keys-pinned.md
+++ b/.changeset/lucky-keys-pinned.md
@@ -1,0 +1,56 @@
+---
+"ssh-mcp": minor
+---
+
+Make `--hostKeyMode=strict` work, and make `trustedHostKey` able to satisfy it.
+
+`strict` refused every host on every connection, and had since the mode was
+introduced. The store it consults is an in-memory `Map` shared by every profile,
+and the only write to it is the trust-on-first-use accept at the bottom of
+`verifyHostKey` — below the strict branch, so strict never reached it. Measured on
+2.7.0: two consecutive calls both threw `HOST_KEY_UNKNOWN` with the store still at
+zero entries, while `tofu` populated it on the first call. Since the mode is fixed
+at startup, no earlier `tofu` connection could seed it either.
+
+A pin did not rescue it. `trustedHostKey` was a reject-only gate in
+`connection.ts`: it could refuse a wrong key, but a *matching* pin fell through to
+`verifyHostKey` and was refused anyway for the empty store. So `strict` plus a
+correct pin — the combination that reads like the secure configuration — connected
+to nothing, and the refusal's own advice, "pin the key with trustedHostKey", was
+the advice that did not work.
+
+The pin is now answered in `verifyHostKey` ahead of every other branch, and it
+neither reads nor writes the store. Keeping it out of the store is the point rather
+than an omission: `knownHostsStore` is one `Map` for all profiles, so seeding it
+from the pin — the obvious fix, and the one this replaced — made two profiles
+pinning different keys for the same `host:port` produce a false
+`HOST_KEY_MISMATCH` against each other's entry. A pinned host has no use for
+trust-on-first-use memory; the pin already is that memory.
+
+`strict` therefore means "every host must be pinned". That is the honest
+description of what it can do while the store lives only for the process, and it is
+still worth setting: it turns a missing pin into a refusal instead of a first-use
+accept.
+
+### Behaviour changes
+
+- **A key that contradicts a pin now raises `HOST_KEY_PIN_MISMATCH`.** It was
+  already refused — the old gate returned `false` — but ssh2 turned that into a
+  generic handshake failure that named nothing. The refusal now names the pin as
+  what decided, prints both fingerprints, and deliberately offers no mode as a way
+  out, because none overrides a pin. The check still runs before the mode is
+  consulted, so `insecure` does not bypass it; that ordering is preserved from the
+  old gate rather than newly chosen, and losing it would have been a regression
+  dressed as a cleanup.
+- **A matching pin now wins over a store entry for the same `host:port`.**
+  Previously it threw `HOST_KEY_MISMATCH`. Reachable with the shared store: one
+  profile learns a key under `tofu`, a second profile pins a different one for the
+  same host and port. This is a widening — a case that refused now connects — and
+  it is intended: an explicit pin is operator configuration and a store entry is
+  trust-on-first-use memory. If you were relying on the old refusal, you were
+  relying on two profiles disagreeing about one host.
+
+Unchanged: `strict` without a pin still refuses with `HOST_KEY_UNKNOWN`; `tofu`
+learns and compares exactly as before; `insecure` without a pin still accepts
+anything; and the store still does not persist across a restart, which
+[SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) covers.

--- a/.changeset/lucky-keys-pinned.md
+++ b/.changeset/lucky-keys-pinned.md
@@ -4,6 +4,10 @@
 
 Make `--hostKeyMode=strict` work, and make `trustedHostKey` able to satisfy it.
 
+`minor` rather than `patch` because a config that started yesterday can refuse to
+start today — see **Behaviour changes** — and because one combination that
+previously refused now connects.
+
 `strict` refused every host on every connection, and had since the mode was
 introduced. The store it consults is an in-memory `Map` shared by every profile,
 and the only write to it is the trust-on-first-use accept at the bottom of
@@ -20,12 +24,22 @@ to nothing, and the refusal's own advice, "pin the key with trustedHostKey", was
 the advice that did not work.
 
 The pin is now answered in `verifyHostKey` ahead of every other branch, and it
-neither reads nor writes the store. Keeping it out of the store is the point rather
-than an omission: `knownHostsStore` is one `Map` for all profiles, so seeding it
-from the pin — the obvious fix, and the one this replaced — made two profiles
-pinning different keys for the same `host:port` produce a false
-`HOST_KEY_MISMATCH` against each other's entry. A pinned host has no use for
-trust-on-first-use memory; the pin already is that memory.
+never *reads* the store. That is the point rather than an omission:
+`knownHostsStore` is one `Map` for all profiles, so consulting it for a pinned host
+means two profiles pinning different keys for the same `host:port` collide with a
+false `HOST_KEY_MISMATCH` — once the host presents each of them its own key, which
+is the only way that state arises.
+
+It does still *write*, under `tofu` only. Dropping the write was a draft of this
+fix and it cost a real refusal, found in review after the draft had been written
+down as finished: on 2.7.0 a matching pin fell through into the trust-on-first-use
+accept, so a pinned profile seeded the shared store and an unpinned profile on the
+same `host:port` was compared against a pin-verified fingerprint. Without the write
+that profile trust-on-first-uses whatever it is served, and the store then holds the
+attacker's key — so the next connection served the genuine one is refused, with the
+diagnostic naming the real server as the impostor. Not written under `strict`,
+because there the store is the only thing that can admit an *unpinned* profile, and
+seeding it would mean pinning one profile silently admitted every other.
 
 `strict` therefore means "every host must be pinned". That is the honest
 description of what it can do while the store lives only for the process, and it is
@@ -43,12 +57,15 @@ accept.
   old gate rather than newly chosen, and losing it would have been a regression
   dressed as a cleanup.
 - **A matching pin now wins over a store entry for the same `host:port`.**
-  Previously it threw `HOST_KEY_MISMATCH`. Reachable with the shared store: one
-  profile learns a key under `tofu`, a second profile pins a different one for the
-  same host and port. This is a widening — a case that refused now connects — and
-  it is intended: an explicit pin is operator configuration and a store entry is
-  trust-on-first-use memory. If you were relying on the old refusal, you were
-  relying on two profiles disagreeing about one host.
+  Previously it threw `HOST_KEY_MISMATCH`. It needs the entry to be stale relative
+  to the key the host presents now — an earlier `tofu` connection learned a key the
+  host has since rotated away from, or learned one from an interceptor. (Two
+  profiles merely pinning different keys does not reach it: whichever pin disagrees
+  with the served key is stopped before the store is consulted.) This is a widening
+  — a case that refused now connects — and it is intended: an explicit pin is
+  operator configuration, a store entry is unauthenticated first-use memory. If you
+  were relying on the old refusal, you were relying on a store entry that no longer
+  matches the host.
 
 - **A blank `trustedHostKey` is now a startup error.** `z.string().optional()`
   accepted `trustedHostKey = ""`, and the gate that read it tested truthiness — so
@@ -66,6 +83,11 @@ accept.
   The runtime predicate is truthiness again, and the schema is the primary guard.
 
 Unchanged: `strict` without a pin still refuses with `HOST_KEY_UNKNOWN`; `tofu`
-learns and compares exactly as before; `insecure` without a pin still accepts
-anything; and the store still does not persist across a restart, which
+without a pin learns and compares exactly as before; `insecure` without a pin still
+accepts anything; a key contradicting a pin is still refused in every mode; and the
+store still does not persist across a restart, which
 [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) covers.
+
+Note what `--insecureHostKey` does *not* do: it has never lifted a pin, and now
+that the pin is a documented guarantee rather than an accident, that is worth
+stating. A profile with `trustedHostKey` set verifies its host under every mode.

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ Secrets are **never** passed as CLI arguments.
 | `--trustProxy` | false | Read the client address from `X-Forwarded-For`, but only when the peer is the proxy — bare means a loopback peer |
 | `--trustedProxies` | — | Comma-separated peer addresses allowed to send `X-Forwarded-For`. Empty means loopback only |
 | `--allowedHosts` | bind address + localhost | Comma-separated Host headers accepted by the DNS-rebinding guard |
-| `--hostKeyMode` | `tofu` | `tofu \| strict \| insecure`. See [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) — `strict` currently refuses every host |
+| `--hostKeyMode` | `tofu` | `tofu \| strict \| insecure`. `strict` accepts only hosts pinned with `trustedHostKey`. See [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) |
 | `--insecureHostKey` | false | Disable host key verification (test only!) |
 | `--allowUncheckedConfigAcl` | false | Windows: report every ACL finding and refuse none |
 | `--strictConfigAcl` | false | Windows: refuse on every ACL finding, including a read-only over-grant |

--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ Secrets are **never** passed as CLI arguments.
 | `--trustedProxies` | — | Comma-separated peer addresses allowed to send `X-Forwarded-For`. Empty means loopback only |
 | `--allowedHosts` | bind address + localhost | Comma-separated Host headers accepted by the DNS-rebinding guard |
 | `--hostKeyMode` | `tofu` | `tofu \| strict \| insecure`. `strict` accepts only hosts pinned with `trustedHostKey`. See [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart) |
-| `--insecureHostKey` | false | Disable host key verification (test only!) |
+| `--insecureHostKey` | false | Disable host key verification for hosts with no `trustedHostKey` — a pin still refuses (test only!) |
 | `--allowUncheckedConfigAcl` | false | Windows: report every ACL finding and refuse none |
 | `--strictConfigAcl` | false | Windows: refuse on every ACL finding, including a read-only over-grant |
 | `--disableApproval` | false | Skip the approval gate (quick start profile only) |
@@ -788,7 +788,8 @@ process fails the connection. Nothing is written to disk and `~/.ssh/known_hosts
 is not consulted, so a restart accepts afresh — see
 [SECURITY.md](./SECURITY.md#host-key-trust-does-not-survive-a-restart). Pin
 explicitly with `trustedHostKey` in a profile, which is the only control here that
-survives a restart, or pass `--insecureHostKey` to opt out (test environments only).
+survives a restart — and which no host key mode overrides, so `--insecureHostKey`
+is an opt-out only for hosts you have not pinned (test environments only).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,9 +91,16 @@ the fingerprint you expect. It is answered in `verifyHostKey` (`src/ssh/host-key
 of every other branch, and it neither reads nor writes the store, so an empty store does not
 weaken it and a stale entry cannot override it. Use it for anything that matters.
 
-That last sentence was untrue before 2.8.0, and in the direction that mattered: the pin was
-a reject-only gate in `connection.ts`, so it could refuse a wrong key but could never satisfy
-anything. It is now the authority for the host it names, in every mode.
+Before 2.8.0 this section claimed the pin "is checked in `connection.ts` before the store is
+consulted at all, so an empty store does not weaken it". Under `strict` that was untrue, and in
+the direction that mattered: the pin was a reject-only gate, so it could refuse a wrong key but
+could not satisfy the store check that followed it. It is now the authority for the host it
+names, in every mode.
+
+A pinned profile does still record its key in the store under `tofu`, so an unpinned profile on
+the same `host:port` is compared against a pin-verified fingerprint rather than trusting its own
+first use. Not under `strict`: there the store is the only thing that can admit an unpinned
+profile, and seeding it from a pin would mean pinning one profile admitted every other.
 
 **`--hostKeyMode=strict` means "every host must be pinned".** Strict refuses any host whose
 key is not already trusted, and the store it consults is only ever written by the TOFU accept

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,7 +100,8 @@ names, in every mode.
 A pinned profile does still record its key in the store under `tofu`, so an unpinned profile on
 the same `host:port` is compared against a pin-verified fingerprint rather than trusting its own
 first use. Not under `strict`: there the store is the only thing that can admit an unpinned
-profile, and seeding it from a pin would mean pinning one profile admitted every other.
+profile, and seeding it from a pin would mean pinning one profile admitted every other. Not
+under `insecure` either, where the store decides nothing anyway.
 
 **`--hostKeyMode=strict` means "every host must be pinned".** Strict refuses any host whose
 key is not already trusted, and the store it consults is only ever written by the TOFU accept

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,8 +88,10 @@ that makes a swapped key visible only fires against a key this process already s
 
 **`trustedHostKey` on the profile is the only control here that survives a restart.** Pin
 the fingerprint you expect. It is answered in `verifyHostKey` (`src/ssh/host-key.ts`) ahead
-of every other branch, and it neither reads nor writes the store, so an empty store does not
-weaken it and a stale entry cannot override it. Use it for anything that matters.
+of every other branch. It never *reads* the store, so an empty store does not weaken it and a
+stale entry cannot override it; it writes only under `tofu`, and only into an empty slot — see
+below, because that write is what an unpinned profile on the same host is judged against. Use it
+for anything that matters.
 
 Before 2.8.0 this section claimed the pin "is checked in `connection.ts` before the store is
 consulted at all, so an empty store does not weaken it". Under `strict` that was untrue, and in
@@ -108,8 +110,8 @@ The upshot is that nothing an unpinned profile experiences changed in 2.8.0. The
 pin decide only for the profile that carries them.
 
 **`--hostKeyMode=strict` means "every host must be pinned".** Strict refuses any host whose
-key is not already trusted, and the store it consults is only ever written by the TOFU accept
-— which strict, by definition, does not reach. Since the mode is fixed at startup, no earlier
+key is not already trusted, and the store it consults is only ever written under `tofu`, by
+either write site — which strict, by definition, does not reach. Since the mode is fixed at startup, no earlier
 `tofu` connection can seed it either. So a pin is the only thing that satisfies strict, and
 strict is worth setting for exactly one reason: it turns a missing pin into a refusal instead
 of a first-use accept.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,18 +87,32 @@ positioned to intercept has to win once per start rather than once ever. The mis
 that makes a swapped key visible only fires against a key this process already saw.
 
 **`trustedHostKey` on the profile is the only control here that survives a restart.** Pin
-the fingerprint you expect; it is checked in `connection.ts` before the store is consulted
-at all, so an empty store does not weaken it. Use it for anything that matters.
+the fingerprint you expect. It is answered in `verifyHostKey` (`src/ssh/host-key.ts`) ahead
+of every other branch, and it neither reads nor writes the store, so an empty store does not
+weaken it and a stale entry cannot override it. Use it for anything that matters.
 
-**`--hostKeyMode=strict` refuses every host, and pinning does not rescue it.** Strict rejects
-any host whose key is not already in the store, and the only write to that store is the TOFU
-accept further down the same function — unreachable once the strict branch has thrown.
-`trustedHostKey` never writes to it either. So under strict the store starts empty and stays
-empty: measured, two consecutive connections both throw `HOST_KEY_UNKNOWN` with the store
-still at zero entries, and a matching `trustedHostKey` does not change that. The mode is only
-satisfiable by a key accepted earlier in the same process under `tofu`, and the mode is fixed
-at startup, so that cannot happen. Treat strict as unusable until the code changes; use
-`trustedHostKey`.
+That last sentence was untrue before 2.8.0, and in the direction that mattered: the pin was
+a reject-only gate in `connection.ts`, so it could refuse a wrong key but could never satisfy
+anything. It is now the authority for the host it names, in every mode.
+
+**`--hostKeyMode=strict` means "every host must be pinned".** Strict refuses any host whose
+key is not already trusted, and the store it consults is only ever written by the TOFU accept
+— which strict, by definition, does not reach. Since the mode is fixed at startup, no earlier
+`tofu` connection can seed it either. So a pin is the only thing that satisfies strict, and
+strict is worth setting for exactly one reason: it turns a missing pin into a refusal instead
+of a first-use accept.
+
+Before 2.8.0 that combination connected to nothing. Strict threw `HOST_KEY_UNKNOWN` for every
+host on every connection — measured, two consecutive connections with the store still at zero
+entries — and a matching `trustedHostKey` did not change it, because the pin never wrote to
+the store and its gate ran before the function that would have consulted it. The refusal's own
+advice, "pin the key with trustedHostKey", was the advice that did not work.
+
+A key that contradicts a pin is refused as `HOST_KEY_PIN_MISMATCH` in **every** mode,
+`insecure` included. That is deliberate and predates the fix — the old gate sat ahead of the
+mode check, and the ordering was preserved because losing it would have been a regression
+dressed as a cleanup. There is no mode that overrides a pin, and the refusal does not offer
+one.
 
 **`ask-destructive` gates less than the name suggests, and `kill` is one example rather
 than the exception.** Outside the never-allowed list, five things produce the `destructive`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,11 +97,15 @@ the direction that mattered: the pin was a reject-only gate, so it could refuse 
 could not satisfy the store check that followed it. It is now the authority for the host it
 names, in every mode.
 
-A pinned profile does still record its key in the store under `tofu`, so an unpinned profile on
-the same `host:port` is compared against a pin-verified fingerprint rather than trusting its own
-first use. Not under `strict`: there the store is the only thing that can admit an unpinned
-profile, and seeding it from a pin would mean pinning one profile admitted every other. Not
-under `insecure` either, where the store decides nothing anyway.
+A pinned profile does still record its key in the store under `tofu`, and only into an empty
+slot, so an unpinned profile on the same `host:port` is compared against a pin-verified
+fingerprint rather than trusting its own first use — and is never compared against a value some
+*other* pinned profile overwrote. Not recorded under `strict`: there the store is the only thing
+that can admit an unpinned profile, and seeding it from a pin would mean pinning one profile
+admitted every other. Not under `insecure` either, where the store decides nothing anyway.
+
+The upshot is that nothing an unpinned profile experiences changed in 2.8.0. The mode and the
+pin decide only for the profile that carries them.
 
 **`--hostKeyMode=strict` means "every host must be pinned".** Strict refuses any host whose
 key is not already trusted, and the store it consults is only ever written by the TOFU accept

--- a/config.default.toml
+++ b/config.default.toml
@@ -40,7 +40,11 @@ auth = "key"
 keyRef = "~/.ssh/id_ed25519"      # Path to private key
 via = "bastion"                   # ProxyJump profile name
 workdir = "/var/www/myapp"
-trustedHostKey = "SHA256:..."     # Pin host key fingerprint (optional)
+# trustedHostKey = "SHA256:<real fingerprint>"   # Pin the host key (optional, and the
+#   one control here that survives a restart). Commented out on purpose: a placeholder
+#   value is not inert — it is a pin nothing can match, so the profile refuses every
+#   connection. Get the real one with `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`
+#   on the server.
 role = "operator"
 readOnly = false
 approvalPolicy = "ask-all"        # Prod requires approval for everything

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -128,7 +128,15 @@ export const profileSchema = z.object({
   // profile name, and an unrecognised name resolves to the strictest tier.
   group: z.string().optional(),
   workdir: z.string().optional(),
-  trustedHostKey: z.string().optional(),
+  // `.trim().min(1)` rather than a bare string. `trustedHostKey = ""` passed
+  // validation and then did nothing: the old gate in connection.ts tested it for
+  // truthiness, so an empty pin was silently inert and the operator who wrote the
+  // line believed they were pinned. A blank pin is always a mistake, and a loud
+  // one at startup beats a profile that quietly verifies nothing. The trim is for
+  // the same reason in the other direction — the comparison against a fingerprint
+  // is exact, so a trailing newline from a heredoc or an editor refused every
+  // key with no hint as to why.
+  trustedHostKey: z.string().trim().min(1, 'trustedHostKey cannot be empty').optional(),
   tty: z.boolean().default(false),
   role: z.string().default('operator'),
   readOnly: z.boolean().default(false),

--- a/src/ssh/connection.ts
+++ b/src/ssh/connection.ts
@@ -186,11 +186,10 @@ export class SSHConnection {
         hostVerifier: (key: Buffer) => {
           // The pin used to be checked here, as a `return false` ahead of
           // verifyHostKey. That made it reject-only: a *matching* pin fell
-          // through and was then refused anyway under `strict`, because the
-          // store it consults can never be populated in that mode. Passing the
-          // pin in instead puts one function in charge of the whole decision,
-          // and `return false` gave ssh2 a generic handshake failure where
-          // verifyHostKey raises a message that names what decided.
+          // through and was refused anyway under `strict`, whose store can never
+          // be populated. Passing it in puts one function in charge of the whole
+          // decision, and `return false` gave ssh2 a generic handshake failure
+          // where verifyHostKey raises a message that names what decided.
           return verifyHostKey(
             this.profile.host,
             this.profile.port,

--- a/src/ssh/connection.ts
+++ b/src/ssh/connection.ts
@@ -184,16 +184,20 @@ export class SSHConnection {
         username: this.profile.user,
         algorithms: FROZEN_ALGORITHMS as ConnectConfig['algorithms'],
         hostVerifier: (key: Buffer) => {
-          const fp = fingerprintPublicKey(key);
-          if (this.profile.trustedHostKey && fp !== this.profile.trustedHostKey) {
-            return false;
-          }
+          // The pin used to be checked here, as a `return false` ahead of
+          // verifyHostKey. That made it reject-only: a *matching* pin fell
+          // through and was then refused anyway under `strict`, because the
+          // store it consults can never be populated in that mode. Passing the
+          // pin in instead puts one function in charge of the whole decision,
+          // and `return false` gave ssh2 a generic handshake failure where
+          // verifyHostKey raises a message that names what decided.
           return verifyHostKey(
             this.profile.host,
             this.profile.port,
-            fp,
+            fingerprintPublicKey(key),
             this.knownHostsStore,
             this.hostKeyMode,
+            this.profile.trustedHostKey,
           );
         },
         readyTimeout: 20000,

--- a/src/ssh/host-key.ts
+++ b/src/ssh/host-key.ts
@@ -99,7 +99,18 @@ export function verifyHostKey(
     // a different profile that pinned nothing — strict's whole point. Under
     // `insecure` 2.7.0 returned before reaching the write, so writing now would
     // invent a record where there was none.
-    if (mode === 'tofu') knownHosts.set(key, fingerprint);
+    // `has`, not an unconditional set. 2.7.0's write lived in the else-branch of
+    // `if (stored)`, so it only ever filled an empty slot — it never overwrote.
+    // Overwriting made the entry order-dependent: with two profiles pinning
+    // different keys for one host:port, whichever connected last decided what an
+    // *unpinned* profile was compared against, so that profile got a false
+    // HOST_KEY_MISMATCH for a key the other pin had authorised. Measured as a
+    // three-connection sequence; single calls do not show it.
+    //
+    // A single-entry store still cannot represent a host that serves two keys —
+    // nothing here can — but not overwriting keeps the baseline stable and matches
+    // what this write replaced.
+    if (mode === 'tofu' && !knownHosts.has(key)) knownHosts.set(key, fingerprint);
     return true;
   }
 

--- a/src/ssh/host-key.ts
+++ b/src/ssh/host-key.ts
@@ -4,13 +4,9 @@ import { OperatorError } from '../errors.js';
 export type HostKeyMode = 'tofu' | 'strict' | 'insecure';
 
 /**
- * The one operational instruction two of the three refusals below have to give.
- *
- * Shared as a literal rather than through a message builder: the three refusals
- * deliberately diverge in their advice — MISMATCH warns against
- * `--insecureHostKey`, UNKNOWN offers two modes, PIN_MISMATCH offers none —
- * and message-quality.test.ts asserts that divergence per message. Only the
- * command is common, and only it should be.
+ * Shared as a literal, not through a message builder: the three refusals below
+ * diverge in their advice, and message-quality.test.ts asserts each one's wording
+ * separately. Only the command is common, and only it should be.
  */
 const CONFIRM_OUT_OF_BAND =
   '`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` on the server';
@@ -28,10 +24,9 @@ export function fingerprintPublicKey(key: Buffer): string {
  * Decide whether to accept the key a host just presented.
  *
  * `knownHosts` is one Map shared by every profile (connection-registry.ts), which
- * is why a pin answers this without ever *reading* it: seeding the store from the
- * pin makes two profiles pinning different keys for one host:port collide with a
- * false HOST_KEY_MISMATCH, once the host presents each its own key. It still
- * writes, under `tofu` only — see the pin branch.
+ * is why a pin never *reads* it: consulting it for a pinned host would make two
+ * profiles pinning different keys for one host:port collide with a false
+ * HOST_KEY_MISMATCH, once the host presents each its own key.
  *
  * Why `--hostKeyMode=strict` refused every host before 2.8.0 is in
  * .changeset/lucky-keys-pinned.md and SECURITY.md; the branch order here is what
@@ -50,17 +45,17 @@ export function verifyHostKey(
   mode: HostKeyMode,
   pinnedFingerprint: string | undefined,
 ): boolean {
+  const key = `${host}:${port}`;
+
   // Before `insecure`, not after: the gate this replaced sat ahead of
   // verifyHostKey in connection.ts, so a key contradicting the pin was refused in
   // every mode, `insecure` included. Pinned by host-key.test.ts, "refuses a key
-  // that contradicts the pin, in every mode including insecure" — which fails on
-  // the reordering, measured, so this is not a comment you have to take on faith.
-  const key = `${host}:${port}`;
-
-  // Truthiness, not `!== undefined`. `trustedHostKey = ""` was inert on 2.7.0
-  // because the gate this replaced tested truthiness; `!== undefined` would turn
-  // the same config into "refuse every host". The schema rejects a blank pin now,
-  // so this is defence in depth rather than the primary guard.
+  // that contradicts the pin, in every mode including insecure".
+  //
+  // Truthiness, not `!== undefined`: `trustedHostKey = ""` was inert on 2.7.0
+  // because that gate tested truthiness, and `!== undefined` would turn the same
+  // config into "refuse every host". The schema rejects a blank pin, so this is
+  // defence in depth rather than the primary guard.
   if (pinnedFingerprint) {
     if (pinnedFingerprint !== fingerprint) {
       // No "or turn the check off" exit here, unlike the two refusals below.
@@ -77,39 +72,17 @@ export function verifyHostKey(
         'which is what pinning exists to catch.',
       );
     }
-    // Matched. The store is not *read* — that is what keeps two profiles pinning
-    // different keys for one host:port from colliding — but it is still written,
-    // and under `tofu` only.
+    // Matched. Two constraints on the write, neither derivable from the code:
     //
-    // Dropping the write was a draft of this fix, and it cost a real refusal.
-    // On 2.7.0 a matching pin fell through into the trust-on-first-use
-    // accept below, so a pinned profile seeded the shared store and an unpinned
-    // profile on the same host:port was compared against it. Measured: pinned
-    // profile connects (served K, store becomes {H:22 -> K}), then an unpinned
-    // profile is served K' and refuses with HOST_KEY_MISMATCH. Without the write
-    // the unpinned profile trust-on-first-uses K' instead, and the store then
-    // holds the attacker's key — so the next unpinned connection served the
-    // genuine K is refused, with the diagnostic naming the real server as the
-    // impostor. The collision argument does not justify dropping the write: it is
-    // about the read, and the read is already skipped. (Found in review, after
-    // the draft had been written down as finished.)
+    // `tofu` only — under `strict` the store is the only thing that admits an
+    // *unpinned* profile, so seeding it there would let one profile's pin authorise
+    // another. Fill-only — an unconditional set makes the entry order-dependent for
+    // an unpinned sibling, and 2.7.0's write was reachable only on a store miss, so
+    // this writes exactly when that one would have.
     //
-    // `tofu` only, deliberately. Under `strict` the store is what an *unpinned*
-    // profile consults, so seeding it there would let one profile's pin authorise
-    // a different profile that pinned nothing — strict's whole point. Under
-    // `insecure` 2.7.0 returned before reaching the write, so writing now would
-    // invent a record where there was none.
-    // `has`, not an unconditional set. 2.7.0's write lived in the else-branch of
-    // `if (stored)`, so it only ever filled an empty slot — it never overwrote.
-    // Overwriting made the entry order-dependent: with two profiles pinning
-    // different keys for one host:port, whichever connected last decided what an
-    // *unpinned* profile was compared against, so that profile got a false
-    // HOST_KEY_MISMATCH for a key the other pin had authorised. Measured as a
-    // three-connection sequence; single calls do not show it.
-    //
-    // A single-entry store still cannot represent a host that serves two keys —
-    // nothing here can — but not overwriting keeps the baseline stable and matches
-    // what this write replaced.
+    // And it is inside the match, below the throw: recording on the refusal path
+    // would put an interceptor's fingerprint into the shared store, which is the
+    // failure the write exists to prevent.
     if (mode === 'tofu' && !knownHosts.has(key)) knownHosts.set(key, fingerprint);
     return true;
   }

--- a/src/ssh/host-key.ts
+++ b/src/ssh/host-key.ts
@@ -3,6 +3,18 @@ import { OperatorError } from '../errors.js';
 
 export type HostKeyMode = 'tofu' | 'strict' | 'insecure';
 
+/**
+ * The one operational instruction two of the three refusals below have to give.
+ *
+ * Shared as a literal rather than through a message builder: the three refusals
+ * deliberately diverge in their advice — MISMATCH warns against
+ * `--insecureHostKey`, UNKNOWN offers two modes, PIN_MISMATCH offers none —
+ * and message-quality.test.ts asserts that divergence per message. Only the
+ * command is common, and only it should be.
+ */
+const CONFIRM_OUT_OF_BAND =
+  '`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` on the server';
+
 export function fingerprintPublicKey(key: Buffer): string {
   const hash = createHash('sha256').update(key).digest('base64');
   // `={0,2}` rather than `=+`: base64 padding is never longer than two
@@ -15,22 +27,19 @@ export function fingerprintPublicKey(key: Buffer): string {
 /**
  * Decide whether to accept the key a host just presented.
  *
- * The order of the branches below is load-bearing, and two of them exist because
- * getting it wrong is how `--hostKeyMode=strict` came to refuse every host on
- * every connection until 2.8.0. The store is in-memory and lives for the process;
- * the only write to it is the trust-on-first-use accept at the bottom, which
- * `strict` never reaches. So under strict the store started empty and stayed
- * empty, and a pin did not rescue it either — `trustedHostKey` was a reject-only
- * gate in connection.ts that fell through to here and threw anyway. Strict plus a
- * correct pin, which reads like the secure configuration, connected to nothing.
+ * `knownHosts` is one Map shared by every profile (connection-registry.ts), which
+ * is why a pin answers this without ever *reading* it: seeding the store from the
+ * pin makes two profiles pinning different keys for one host:port collide with a
+ * false HOST_KEY_MISMATCH, once the host presents each its own key. It still
+ * writes, under `tofu` only — see the pin branch.
  *
- * A pin now answers the question by itself, and deliberately without consulting
- * or writing the store. `knownHostsStore` is a single Map shared by every profile
- * (connection-registry.ts), so seeding it from the pin — the obvious fix, and the
- * one this replaced — meant two profiles pinning different keys for the same
- * `host:port` produced a false HOST_KEY_MISMATCH against each other's entry. A
- * pinned host has no use for trust-on-first-use memory: the pin already is that
- * memory, and it outranks anything the store could have learned.
+ * Why `--hostKeyMode=strict` refused every host before 2.8.0 is in
+ * .changeset/lucky-keys-pinned.md and SECURITY.md; the branch order here is what
+ * that history left behind.
+ *
+ * @param pinnedFingerprint `trustedHostKey` from the profile. Falsy means no pin.
+ *   A value decides the outcome in every mode, `insecure` included, and is never
+ *   compared against `knownHosts`.
  */
 export function verifyHostKey(
   host: string,
@@ -38,42 +47,63 @@ export function verifyHostKey(
   fingerprint: string,
   knownHosts: Map<string, string>,
   mode: HostKeyMode,
-  trustedHostKey?: string,
+  pinnedFingerprint: string | undefined,
 ): boolean {
-  // Before `insecure`, not after. This function replaced a gate that sat ahead of
-  // it in connection.ts, so a key contradicting the pin was refused in every mode
-  // — `insecure` included. Moving the check below the early return would keep the
-  // tests green and silently drop that, which is the one way this change could
-  // have been a security regression rather than a fix.
-  // Truthiness, not `!== undefined`. The schema now rejects a blank pin, so this
-  // is defence in depth rather than the primary guard — but `!== undefined` alone
-  // was a regression I nearly shipped: the gate this replaced tested truthiness,
-  // so `trustedHostKey = ""` was inert on 2.7.0 and would have become "refuse
-  // every host" here. Measured both ways before writing this down.
-  if (trustedHostKey) {
-    if (trustedHostKey !== fingerprint) {
+  // Before `insecure`, not after: the gate this replaced sat ahead of
+  // verifyHostKey in connection.ts, so a key contradicting the pin was refused in
+  // every mode, `insecure` included. Pinned by host-key.test.ts, "refuses a key
+  // that contradicts the pin, in every mode including insecure" — which fails on
+  // the reordering, measured, so this is not a comment you have to take on faith.
+  const key = `${host}:${port}`;
+
+  // Truthiness, not `!== undefined`. `trustedHostKey = ""` was inert on 2.7.0
+  // because the gate this replaced tested truthiness; `!== undefined` would turn
+  // the same config into "refuse every host". The schema rejects a blank pin now,
+  // so this is defence in depth rather than the primary guard.
+  if (pinnedFingerprint) {
+    if (pinnedFingerprint !== fingerprint) {
       // No "or turn the check off" exit here, unlike the two refusals below.
       // Nothing overrides a pin — not tofu, not insecure — so offering a mode
       // would describe a way out that does not exist.
       throw new OperatorError(
         `HOST_KEY_PIN_MISMATCH: the key presented by ${host}:${port} is not the pinned key.\n` +
-        `  pinned   ${trustedHostKey}\n` +
+        `  pinned   ${pinnedFingerprint}\n` +
         `  received ${fingerprint}\n` +
         'trustedHostKey on this profile is what decided, and no host key mode overrides it. ' +
         'Either the pin is stale — the server was rebuilt or its address reused, in which case ' +
-        'confirm the new fingerprint out of band (`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` ' +
-        'on the server) and update trustedHostKey — or something is intercepting this connection, ' +
+        `confirm the new fingerprint out of band (${CONFIRM_OUT_OF_BAND}) ` +
+        'and update trustedHostKey — or something is intercepting this connection, ' +
         'which is what pinning exists to catch.',
       );
     }
-    // Matched. Answered without reading or writing `knownHosts`, for the reason
-    // in the block comment above.
+    // Matched. The store is not *read* — that is what keeps two profiles pinning
+    // different keys for one host:port from colliding — but it is still written,
+    // and under `tofu` only.
+    //
+    // Dropping the write was a draft of this fix, and it cost a real refusal.
+    // On 2.7.0 a matching pin fell through into the trust-on-first-use
+    // accept below, so a pinned profile seeded the shared store and an unpinned
+    // profile on the same host:port was compared against it. Measured: pinned
+    // profile connects (served K, store becomes {H:22 -> K}), then an unpinned
+    // profile is served K' and refuses with HOST_KEY_MISMATCH. Without the write
+    // the unpinned profile trust-on-first-uses K' instead, and the store then
+    // holds the attacker's key — so the next unpinned connection served the
+    // genuine K is refused, with the diagnostic naming the real server as the
+    // impostor. The collision argument does not justify dropping the write: it is
+    // about the read, and the read is already skipped. (Found in review, after
+    // the draft had been written down as finished.)
+    //
+    // `tofu` only, deliberately. Under `strict` the store is what an *unpinned*
+    // profile consults, so seeding it there would let one profile's pin authorise
+    // a different profile that pinned nothing — strict's whole point. Under
+    // `insecure` 2.7.0 returned before reaching the write, so writing now would
+    // invent a record where there was none.
+    if (mode === 'tofu') knownHosts.set(key, fingerprint);
     return true;
   }
 
   if (mode === 'insecure') return true;
 
-  const key = `${host}:${port}`;
   const stored = knownHosts.get(key);
 
   if (stored) {
@@ -88,7 +118,7 @@ export function verifyHostKey(
         'Either the server was rebuilt, reinstalled or had its address reused — in which case the new key is ' +
         'genuine — or something is intercepting this connection, which is what this check exists to catch. ' +
         'Nothing here can tell those apart; confirm the fingerprint out of band, from the host itself ' +
-        '(`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` on the server) or from whoever rebuilt it.\n' +
+        `(${CONFIRM_OUT_OF_BAND}) or from whoever rebuilt it.\n` +
         'If it matches, pin it with trustedHostKey on the profile. Do not reach for --insecureHostKey to get ' +
         'past this: it disables verification for every host and every future connection, including the case ' +
         'this message is warning you about.',

--- a/src/ssh/host-key.ts
+++ b/src/ssh/host-key.ts
@@ -45,7 +45,12 @@ export function verifyHostKey(
   // — `insecure` included. Moving the check below the early return would keep the
   // tests green and silently drop that, which is the one way this change could
   // have been a security regression rather than a fix.
-  if (trustedHostKey !== undefined) {
+  // Truthiness, not `!== undefined`. The schema now rejects a blank pin, so this
+  // is defence in depth rather than the primary guard — but `!== undefined` alone
+  // was a regression I nearly shipped: the gate this replaced tested truthiness,
+  // so `trustedHostKey = ""` was inert on 2.7.0 and would have become "refuse
+  // every host" here. Measured both ways before writing this down.
+  if (trustedHostKey) {
     if (trustedHostKey !== fingerprint) {
       // No "or turn the check off" exit here, unlike the two refusals below.
       // Nothing overrides a pin — not tofu, not insecure — so offering a mode

--- a/src/ssh/host-key.ts
+++ b/src/ssh/host-key.ts
@@ -12,13 +12,60 @@ export function fingerprintPublicKey(key: Buffer): string {
   return `SHA256:${hash.replace(/={0,2}$/, '')}`;
 }
 
+/**
+ * Decide whether to accept the key a host just presented.
+ *
+ * The order of the branches below is load-bearing, and two of them exist because
+ * getting it wrong is how `--hostKeyMode=strict` came to refuse every host on
+ * every connection until 2.8.0. The store is in-memory and lives for the process;
+ * the only write to it is the trust-on-first-use accept at the bottom, which
+ * `strict` never reaches. So under strict the store started empty and stayed
+ * empty, and a pin did not rescue it either — `trustedHostKey` was a reject-only
+ * gate in connection.ts that fell through to here and threw anyway. Strict plus a
+ * correct pin, which reads like the secure configuration, connected to nothing.
+ *
+ * A pin now answers the question by itself, and deliberately without consulting
+ * or writing the store. `knownHostsStore` is a single Map shared by every profile
+ * (connection-registry.ts), so seeding it from the pin — the obvious fix, and the
+ * one this replaced — meant two profiles pinning different keys for the same
+ * `host:port` produced a false HOST_KEY_MISMATCH against each other's entry. A
+ * pinned host has no use for trust-on-first-use memory: the pin already is that
+ * memory, and it outranks anything the store could have learned.
+ */
 export function verifyHostKey(
   host: string,
   port: number,
   fingerprint: string,
   knownHosts: Map<string, string>,
   mode: HostKeyMode,
+  trustedHostKey?: string,
 ): boolean {
+  // Before `insecure`, not after. This function replaced a gate that sat ahead of
+  // it in connection.ts, so a key contradicting the pin was refused in every mode
+  // — `insecure` included. Moving the check below the early return would keep the
+  // tests green and silently drop that, which is the one way this change could
+  // have been a security regression rather than a fix.
+  if (trustedHostKey !== undefined) {
+    if (trustedHostKey !== fingerprint) {
+      // No "or turn the check off" exit here, unlike the two refusals below.
+      // Nothing overrides a pin — not tofu, not insecure — so offering a mode
+      // would describe a way out that does not exist.
+      throw new OperatorError(
+        `HOST_KEY_PIN_MISMATCH: the key presented by ${host}:${port} is not the pinned key.\n` +
+        `  pinned   ${trustedHostKey}\n` +
+        `  received ${fingerprint}\n` +
+        'trustedHostKey on this profile is what decided, and no host key mode overrides it. ' +
+        'Either the pin is stale — the server was rebuilt or its address reused, in which case ' +
+        'confirm the new fingerprint out of band (`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` ' +
+        'on the server) and update trustedHostKey — or something is intercepting this connection, ' +
+        'which is what pinning exists to catch.',
+      );
+    }
+    // Matched. Answered without reading or writing `knownHosts`, for the reason
+    // in the block comment above.
+    return true;
+  }
+
   if (mode === 'insecure') return true;
 
   const key = `${host}:${port}`;

--- a/src/ssh/host-key.ts
+++ b/src/ssh/host-key.ts
@@ -38,8 +38,9 @@ export function fingerprintPublicKey(key: Buffer): string {
  * that history left behind.
  *
  * @param pinnedFingerprint `trustedHostKey` from the profile. Falsy means no pin.
- *   A value decides the outcome in every mode, `insecure` included, and is never
- *   compared against `knownHosts`.
+ *   A value decides the outcome in every mode, `insecure` included. It is never
+ *   compared against `knownHosts`, but a match does record into it under `tofu` —
+ *   see the pin branch for why those two differ.
  */
 export function verifyHostKey(
   host: string,

--- a/test/integration/host-key.test.ts
+++ b/test/integration/host-key.test.ts
@@ -54,13 +54,17 @@ describe.skipIf(!allServersUp(await checkAllServers()))('Host key verification (
       [`${profiles.admin.host}:${profiles.admin.port}`, 'SHA256:definitelyNotTheRealHostKeyAAAAAAAAAAAAAAAA'],
     ]);
     const conn = await connect(knownHosts, 'tofu');
-    await expect(conn.ensureConnected()).rejects.toThrow();
+    // The code, not just the throw. A bare `rejects.toThrow()` passes for a
+    // handshake that failed for any reason at all, so it cannot tell this refusal
+    // from a container that was not listening — and it is the only thing proving
+    // the message survives ssh2's callback boundary and reaches the operator.
+    await expect(conn.ensureConnected()).rejects.toThrow(/HOST_KEY_MISMATCH/);
     await conn.close();
   }, 30000);
 
   it('strict mode refuses an unknown host', async () => {
     const conn = await connect(new Map(), 'strict');
-    await expect(conn.ensureConnected()).rejects.toThrow();
+    await expect(conn.ensureConnected()).rejects.toThrow(/HOST_KEY_UNKNOWN/);
     await conn.close();
   }, 30000);
 
@@ -79,7 +83,29 @@ describe.skipIf(!allServersUp(await checkAllServers()))('Host key verification (
     const conn = await connect(new Map(), 'tofu', {
       trustedHostKey: 'SHA256:pinnedToSomethingElseAAAAAAAAAAAAAAAAAAAAAA',
     });
-    await expect(conn.ensureConnected()).rejects.toThrow();
+    // Named, because the change's whole claim about this path is that it stopped
+    // being an anonymous handshake failure. This assertion passed identically
+    // before and after while it read `rejects.toThrow()`.
+    await expect(conn.ensureConnected()).rejects.toThrow(/HOST_KEY_PIN_MISMATCH/);
+    await conn.close();
+  }, 30000);
+
+  it('strict mode connects with nothing but a matching pin', async () => {
+    // The headline fix, and it had no coverage at this level: both pinning cases
+    // here used `tofu`, where a matching pin reached a trust-on-first-use accept
+    // on 2.7.0 and so passed before the change as well. This one cannot: an empty
+    // store under `strict` is exactly the state that refused every host, so it
+    // fails on 2.7.0 and on any regression that stops the pin reaching
+    // verifyHostKey.
+    const discovered = new Map<string, string>();
+    const seed = await connect(discovered, 'tofu');
+    await seed.ensureConnected();
+    await seed.close();
+    const real = discovered.get(`${profiles.admin.host}:${profiles.admin.port}`);
+    expect(real).toBeDefined();
+
+    const conn = await connect(new Map(), 'strict', { trustedHostKey: real });
+    await expect(conn.ensureConnected()).resolves.not.toThrow();
     await conn.close();
   }, 30000);
 

--- a/test/unit/config/trusted-host-key.test.ts
+++ b/test/unit/config/trusted-host-key.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
+import { readFile } from 'node:fs/promises';
 import { loadConfig } from '../../../src/config/loader.js';
 import { makeConfigDir, enforceAcl, type ConfigDir } from './helpers.js';
 
@@ -56,5 +57,31 @@ ${line}
     // stray character. A trailing newline is a typo, not an intent.
     const config = await load('trustedHostKey = "  SHA256:abc123  "');
     expect(config.profiles[0].trustedHostKey).toBe('SHA256:abc123');
+  });
+});
+
+/**
+ * The template we ship, loaded the way an operator would load it.
+ *
+ * `config.default.toml` is COPYed into the published image (Dockerfile) as the file
+ * operators start from, and nothing in the suite read it. That mattered for one
+ * field: `trustedHostKey = "SHA256:..."` shipped uncommented, and a placeholder pin
+ * is not an inert example — it is a pin nothing can match, so that profile refused
+ * every connection. The schema catches a *blank* pin; nothing catches a plausible
+ * one, and nothing caught the comment being un-commented by the next tidy-up.
+ */
+describe('the shipped config.default.toml', () => {
+  let cfg: ConfigDir;
+  afterEach(async () => { await cfg?.cleanup(); });
+
+  it('parses, and arms no host key pin', async () => {
+    const text = await readFile(new URL('../../../config.default.toml', import.meta.url), 'utf8');
+    cfg = await makeConfigDir('ssh-mcp-default-');
+    const config = await loadConfig(await cfg.write(text), enforceAcl());
+
+    expect(config.profiles.length).toBeGreaterThan(0);
+    for (const profile of config.profiles) {
+      expect(profile.trustedHostKey, `${profile.name} ships with a pin`).toBeUndefined();
+    }
   });
 });

--- a/test/unit/config/trusted-host-key.test.ts
+++ b/test/unit/config/trusted-host-key.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { loadConfig } from '../../../src/config/loader.js';
+import { makeConfigDir, enforceAcl, type ConfigDir } from './helpers.js';
+
+/**
+ * `trustedHostKey` is the only host-key control that survives a restart, so a
+ * profile that carries the line and verifies nothing is the worst outcome the
+ * field has.
+ *
+ * This goes config file → loadConfig rather than testing the zod schema in
+ * isolation, for the reason max-chars.test.ts gives: the interesting failure is a
+ * value that passes validation and then means something different downstream, and
+ * that is invisible one step earlier.
+ */
+describe('trustedHostKey in the config schema', () => {
+  let cfg: ConfigDir;
+  afterEach(async () => { await cfg?.cleanup(); });
+
+  const profile = (line: string) => `
+[[profiles]]
+name = "dev"
+host = "localhost"
+user = "test"
+${line}
+`;
+
+  const load = async (line: string) => {
+    cfg = await makeConfigDir('ssh-mcp-pin-');
+    const path = await cfg.write(profile(line));
+    return loadConfig(path, enforceAcl());
+  };
+
+  it('accepts a fingerprint', async () => {
+    const config = await load('trustedHostKey = "SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG"');
+    expect(config.profiles[0].trustedHostKey).toBe(
+      'SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG',
+    );
+  });
+
+  it('refuses an empty pin instead of silently ignoring it', async () => {
+    // `z.string().optional()` accepted this, and the gate that read it tested
+    // truthiness — so the line was inert and the operator who wrote it believed
+    // the profile was pinned. Loud at startup is the only safe reading of a blank
+    // pin, because the alternative is a profile that verifies nothing and says so
+    // nowhere.
+    await expect(load('trustedHostKey = ""')).rejects.toThrow(/trustedHostKey cannot be empty/);
+  });
+
+  it('refuses a whitespace-only pin for the same reason', async () => {
+    await expect(load('trustedHostKey = "   "')).rejects.toThrow(/trustedHostKey cannot be empty/);
+  });
+
+  it('trims surrounding whitespace rather than refusing every key', async () => {
+    // The comparison against the presented fingerprint is exact, so an untrimmed
+    // value refused every connection with nothing in the message pointing at the
+    // stray character. A trailing newline is a typo, not an intent.
+    const config = await load('trustedHostKey = "  SHA256:abc123  "');
+    expect(config.profiles[0].trustedHostKey).toBe('SHA256:abc123');
+  });
+});

--- a/test/unit/guard/message-quality.test.ts
+++ b/test/unit/guard/message-quality.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { verifyHostKey } from '../../../src/ssh/host-key.js';
+import { verifyHostKey, fingerprintPublicKey } from '../../../src/ssh/host-key.js';
 
 /**
  * #41: mechanisms that work correctly while telling the reader something
@@ -40,33 +40,41 @@ describe('host key mismatch explains itself', () => {
 
   // The message next door was already right, and is the standard the one above
   // was measured against: it names the setting that decided and gives two ways out.
-  /**
-   * The third refusal, and the only one that deliberately offers no way out.
-   *
-   * It lives here rather than beside the pin's behaviour cases because this file
-   * is where "a refusal explains itself" is the concern — and because a sweep of
-   * this file should cover all three host-key refusals, not two of them.
-   */
-  it('the pin refusal names the pin, shows both keys, and offers no mode as an escape', () => {
-    const PIN = 'SHA256:pinnedkeypinnedkeypinnedkeypinnedkeypinne';
-    const OTHER = 'SHA256:otherkeyotherkeyotherkeyotherkeyotherkeyo';
-    const refused = () => verifyHostKey('10.0.0.7', 22, OTHER, new Map(), 'tofu', PIN);
-
-    expect(refused).toThrow(/HOST_KEY_PIN_MISMATCH/);
-    expect(refused).toThrow(/trustedHostKey/);
-    // Both in full, for the same reason the mismatch case asserts it: the reader's
-    // whole job is comparing them.
-    expect(refused).toThrow(new RegExp(PIN));
-    expect(refused).toThrow(new RegExp(OTHER));
-    // Nothing overrides a pin — not tofu, not insecure. A refusal that named a
-    // mode would be describing a way out that does not exist, which is the exact
-    // failure #41 was about.
-    expect(refused).not.toThrow(/--insecureHostKey|--hostKeyMode/);
-  });
-
   it('the unknown-key refusal still names what decided and how to proceed', () => {
     const unknown = () => verifyHostKey('10.0.0.9', 22, 'SHA256:ccc', new Map(), 'strict', undefined);
     expect(unknown).toThrow(/--hostKeyMode=strict/);
     expect(unknown).toThrow(/trustedHostKey/);
+  });
+
+  // All three host-key refusals belong in the file where "a refusal explains
+  // itself" is the concern; this is the only one that deliberately offers no exit.
+  it('the pin refusal names the pin, shows both keys against their labels, and offers no escape', () => {
+    const PIN = fingerprintPublicKey(Buffer.from('pinned-host-key'));
+    const OTHER = fingerprintPublicKey(Buffer.from('some-other-host-key'));
+    const esc = (fp: string) => fp.replace(/[+/]/g, (c) => `\\${c}`);
+    const refused = () => verifyHostKey('10.0.0.7', 22, OTHER, new Map(), 'tofu', PIN);
+
+    expect(refused).toThrow(/HOST_KEY_PIN_MISMATCH/);
+    expect(refused).toThrow(/trustedHostKey/);
+
+    // Bound to their labels, not merely present. Two `toThrow(substring)` checks
+    // pass just as happily on a message that tells the operator their config holds
+    // the key the server presented and the server presented their pin — and
+    // comparing the two is the reader's whole job here.
+    expect(refused).toThrow(new RegExp(`pinned\\s+${esc(PIN)}`));
+    expect(refused).toThrow(new RegExp(`received\\s+${esc(OTHER)}`));
+
+    // The actionable half. Without these the entire diagnostic — both causes, the
+    // verification command, "update trustedHostKey" — is deletable with the suite
+    // green, which is the #41 class this file exists to catch. It is also the only
+    // assertion holding the shared CONFIRM_OUT_OF_BAND to its second consumer.
+    expect(refused).toThrow(/out of band/);
+    expect(refused).toThrow(/ssh-keygen -lf/);
+    expect(refused).toThrow(/rebuilt/);
+    expect(refused).toThrow(/intercepting/);
+
+    // Nothing overrides a pin — not tofu, not insecure. A refusal naming a mode
+    // would describe a way out that does not exist.
+    expect(refused).not.toThrow(/--insecureHostKey|--hostKeyMode/);
   });
 });

--- a/test/unit/guard/message-quality.test.ts
+++ b/test/unit/guard/message-quality.test.ts
@@ -12,7 +12,7 @@ import { verifyHostKey } from '../../../src/ssh/host-key.js';
 describe('host key mismatch explains itself', () => {
   const seen = () => new Map([['10.0.0.5:22', 'SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']]);
   const mismatch = () =>
-    verifyHostKey('10.0.0.5', 22, 'SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', seen(), 'tofu');
+    verifyHostKey('10.0.0.5', 22, 'SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', seen(), 'tofu', undefined);
 
   it('names both causes rather than only the fact', () => {
     // The reader cannot act on "the key changed" alone: a rebuilt server and an
@@ -40,8 +40,32 @@ describe('host key mismatch explains itself', () => {
 
   // The message next door was already right, and is the standard the one above
   // was measured against: it names the setting that decided and gives two ways out.
+  /**
+   * The third refusal, and the only one that deliberately offers no way out.
+   *
+   * It lives here rather than beside the pin's behaviour cases because this file
+   * is where "a refusal explains itself" is the concern — and because a sweep of
+   * this file should cover all three host-key refusals, not two of them.
+   */
+  it('the pin refusal names the pin, shows both keys, and offers no mode as an escape', () => {
+    const PIN = 'SHA256:pinnedkeypinnedkeypinnedkeypinnedkeypinne';
+    const OTHER = 'SHA256:otherkeyotherkeyotherkeyotherkeyotherkeyo';
+    const refused = () => verifyHostKey('10.0.0.7', 22, OTHER, new Map(), 'tofu', PIN);
+
+    expect(refused).toThrow(/HOST_KEY_PIN_MISMATCH/);
+    expect(refused).toThrow(/trustedHostKey/);
+    // Both in full, for the same reason the mismatch case asserts it: the reader's
+    // whole job is comparing them.
+    expect(refused).toThrow(new RegExp(PIN));
+    expect(refused).toThrow(new RegExp(OTHER));
+    // Nothing overrides a pin — not tofu, not insecure. A refusal that named a
+    // mode would be describing a way out that does not exist, which is the exact
+    // failure #41 was about.
+    expect(refused).not.toThrow(/--insecureHostKey|--hostKeyMode/);
+  });
+
   it('the unknown-key refusal still names what decided and how to proceed', () => {
-    const unknown = () => verifyHostKey('10.0.0.9', 22, 'SHA256:ccc', new Map(), 'strict');
+    const unknown = () => verifyHostKey('10.0.0.9', 22, 'SHA256:ccc', new Map(), 'strict', undefined);
     expect(unknown).toThrow(/--hostKeyMode=strict/);
     expect(unknown).toThrow(/trustedHostKey/);
   });

--- a/test/unit/ssh/host-key.test.ts
+++ b/test/unit/ssh/host-key.test.ts
@@ -131,6 +131,18 @@ describe('verifyHostKey with a pinned key', () => {
     expect(verifyHostKey('plain.com', 22, OTHER, knownHosts, 'tofu', undefined)).toBe(true);
     expect(knownHosts.get('plain.com:22')).toBe(OTHER);
   });
+
+  it('treats an empty pin as no pin, not as a pin nothing can match', () => {
+    // A regression this change nearly shipped. The gate it replaced tested
+    // truthiness, so `trustedHostKey = ""` was inert on 2.7.0; a `!== undefined`
+    // predicate turned the same config into "refuse every host on every
+    // connection" — fail-closed, but a config that worked would have stopped
+    // working. The schema rejects a blank pin now, so this asserts the runtime
+    // half of a two-layer guard.
+    const knownHosts = new Map<string, string>();
+    expect(verifyHostKey('plain.com', 22, OTHER, knownHosts, 'tofu', '')).toBe(true);
+    expect(knownHosts.get('plain.com:22')).toBe(OTHER);
+  });
 });
 
 describe('fingerprintPublicKey', () => {

--- a/test/unit/ssh/host-key.test.ts
+++ b/test/unit/ssh/host-key.test.ts
@@ -44,6 +44,95 @@ describe('verifyHostKey', () => {
   });
 });
 
+/**
+ * `--hostKeyMode=strict` refused every host on every connection until 2.8.0.
+ *
+ * The store it consults is in-memory and lives for the process, and the only
+ * write to it sat *below* the strict throw — so under strict it started empty
+ * and stayed empty. Measured on 2.7.0: two consecutive calls both threw with
+ * `knownHosts.size === 0`, while tofu populated it on the first call. A pin did
+ * not help either, because it was a reject-only gate in `connection.ts` that
+ * fell through to this function and threw anyway. So strict plus a correct pin —
+ * the combination that reads like the secure configuration — connected to
+ * nothing, and the refusal's own advice ("pin the key with trustedHostKey") was
+ * the advice that did not work.
+ *
+ * A pin is now the authority for the host it names, and is deliberately kept
+ * *out* of the shared store rather than seeding it: `knownHostsStore` is one Map
+ * for every profile (connection-registry.ts), so seeding meant two profiles
+ * pinning different keys for the same host:port produced a false
+ * HOST_KEY_MISMATCH against each other's entry. A pinned host needs no
+ * trust-on-first-use memory — the pin already is that memory, and it outranks it.
+ */
+describe('verifyHostKey with a pinned key', () => {
+  const PIN = 'SHA256:pinnedkeypinnedkeypinnedkeypinnedkeypinne';
+  const OTHER = 'SHA256:otherkeyotherkeyotherkeyotherkeyotherkeyo';
+
+  it('satisfies strict mode, which is the whole point', () => {
+    const knownHosts = new Map<string, string>();
+    expect(verifyHostKey('pinned.com', 22, PIN, knownHosts, 'strict', PIN)).toBe(true);
+  });
+
+  it('still refuses an unpinned unknown host under strict', () => {
+    // The fix must not turn strict into tofu for hosts nobody pinned.
+    const knownHosts = new Map<string, string>();
+    expect(() => verifyHostKey('bare.com', 22, OTHER, knownHosts, 'strict')).toThrow(
+      /HOST_KEY_UNKNOWN/,
+    );
+    expect(knownHosts.size).toBe(0);
+  });
+
+  it('refuses a key that contradicts the pin, in every mode including insecure', () => {
+    // Ordering, not decoration. The pin check has to run BEFORE the insecure
+    // early return: the reject-only gate this replaces sat in connection.ts
+    // ahead of this function, so a mismatched pin refused even under insecure.
+    // Putting the pin branch after `mode === 'insecure'` would silently drop
+    // that, which is the one way this change could have been a regression.
+    for (const mode of ['strict', 'tofu', 'insecure'] as const) {
+      expect(() => verifyHostKey('pinned.com', 22, OTHER, new Map(), mode, PIN)).toThrow(
+        /HOST_KEY_PIN_MISMATCH/,
+      );
+    }
+  });
+
+  it('names the pin as what decided, and does not offer a way to switch it off', () => {
+    // Same standard as the two refusals next door (see message-quality.test.ts):
+    // a refusal has to say what decided and how to proceed, without pointing at
+    // the least safe exit. Here the operator edits the pin or investigates; there
+    // is no mode that overrides a pin, and the message must not imply one.
+    const refused = () => verifyHostKey('pinned.com', 22, OTHER, new Map(), 'tofu', PIN);
+    expect(refused).toThrow(/trustedHostKey/);
+    expect(refused).toThrow(new RegExp(PIN));
+    expect(refused).toThrow(new RegExp(OTHER));
+    expect(refused).not.toThrow(/--insecureHostKey|--hostKeyMode=insecure/);
+  });
+
+  it('does not write a pinned host into the shared store', () => {
+    // What makes the cross-profile collision impossible. If this ever records,
+    // a second profile pinning a different key for the same host:port starts
+    // failing with HOST_KEY_MISMATCH against an entry it never agreed to.
+    const knownHosts = new Map<string, string>();
+    verifyHostKey('pinned.com', 22, PIN, knownHosts, 'strict', PIN);
+    expect(knownHosts.size).toBe(0);
+  });
+
+  it('lets the pin win over a stale store entry for the same host', () => {
+    // Reachable with one shared store: profile A (tofu, no pin) learns a key,
+    // profile B pins a different one for the same host:port. B must be judged
+    // against its pin, not against A's memory.
+    const knownHosts = new Map([['shared.com:22', OTHER]]);
+    expect(verifyHostKey('shared.com', 22, PIN, knownHosts, 'strict', PIN)).toBe(true);
+    expect(knownHosts.get('shared.com:22')).toBe(OTHER);
+  });
+
+  it('is inert when no pin is configured', () => {
+    // undefined must not be read as "pin that matches nothing".
+    const knownHosts = new Map<string, string>();
+    expect(verifyHostKey('plain.com', 22, OTHER, knownHosts, 'tofu', undefined)).toBe(true);
+    expect(knownHosts.get('plain.com:22')).toBe(OTHER);
+  });
+});
+
 describe('fingerprintPublicKey', () => {
   it('produces a deterministic SHA256 fingerprint', () => {
     const key = Buffer.from('fake-key-data');

--- a/test/unit/ssh/host-key.test.ts
+++ b/test/unit/ssh/host-key.test.ts
@@ -4,19 +4,19 @@ import { verifyHostKey, fingerprintPublicKey } from '../../../src/ssh/host-key.j
 describe('verifyHostKey', () => {
   it('accepts a key that matches known_hosts', () => {
     const knownHosts = new Map([['example.com:22', 'SHA256:abc123']]);
-    expect(verifyHostKey('example.com', 22, 'SHA256:abc123', knownHosts, 'tofu')).toBe(true);
+    expect(verifyHostKey('example.com', 22, 'SHA256:abc123', knownHosts, 'tofu', undefined)).toBe(true);
   });
 
   it('rejects a key that does not match known_hosts', () => {
     const knownHosts = new Map([['example.com:22', 'SHA256:abc123']]);
-    expect(() => verifyHostKey('example.com', 22, 'SHA256:different', knownHosts, 'tofu')).toThrow(
+    expect(() => verifyHostKey('example.com', 22, 'SHA256:different', knownHosts, 'tofu', undefined)).toThrow(
       /HOST_KEY_MISMATCH/,
     );
   });
 
   it('accepts and records a new key in TOFU mode', () => {
     const knownHosts = new Map<string, string>();
-    const result = verifyHostKey('newhost.com', 22, 'SHA256:newkey', knownHosts, 'tofu');
+    const result = verifyHostKey('newhost.com', 22, 'SHA256:newkey', knownHosts, 'tofu', undefined);
     expect(result).toBe(true);
     expect(knownHosts.get('newhost.com:22')).toBe('SHA256:newkey');
   });
@@ -25,44 +25,34 @@ describe('verifyHostKey', () => {
     const knownHosts = new Map<string, string>();
     // Distinct from HOST_KEY_MISMATCH: nothing changed, the host is simply not
     // known yet. The message must also point at a flag that actually exists.
-    expect(() => verifyHostKey('newhost.com', 22, 'SHA256:newkey', knownHosts, 'strict')).toThrow(
+    expect(() => verifyHostKey('newhost.com', 22, 'SHA256:newkey', knownHosts, 'strict', undefined)).toThrow(
       /HOST_KEY_UNKNOWN/,
     );
-    expect(() => verifyHostKey('newhost.com', 22, 'SHA256:newkey', knownHosts, 'strict')).toThrow(
+    expect(() => verifyHostKey('newhost.com', 22, 'SHA256:newkey', knownHosts, 'strict', undefined)).toThrow(
       /--hostKeyMode=tofu/,
     );
   });
 
   it('always accepts in insecure mode', () => {
     const knownHosts = new Map<string, string>();
-    expect(verifyHostKey('any.com', 22, 'SHA256:whatever', knownHosts, 'insecure')).toBe(true);
+    expect(verifyHostKey('any.com', 22, 'SHA256:whatever', knownHosts, 'insecure', undefined)).toBe(true);
   });
 
   it('uses non-default port in key lookup', () => {
     const knownHosts = new Map([['example.com:2222', 'SHA256:abc']]);
-    expect(verifyHostKey('example.com', 2222, 'SHA256:abc', knownHosts, 'tofu')).toBe(true);
+    expect(verifyHostKey('example.com', 2222, 'SHA256:abc', knownHosts, 'tofu', undefined)).toBe(true);
   });
 });
 
 /**
- * `--hostKeyMode=strict` refused every host on every connection until 2.8.0.
+ * `--hostKeyMode=strict` refused every host on every connection until 2.8.0, and a
+ * pin could not satisfy it. The history is in .changeset/lucky-keys-pinned.md; what
+ * these cases pin is the shape the fix left behind.
  *
- * The store it consults is in-memory and lives for the process, and the only
- * write to it sat *below* the strict throw — so under strict it started empty
- * and stayed empty. Measured on 2.7.0: two consecutive calls both threw with
- * `knownHosts.size === 0`, while tofu populated it on the first call. A pin did
- * not help either, because it was a reject-only gate in `connection.ts` that
- * fell through to this function and threw anyway. So strict plus a correct pin —
- * the combination that reads like the secure configuration — connected to
- * nothing, and the refusal's own advice ("pin the key with trustedHostKey") was
- * the advice that did not work.
- *
- * A pin is now the authority for the host it names, and is deliberately kept
- * *out* of the shared store rather than seeding it: `knownHostsStore` is one Map
- * for every profile (connection-registry.ts), so seeding meant two profiles
- * pinning different keys for the same host:port produced a false
- * HOST_KEY_MISMATCH against each other's entry. A pinned host needs no
- * trust-on-first-use memory — the pin already is that memory, and it outranks it.
+ * Two properties here would regress silently if they were not asserted: the pin
+ * branch sitting ahead of the `insecure` early return, and the store being written
+ * under `tofu` but not under `strict`. Both are measured, not argued — reordering
+ * the branch fails the insecure case, and moving the write fails the two store cases.
  */
 describe('verifyHostKey with a pinned key', () => {
   const PIN = 'SHA256:pinnedkeypinnedkeypinnedkeypinnedkeypinne';
@@ -76,7 +66,7 @@ describe('verifyHostKey with a pinned key', () => {
   it('still refuses an unpinned unknown host under strict', () => {
     // The fix must not turn strict into tofu for hosts nobody pinned.
     const knownHosts = new Map<string, string>();
-    expect(() => verifyHostKey('bare.com', 22, OTHER, knownHosts, 'strict')).toThrow(
+    expect(() => verifyHostKey('bare.com', 22, OTHER, knownHosts, 'strict', undefined)).toThrow(
       /HOST_KEY_UNKNOWN/,
     );
     expect(knownHosts.size).toBe(0);
@@ -95,31 +85,49 @@ describe('verifyHostKey with a pinned key', () => {
     }
   });
 
-  it('names the pin as what decided, and does not offer a way to switch it off', () => {
-    // Same standard as the two refusals next door (see message-quality.test.ts):
-    // a refusal has to say what decided and how to proceed, without pointing at
-    // the least safe exit. Here the operator edits the pin or investigates; there
-    // is no mode that overrides a pin, and the message must not imply one.
-    const refused = () => verifyHostKey('pinned.com', 22, OTHER, new Map(), 'tofu', PIN);
-    expect(refused).toThrow(/trustedHostKey/);
-    expect(refused).toThrow(new RegExp(PIN));
-    expect(refused).toThrow(new RegExp(OTHER));
-    expect(refused).not.toThrow(/--insecureHostKey|--hostKeyMode=insecure/);
+  it('records a pinned key under tofu, so an unpinned sibling profile is still compared', () => {
+    // Dropping this write was a draft of the fix and it cost a real refusal.
+    // The store is one Map for every profile, so on 2.7.0 a pinned profile seeded
+    // it and an unpinned profile on the same host:port was checked against a
+    // pin-verified fingerprint. Without the write that profile trust-on-first-uses
+    // whatever it is served — and the store then holds the attacker's key, so the
+    // next connection served the genuine one is refused with the diagnostic naming
+    // the real server as the impostor.
+    const knownHosts = new Map<string, string>();
+    verifyHostKey('shared.com', 22, PIN, knownHosts, 'tofu', PIN);
+    expect(knownHosts.get('shared.com:22')).toBe(PIN);
+
+    // The sibling, unpinned, served something else.
+    expect(() => verifyHostKey('shared.com', 22, OTHER, knownHosts, 'tofu', undefined)).toThrow(
+      /HOST_KEY_MISMATCH/,
+    );
   });
 
-  it('does not write a pinned host into the shared store', () => {
-    // What makes the cross-profile collision impossible. If this ever records,
-    // a second profile pinning a different key for the same host:port starts
-    // failing with HOST_KEY_MISMATCH against an entry it never agreed to.
+  it('does not record under strict, so one profile\'s pin cannot authorise another', () => {
+    // The store is what an *unpinned* profile consults, and under strict that is
+    // the only thing that could let it through. Seeding it from a pin would mean
+    // pinning one profile silently admitted every other profile to that host —
+    // which is the guarantee strict exists to make.
     const knownHosts = new Map<string, string>();
-    verifyHostKey('pinned.com', 22, PIN, knownHosts, 'strict', PIN);
+    verifyHostKey('shared.com', 22, PIN, knownHosts, 'strict', PIN);
+    expect(knownHosts.size).toBe(0);
+    expect(() => verifyHostKey('shared.com', 22, PIN, knownHosts, 'strict', undefined)).toThrow(
+      /HOST_KEY_UNKNOWN/,
+    );
+  });
+
+  it('does not record under insecure either, matching what it replaced', () => {
+    const knownHosts = new Map<string, string>();
+    verifyHostKey('shared.com', 22, PIN, knownHosts, 'insecure', PIN);
     expect(knownHosts.size).toBe(0);
   });
 
   it('lets the pin win over a stale store entry for the same host', () => {
-    // Reachable with one shared store: profile A (tofu, no pin) learns a key,
-    // profile B pins a different one for the same host:port. B must be judged
-    // against its pin, not against A's memory.
+    // The store entry has to be stale relative to what the host presents *now* —
+    // an earlier tofu connection learned a key the host has since rotated away
+    // from, or learned one from an interceptor. Two profiles merely pinning
+    // different keys does not reach here: whichever pin disagrees with the served
+    // key is stopped by the branch above and never sees the store.
     const knownHosts = new Map([['shared.com:22', OTHER]]);
     expect(verifyHostKey('shared.com', 22, PIN, knownHosts, 'strict', PIN)).toBe(true);
     expect(knownHosts.get('shared.com:22')).toBe(OTHER);

--- a/test/unit/ssh/host-key.test.ts
+++ b/test/unit/ssh/host-key.test.ts
@@ -83,9 +83,17 @@ describe('verifyHostKey with a pinned key', () => {
     // Putting the pin branch after `mode === 'insecure'` would silently drop
     // that, which is the one way this change could have been a regression.
     for (const mode of ['strict', 'tofu', 'insecure'] as const) {
-      expect(() => verifyHostKey('pinned.com', 22, OTHER, new Map(), mode, PIN)).toThrow(
+      // One store per mode, inspected after the throw. The refusal path's side
+      // effect is the only mutable one on a throwing branch here, and it was
+      // unasserted: hoisting the write above the pin branch records the key the
+      // *interceptor* presented and leaves all 837 tests green. That is the exact
+      // failure the write exists to prevent — a pinned profile that correctly
+      // refused, poisoning every unpinned sibling on the same host:port.
+      const knownHosts = new Map<string, string>();
+      expect(() => verifyHostKey('pinned.com', 22, OTHER, knownHosts, mode, PIN)).toThrow(
         /HOST_KEY_PIN_MISMATCH/,
       );
+      expect(knownHosts.size, `store written on refusal under ${mode}`).toBe(0);
     }
   });
 
@@ -138,6 +146,21 @@ describe('verifyHostKey with a pinned key', () => {
     );
   });
 
+  it('cannot be reached across modes in this process, and is pinned in case that changes', () => {
+    // A pinned tofu write followed by an unpinned strict read admits the sibling
+    // off another profile's pin — the outcome the case above calls strict's
+    // guarantee, by a route that case does not cover. It is unreachable as shipped:
+    // the mode is one process-wide flag, resolved once in resolveHostKeyMode
+    // (src/cli.ts) and stored once on the single ConnectionRegistry, so no process
+    // can perform a tofu write and a strict read. Pinned as the current behaviour
+    // rather than "fixed", because fixing an unreachable path would mean tracking
+    // per-entry provenance in the store for no live case — but if the mode ever
+    // becomes per-profile, this test is the one that has to be revisited first.
+    const knownHosts = new Map<string, string>();
+    verifyHostKey('shared.com', 22, PIN, knownHosts, 'tofu', PIN);
+    expect(verifyHostKey('shared.com', 22, PIN, knownHosts, 'strict', undefined)).toBe(true);
+  });
+
   it('does not record under insecure either, matching what it replaced', () => {
     const knownHosts = new Map<string, string>();
     verifyHostKey('shared.com', 22, PIN, knownHosts, 'insecure', PIN);
@@ -153,6 +176,16 @@ describe('verifyHostKey with a pinned key', () => {
     const knownHosts = new Map([['shared.com:22', OTHER]]);
     expect(verifyHostKey('shared.com', 22, PIN, knownHosts, 'strict', PIN)).toBe(true);
     expect(knownHosts.get('shared.com:22')).toBe(OTHER);
+  });
+
+  it('requires the pin argument, so a caller cannot omit it and silently lose pinning', () => {
+    // The only structural defence against the 2.7.0 shape — a call site that
+    // forgets the pin — and reverting `string | undefined` to `string?` passed the
+    // unit suite, the integration suite and `tsc`. This directive is the gate:
+    // `npm run typecheck` includes test/, so the moment the parameter becomes
+    // optional the unused @ts-expect-error is itself an error.
+    // @ts-expect-error - the sixth argument is required on purpose
+    expect(() => verifyHostKey('plain.com', 22, OTHER, new Map(), 'tofu')).toBeTruthy();
   });
 
   it('is inert when no pin is configured', () => {

--- a/test/unit/ssh/host-key.test.ts
+++ b/test/unit/ssh/host-key.test.ts
@@ -55,8 +55,12 @@ describe('verifyHostKey', () => {
  * the branch fails the insecure case, and moving the write fails the two store cases.
  */
 describe('verifyHostKey with a pinned key', () => {
-  const PIN = 'SHA256:pinnedkeypinnedkeypinnedkeypinnedkeypinne';
-  const OTHER = 'SHA256:otherkeyotherkeyotherkeyotherkeyotherkeyo';
+  // Derived rather than hand-written. A real fingerprint is 43 characters of
+  // mixed-case base64 with digits and +/; the hand-written lowercase-alpha strings
+  // these replaced were the reason a case-folding comparison passed the whole
+  // suite — there was no case to fold.
+  const PIN = fingerprintPublicKey(Buffer.from('pinned-host-key'));
+  const OTHER = fingerprintPublicKey(Buffer.from('some-other-host-key'));
 
   it('satisfies strict mode, which is the whole point', () => {
     const knownHosts = new Map<string, string>();
@@ -138,6 +142,17 @@ describe('verifyHostKey with a pinned key', () => {
     const knownHosts = new Map<string, string>();
     expect(verifyHostKey('plain.com', 22, OTHER, knownHosts, 'tofu', undefined)).toBe(true);
     expect(knownHosts.get('plain.com:22')).toBe(OTHER);
+  });
+
+  it('compares the pin case-sensitively', () => {
+    // A fingerprint is base64, so case is significant: two keys differing only in
+    // case are two different keys. `toLowerCase()` on both sides of the comparison
+    // passed all 828 tests before this case existed, because every fixture was
+    // lowercase — which is also why the fixtures above are now derived from
+    // fingerprintPublicKey instead of written by hand.
+    expect(PIN).not.toBe(PIN.toLowerCase());
+    expect(() => verifyHostKey('pinned.com', 22, PIN.toLowerCase(), new Map(), 'strict', PIN))
+      .toThrow(/HOST_KEY_PIN_MISMATCH/);
   });
 
   it('treats an empty pin as no pin, not as a pin nothing can match', () => {

--- a/test/unit/ssh/host-key.test.ts
+++ b/test/unit/ssh/host-key.test.ts
@@ -107,6 +107,24 @@ describe('verifyHostKey with a pinned key', () => {
     );
   });
 
+  it('fills an empty slot but never overwrites one', () => {
+    // 2.7.0's write lived in the else-branch of `if (stored)`, so it only ever
+    // filled. An unconditional set made the entry order-dependent: with two
+    // profiles pinning different keys for one host:port, whichever connected last
+    // decided what an *unpinned* profile was compared against — and that profile
+    // then got a false HOST_KEY_MISMATCH for a key the other pin had authorised.
+    // Only a three-connection sequence shows it, which is why it survived the
+    // single-call matrix.
+    const knownHosts = new Map([['shared.com:22', OTHER]]);
+    verifyHostKey('shared.com', 22, PIN, knownHosts, 'tofu', PIN);
+    expect(knownHosts.get('shared.com:22')).toBe(OTHER);
+
+    // And the unpinned sibling still sees what it saw before the pinned profile
+    // connected, which is what keeps this change's disclosure honest: nothing an
+    // unpinned profile experiences differs from 2.7.0.
+    expect(verifyHostKey('shared.com', 22, OTHER, knownHosts, 'tofu', undefined)).toBe(true);
+  });
+
   it('does not record under strict, so one profile\'s pin cannot authorise another', () => {
     // The store is what an *unpinned* profile consults, and under strict that is
     // the only thing that could let it through. Seeding it from a pin would mean


### PR DESCRIPTION
`--hostKeyMode=strict` refused every host on every connection, and had since the mode was introduced. This makes it work, and makes `trustedHostKey` able to satisfy it.

Closes the deferred item from #181, which documented the defect and left the code alone.

## The defect

`knownHostsStore` is an in-memory `Map` shared by every profile (`connection-registry.ts:12`), and the only write to it is the trust-on-first-use accept at the bottom of `verifyHostKey` — below the strict throw, so strict never reached it. Measured on 2.7.0: two consecutive calls both threw `HOST_KEY_UNKNOWN` with the store still at zero entries, while `tofu` populated it on the first call. The mode is fixed at startup, so no earlier `tofu` connection could seed it either.

A pin did not rescue it. `trustedHostKey` was a reject-only gate in `connection.ts` — `if (pin && fp !== pin) return false` — so it could refuse a wrong key, but a **matching** pin fell through to `verifyHostKey` and was refused anyway for the empty store. So `strict` plus a correct pin, the combination that reads like the secure configuration, connected to nothing. And the refusal's own advice, *"Pin the key with trustedHostKey in the profile"*, was the advice that did not work.

## The fix

The pin is answered in `verifyHostKey` ahead of every other branch. Order matters and is asserted:

| | |
|---|---|
| pin set, contradicts the served key | `HOST_KEY_PIN_MISMATCH`, in **every** mode including `insecure` |
| pin set, matches | accept — the store is never *read* |
| no pin | unchanged from 2.7.0, every mode |

The pin check sits **before** `if (mode === 'insecure') return true` because the gate it replaced sat ahead of `verifyHostKey` and ahead of the mode read, so a contradicting pin refused under `insecure` too. Moving it below would keep that behaviour's tests... no: it fails `refuses a key that contradicts the pin, in every mode including insecure`. Measured.

The store is never read for a pinned host — consulting it would make two profiles pinning different keys for one `host:port` collide with a false `HOST_KEY_MISMATCH`. It **is** written, under `tofu` only and only into an empty slot. `strict` does not write, because there the store is the only thing that can admit an *unpinned* profile and seeding it would let one profile's pin authorise another.

**Net effect: nothing an unpinned profile experiences differs from 2.7.0.** Every behaviour change is about a profile carrying a pin.

## Verification

The review found that single-call matrices are insufficient here — twice — so the final pass ran **209,712 ordered sequences** (length 1–4, 16 step shapes × 3 modes) against this branch, the first commit, and `main` with main's gate simulated:

```
unpinned-step divergences from 2.7.0 ........ 0
cells where this branch refuses and main accepted ... 0
store-content divergences ................... 0   (byte-identical at every point)
cells where this branch accepts and main refused ... 79,468 — every one has a
    pinned step at the diverging position, i.e. every one is the intended fix
non-tofu store writes ....................... 0
```

The zero store divergence has a reason worth recording: main's bottom `knownHosts.set` was reachable only on a store miss, so main's write was fill-only too, and `!knownHosts.has(key)` makes the pin branch write exactly when main would have.

`840` unit + property, `132` integration against real SSH containers, typecheck and build clean.

## Behaviour changes

Three, all disclosed in the changeset, all about pinned profiles:

- **A key contradicting a pin now raises `HOST_KEY_PIN_MISMATCH`.** It was already refused, but `return false` gave ssh2 a generic handshake failure naming nothing.
- **A matching pin now wins over a store entry for the same `host:port`.** It needs the entry to be stale against what the host presents now — a rotated key, or one learned from an interceptor. (Two profiles merely pinning different keys does not reach it: whichever pin disagrees with the served key is stopped before the store.)
- **A blank `trustedHostKey` is now a startup error.** `z.string().optional()` accepted `trustedHostKey = ""`, and the gate that read it tested truthiness — so the line was inert and the operator who wrote it believed the profile was pinned. Whitespace is trimmed rather than refused, since the comparison is exact and a trailing newline refused every key with nothing pointing at the stray character.

`minor` rather than `patch`, matching what 2.3.0 and 2.2.0 did for the same shape: a config that started yesterday can refuse to start today.

## Review history, and what it caught

Three rounds, and the third was the first to find no code defect. This branch is seven commits because each round found something inside the previous round's fix — the history is kept rather than squashed, since the two load-bearing constraints on the store write were both discovered rather than designed.

Round 1 (six reviewers, 20 findings) caught, among others, that dropping the store write cost a real refusal: on 2.7.0 a pinned profile seeded the shared store, so an unpinned sibling was compared against a pin-verified fingerprint. Without the write that sibling trust-on-first-uses whatever it is served — and the store then holds the attacker's key, so the next connection served the genuine one is refused with the diagnostic naming the real server as the impostor.

Round 2 was killed by API 529s (eight dispatches, eight failures). I ran the security axis's own question myself and it found that restoring the write as an unconditional `set` made the entry order-dependent, giving an *unpinned* profile a false `HOST_KEY_MISMATCH` for a key another pin had authorised. Only a three-connection sequence shows it.

Round 3 found no code defect and four test gaps, each reproduced before fixing:

- **the refusal path's store side effect was unasserted** — hoisting the write above the pin branch records the interceptor's fingerprint while all 837 tests pass, which is verbatim the failure the write exists to prevent
- **the `PIN_MISMATCH` message's entire actionable half was deletable** with the suite green, and so was the `CONFIRM_OUT_OF_BAND` constant extracted the round before *because* two refusals needed it — only one was asserted
- **`pinned` and `received` could be swapped** — both fingerprints asserted present, neither against its label, on the message whose own comment says comparing them is the reader's whole job
- **the shipped `config.default.toml` had no test**, so re-arming the placeholder pin was undetectable on the file Docker COPYs into the image

Plus four comments that were wrong or misplaced, including a function header that blamed *seeding* the store for a collision the *read* causes — contradicting both the code and its own branch comment sixty lines down.

Every fix is confirmed by mutation: hoisted write, dropped constant, swapped labels, gutted advice, re-armed template pin all now fail, and reverting the parameter to optional fails `typecheck` through a `@ts-expect-error` gate.

## Not done

Converting the six positional parameters to an options object, which two rounds raised. The hazard is a call-site typo; an options object does not prevent passing one value twice; there is one production caller and every one of the 24 sites was verified to pass the right argument. On this branch that is churn rather than safety.

Also unchanged: the store still does not persist across a restart, so `strict` means "every host must be pinned". That is stated in SECURITY.md rather than papered over — a file-backed known_hosts is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
